### PR TITLE
Add tests for DevOpsConfigService

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../DevOpsAssistant/DevOpsAssistant.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsConfigServiceTests.cs
@@ -1,0 +1,57 @@
+using System.Threading.Tasks;
+using DevOpsAssistant.Services;
+using Xunit;
+
+namespace DevOpsAssistant.Tests;
+
+public class DevOpsConfigServiceTests
+{
+    [Fact]
+    public async Task SaveAsync_Persists_Config_And_Updates_Property()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        var config = new DevOpsConfig
+        {
+            Organization = "Org",
+            Project = "Proj",
+            PatToken = "Token"
+        };
+
+        await service.SaveAsync(config);
+
+        Assert.Equal("Org", service.Config.Organization);
+        var stored = await storage.GetItemAsync<DevOpsConfig>("devops-config");
+        Assert.Equal("Org", stored.Organization);
+        Assert.Equal("Proj", stored.Project);
+        Assert.Equal("Token", stored.PatToken);
+    }
+
+    [Fact]
+    public async Task LoadAsync_Loads_Config_When_Present()
+    {
+        var storage = new FakeLocalStorageService();
+        var stored = new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "Token" };
+        await storage.SetItemAsync("devops-config", stored);
+        var service = new DevOpsConfigService(storage);
+
+        await service.LoadAsync();
+
+        Assert.Equal("Org", service.Config.Organization);
+        Assert.Equal("Proj", service.Config.Project);
+        Assert.Equal("Token", service.Config.PatToken);
+    }
+
+    [Fact]
+    public async Task LoadAsync_Keeps_Default_When_No_Config()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+
+        await service.LoadAsync();
+
+        Assert.Equal(string.Empty, service.Config.Organization);
+        Assert.Equal(string.Empty, service.Config.Project);
+        Assert.Equal(string.Empty, service.Config.PatToken);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/FakeLocalStorageService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/FakeLocalStorageService.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Blazored.LocalStorage;
+
+namespace DevOpsAssistant.Tests;
+
+public class FakeLocalStorageService : ILocalStorageService
+{
+    private readonly Dictionary<string, string?> _store = new();
+
+    public event EventHandler<ChangingEventArgs>? Changing;
+    public event EventHandler<ChangedEventArgs>? Changed;
+
+    public ValueTask ClearAsync(CancellationToken cancellationToken = default)
+    {
+        _store.Clear();
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<bool> ContainKeyAsync(string key, CancellationToken cancellationToken = default)
+        => new(_store.ContainsKey(key));
+
+    public ValueTask<T> GetItemAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        if (_store.TryGetValue(key, out var json))
+        {
+            var value = System.Text.Json.JsonSerializer.Deserialize<T>(json!);
+            return new ValueTask<T>(value!);
+        }
+        return new ValueTask<T>(default(T)!);
+    }
+
+    public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
+    {
+        _store.TryGetValue(key, out var value);
+        return new ValueTask<string>(value!);
+    }
+
+    public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default)
+        => new(_store.Keys.ElementAt(index));
+
+    public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)
+        => new(_store.Keys.AsEnumerable());
+
+    public ValueTask<int> LengthAsync(CancellationToken cancellationToken = default)
+        => new(_store.Count);
+
+    public ValueTask RemoveItemAsync(string key, CancellationToken cancellationToken = default)
+    {
+        _store.Remove(key);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask RemoveItemsAsync(IEnumerable<string> keys, CancellationToken cancellationToken = default)
+    {
+        foreach (var key in keys)
+        {
+            _store.Remove(key);
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask SetItemAsync<T>(string key, T data, CancellationToken cancellationToken = default)
+    {
+        _store[key] = System.Text.Json.JsonSerializer.Serialize(data);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask SetItemAsStringAsync(string key, string data, CancellationToken cancellationToken = default)
+    {
+        _store[key] = data;
+        return ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- create xUnit test project
- add fake local storage service
- test config load/save operations

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --logger "console;verbosity=detailed"`

------
https://chatgpt.com/codex/tasks/task_e_6840c1d540708328bbb28dd8d2992d9e