### PR TITLE
Add DevOps work item overview page

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -1,7 +1,8 @@
-﻿@page "/"
+@page "/"
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello, world!</h1>
-
-Welcome to your new app.
+<MudPaper Class="p-4">
+    <MudText Typo="Typo.h6">Welcome to DevOpsAssistant</MudText>
+    <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
+</MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -1,0 +1,83 @@
+@page "/work-items"
+@using DevOpsAssistant.Services
+@inject DevOpsApiService ApiService
+
+<PageTitle>Work Items</PageTitle>
+
+<MudPaper Class="p-4">
+    <MudTextField @bind-Value="_path" Label="Area Path" />
+    <MudTextField @bind-Value="_state" Label="State Filter" />
+    <MudTextField @bind-Value="_tags" Label="Tags Filter" />
+    <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
+</MudPaper>
+
+@if (_loading)
+{
+    <p>Loading...</p>
+}
+else if (_roots != null)
+{
+    <ul>
+        @foreach (var epic in _roots)
+        {
+            <li>
+                <b>@epic.Info.Title</b> (@epic.Info.State)
+                @StatusIcon(epic)
+                @if (epic.Children.Any())
+                {
+                    <ul>
+                        @foreach (var feature in epic.Children)
+                        {
+                            <li>
+                                <b>@feature.Info.Title</b> (@feature.Info.State)
+                                @StatusIcon(feature)
+                                @if (feature.Children.Any())
+                                {
+                                    <ul>
+                                        @foreach (var item in feature.Children)
+                                        {
+                                            <li>@item.Info.Title (@item.Info.State)</li>
+                                        }
+                                    </ul>
+                                }
+                            </li>
+                        }
+                    </ul>
+                }
+            </li>
+        }
+    </ul>
+}
+
+@code {
+    private string _path = string.Empty;
+    private string? _state;
+    private string? _tags;
+    private bool _loading;
+    private List<WorkItemNode>? _roots;
+
+    private async Task Load()
+    {
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            _roots = await ApiService.GetWorkItemHierarchyAsync(_path, _state, _tags);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private RenderFragment StatusIcon(WorkItemNode node) => builder =>
+    {
+        if (!node.StatusValid)
+        {
+            builder.OpenComponent<MudIcon>(0);
+            builder.AddAttribute(1, "Color", Color.Warning);
+            builder.AddAttribute(2, "Icon", Icons.Material.Filled.Warning);
+            builder.CloseComponent();
+        }
+    };
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddMudServices();
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddScoped<DevOpsConfigService>();
+builder.Services.AddScoped<DevOpsApiService>();
 
 var host = builder.Build();
 var configService = host.Services.GetRequiredService<DevOpsConfigService>();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -1,0 +1,165 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Net.Http.Json;
+using DevOpsAssistant.Services;
+
+namespace DevOpsAssistant.Services;
+
+public class DevOpsApiService
+{
+    private readonly HttpClient _httpClient;
+    private readonly DevOpsConfigService _configService;
+
+    public DevOpsApiService(HttpClient httpClient, DevOpsConfigService configService)
+    {
+        _httpClient = httpClient;
+        _configService = configService;
+    }
+
+    public async Task<List<WorkItemNode>> GetWorkItemHierarchyAsync(string areaPath, string? state = null, string? tags = null)
+    {
+        var config = _configService.Config;
+        if (string.IsNullOrWhiteSpace(config.Organization) ||
+            string.IsNullOrWhiteSpace(config.Project) ||
+            string.IsNullOrWhiteSpace(config.PatToken))
+        {
+            throw new InvalidOperationException("DevOps configuration is incomplete.");
+        }
+
+        var baseUri = $"https://dev.azure.com/{config.Organization}/{config.Project}/_apis/wit";
+        var pat = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($":{config.PatToken}"));
+        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", pat);
+
+        var wiql = BuildWiql(areaPath, state, tags);
+        var wiqlResponse = await _httpClient.PostAsJsonAsync($"{baseUri}/wiql?api-version=7.0", new { query = wiql });
+        wiqlResponse.EnsureSuccessStatusCode();
+        var wiqlResult = await wiqlResponse.Content.ReadFromJsonAsync<WiqlResult>();
+        if (wiqlResult == null || wiqlResult.WorkItemRelations == null || wiqlResult.WorkItemRelations.Length == 0)
+            return new List<WorkItemNode>();
+
+        var ids = wiqlResult.WorkItemRelations
+            .SelectMany(r => new[] { r.Source?.Id, r.Target?.Id })
+            .Where(id => id.HasValue)
+            .Select(id => id!.Value)
+            .Distinct();
+
+        var idList = string.Join(',', ids);
+        var itemsResult = await _httpClient.GetFromJsonAsync<WorkItemsResult>($"{baseUri}/workitems?ids={idList}&$expand=relations&api-version=7.0");
+        if (itemsResult == null)
+            return new List<WorkItemNode>();
+
+        var dict = itemsResult.Value.ToDictionary(i => i.Id);
+        var nodes = dict.Values.Select(w => new WorkItemNode
+        {
+            Info = new WorkItemInfo
+            {
+                Id = w.Id,
+                Title = w.Fields["System.Title"].GetString() ?? string.Empty,
+                State = w.Fields["System.State"].GetString() ?? string.Empty,
+                WorkItemType = w.Fields["System.WorkItemType"].GetString() ?? string.Empty,
+                Tags = w.Fields.TryGetValue("System.Tags", out var tagEl) ? tagEl.GetString() ?? string.Empty : string.Empty
+            }
+        }).ToDictionary(n => n.Info.Id);
+
+        foreach (var item in itemsResult.Value)
+        {
+            if (item.Relations == null) continue;
+            foreach (var rel in item.Relations.Where(r => r.Rel == "System.LinkTypes.Hierarchy-Forward"))
+            {
+                var childId = int.Parse(rel.Url.Split('/').Last());
+                if (nodes.TryGetValue(item.Id, out var parent) && nodes.TryGetValue(childId, out var child))
+                {
+                    parent.Children.Add(child);
+                }
+            }
+        }
+
+        var childIds = new HashSet<int>(nodes.Values.SelectMany(n => n.Children.Select(c => c.Info.Id)));
+        var roots = nodes.Values.Where(n => !childIds.Contains(n.Info.Id)).ToList();
+        foreach (var root in roots)
+            ComputeStatus(root);
+        return roots;
+    }
+
+    private static string BuildWiql(string areaPath, string? state, string? tags)
+    {
+        var conditions = new List<string>
+        {
+            "[System.TeamProject] = @project",
+            $"[System.AreaPath] UNDER '{areaPath}'",
+            "[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')"
+        };
+        if (!string.IsNullOrWhiteSpace(state))
+            conditions.Add($"[System.State] = '{state}'");
+        if (!string.IsNullOrWhiteSpace(tags))
+            conditions.Add($"[System.Tags] CONTAINS '{tags}'");
+
+        var where = string.Join(" AND ", conditions);
+        return $@"SELECT [System.Id] FROM WorkItemLinks WHERE {where} ORDER BY [System.Id] MODE (Recursive, ReturnMatchingChildren)";
+    }
+
+    private static void ComputeStatus(WorkItemNode node)
+    {
+        foreach (var child in node.Children)
+            ComputeStatus(child);
+
+        if (!node.Children.Any())
+        {
+            node.StatusValid = true;
+            return;
+        }
+
+        var allDone = node.Children.All(c => c.Info.State.Equals("Done", StringComparison.OrdinalIgnoreCase));
+        node.StatusValid = node.Info.State.Equals("Done", StringComparison.OrdinalIgnoreCase) ? allDone : !allDone;
+    }
+
+    private class WiqlResult
+    {
+        public WorkItemRelation[] WorkItemRelations { get; set; } = Array.Empty<WorkItemRelation>();
+    }
+
+    private class WorkItemRelation
+    {
+        public WorkItemRef? Source { get; set; }
+        public WorkItemRef? Target { get; set; }
+    }
+
+    private class WorkItemRef
+    {
+        public int Id { get; set; }
+    }
+
+    private class WorkItemsResult
+    {
+        public WorkItem[] Value { get; set; } = Array.Empty<WorkItem>();
+    }
+
+    private class WorkItem
+    {
+        public int Id { get; set; }
+        public Dictionary<string, JsonElement> Fields { get; set; } = new();
+        public Relation[]? Relations { get; set; }
+    }
+
+    private class Relation
+    {
+        public string Rel { get; set; } = string.Empty;
+        public string Url { get; set; } = string.Empty;
+    }
+}
+
+public class WorkItemInfo
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string State { get; set; } = string.Empty;
+    public string WorkItemType { get; set; } = string.Empty;
+    public string Tags { get; set; } = string.Empty;
+}
+
+public class WorkItemNode
+{
+    public WorkItemInfo Info { get; set; } = new();
+    public List<WorkItemNode> Children { get; } = new();
+    public bool StatusValid { get; set; }
+}


### PR DESCRIPTION
## Summary
- add `DevOpsApiService` for talking to the Azure DevOps API
- register the new service
- add `/work-items` page to display epics, features and child work items
- update home page with navigation link

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684138cd976883289c95e33ed0953e82