### PR TITLE
Fix MudPopoverProvider issue and add front-end test

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="bunit.web" Version="1.26.64" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/MainLayoutTests.cs
@@ -1,0 +1,21 @@
+using Bunit;
+using DevOpsAssistant.Layout;
+using MudBlazor.Services;
+using Xunit;
+
+namespace DevOpsAssistant.Tests;
+
+public class MainLayoutTests : TestContext
+{
+    [Fact]
+    public void Layout_Has_PopoverProvider()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
+        var cut = RenderComponent<MainLayout>();
+
+        // Verify that the MudPopoverProvider is present in the rendered markup
+        cut.Markup.Contains("mud-popover-provider");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 
 <MudThemeProvider />
 <MudDialogProvider />
+<MudPopoverProvider />
 
 <MudLayout>
     <MudAppBar Color="Color.Primary" Fixed="true" Elevation="1">


### PR DESCRIPTION
## Summary
- include `MudPopoverProvider` in `MainLayout`
- add bUnit test for layout
- include bUnit packages for tests

## Testing
- `dotnet test DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v n`

------
https://chatgpt.com/codex/tasks/task_e_684170386c488328b3f3aa49dec5b71e