### PR TITLE
Add menu item for Work Items and fix layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -5,15 +5,20 @@
 <MudThemeProvider />
 <MudDialogProvider />
 
-<MudAppBar Color="Color.Primary" Elevation="1">
-    <MudText Typo="Typo.h6">DevOpsAssistant</MudText>
-    <MudSpacer />
-    <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
-</MudAppBar>
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Fixed="true" Elevation="1">
+        <MudText Typo="Typo.h6">DevOpsAssistant</MudText>
+        <MudSpacer />
+        <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List" Class="mx-2">Work Items</MudNavLink>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
+    </MudAppBar>
 
-<div class="p-4">
-    @Body
-</div>
+    <MudMainContent>
+        <div class="p-4">
+            @Body
+        </div>
+    </MudMainContent>
+</MudLayout>
 
 @code {
     private async Task OpenSettings()


### PR DESCRIPTION
## Summary
- add navigation link for `Work Items` in the header
- wrap layout with `MudLayout` and use `MudMainContent` so pages don't render under the fixed header

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68415170a9848328ac6b9e6383a48ef5