### PR TITLE
Add MudBlazor settings dialog

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,0 +1,39 @@
+@using MudBlazor
+@using DevOpsAssistant.Services
+@inject DevOpsConfigService ConfigService
+
+<MudDialog>
+    <DialogContent>
+        <MudTextField @bind-Value="_model.Organization" Label="Organization" />
+        <MudTextField @bind-Value="_model.Project" Label="Project" />
+        <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
+        <MudButton OnClick="Cancel" Color="Color.Secondary">Cancel</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+
+    private DevOpsConfig _model = new();
+
+    protected override void OnInitialized()
+    {
+        _model = new DevOpsConfig
+        {
+            Organization = ConfigService.Config.Organization,
+            Project = ConfigService.Config.Project,
+            PatToken = ConfigService.Config.PatToken
+        };
+    }
+
+    private async Task Save()
+    {
+        await ConfigService.SaveAsync(_model);
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
@@ -7,8 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.16"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.16" PrivateAssets="all"/>
+        <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.16" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.16" PrivateAssets="all" />
+        <PackageReference Include="MudBlazor" Version="8.7.0" />
     </ItemGroup>
 
 </Project>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -1,3 +1,23 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+@using MudBlazor
+@inject IDialogService DialogService
 
-@Body
+<MudThemeProvider />
+<MudDialogProvider />
+
+<MudAppBar Color="Color.Primary" Elevation="1">
+    <MudText Typo="Typo.h6">DevOpsAssistant</MudText>
+    <MudSpacer />
+    <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
+</MudAppBar>
+
+<div class="p-4">
+    @Body
+</div>
+
+@code {
+    private async Task OpenSettings()
+    {
+        await DialogService.ShowAsync<DevOpsAssistant.Components.SettingsDialog>("Settings");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -1,11 +1,20 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using DevOpsAssistant;
+using MudBlazor.Services;
+using Blazored.LocalStorage;
+using DevOpsAssistant.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddMudServices();
+builder.Services.AddBlazoredLocalStorage();
+builder.Services.AddScoped<DevOpsConfigService>();
 
-await builder.Build().RunAsync();
+var host = builder.Build();
+var configService = host.Services.GetRequiredService<DevOpsConfigService>();
+await configService.LoadAsync();
+await host.RunAsync();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -1,0 +1,9 @@
+namespace DevOpsAssistant.Services
+{
+    public class DevOpsConfig
+    {
+        public string Organization { get; set; } = string.Empty;
+        public string Project { get; set; } = string.Empty;
+        public string PatToken { get; set; } = string.Empty;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -1,0 +1,33 @@
+using Blazored.LocalStorage;
+
+namespace DevOpsAssistant.Services
+{
+    public class DevOpsConfigService
+    {
+        private const string StorageKey = "devops-config";
+        private readonly ILocalStorageService _localStorage;
+        private DevOpsConfig _config = new();
+
+        public DevOpsConfigService(ILocalStorageService localStorage)
+        {
+            _localStorage = localStorage;
+        }
+
+        public DevOpsConfig Config => _config;
+
+        public async Task LoadAsync()
+        {
+            var config = await _localStorage.GetItemAsync<DevOpsConfig>(StorageKey);
+            if (config != null)
+            {
+                _config = config;
+            }
+        }
+
+        public async Task SaveAsync(DevOpsConfig config)
+        {
+            _config = config;
+            await _localStorage.SetItemAsync(StorageKey, config);
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using DevOpsAssistant
 @using DevOpsAssistant.Layout
+@using DevOpsAssistant.Services
+@using MudBlazor


### PR DESCRIPTION
## Summary
- install MudBlazor and Blazored.LocalStorage
- create DevOpsConfig service to persist organisation/project/PAT
- integrate MudBlazor app bar with settings dialog
- load/save config from local storage on startup

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6840bd6b99988328b947e885c159f691