### PR TITLE
Fix missing MudBlazor styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -404,3 +404,4 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+dotnet-install.sh

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
@@ -7,6 +7,7 @@
     <title>DevOpsAssistant</title>
     <base href="/" />
     <link rel="stylesheet" href="css/app.css" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
@@ -29,6 +30,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- include MudBlazor CSS and JS in index.html
- ignore the local `dotnet-install.sh`

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6840c098ab488328b2baafaa14bff569