### PR TITLE
Improve filter clarity for work items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -6,8 +6,8 @@
 
 <MudPaper Class="p-4">
     <MudTextField @bind-Value="_path" Label="Area Path" />
-    <MudTextField @bind-Value="_state" Label="State Filter" />
-    <MudTextField @bind-Value="_tags" Label="Tags Filter" />
+    <MudTextField @bind-Value="_state" Label="State Filter" Placeholder="e.g., Active, Resolved" />
+    <MudTextField @bind-Value="_tags" Label="Tags Filter" Placeholder="Comma separated tags" />
     <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
 </MudPaper>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -90,9 +90,20 @@ public class DevOpsApiService
             "[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')"
         };
         if (!string.IsNullOrWhiteSpace(state))
-            conditions.Add($"[System.State] = '{state}'");
+        {
+            var states = state.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (states.Length == 1)
+                conditions.Add($"[System.State] = '{states[0]}'");
+            else
+                conditions.Add($"[System.State] in ({string.Join(',', states.Select(s => $"'{s}'"))})");
+        }
+
         if (!string.IsNullOrWhiteSpace(tags))
-            conditions.Add($"[System.Tags] CONTAINS '{tags}'");
+        {
+            var tagList = tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var tag in tagList)
+                conditions.Add($"[System.Tags] CONTAINS '{tag}'");
+        }
 
         var where = string.Join(" AND ", conditions);
         return $@"SELECT [System.Id] FROM WorkItemLinks WHERE {where} ORDER BY [System.Id] MODE (Recursive, ReturnMatchingChildren)";


### PR DESCRIPTION
## Summary
- clarify work item filters
- support comma-separated states and tags in queries

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_684152f94a38832893992fa192a62370