### PR TITLE
Improve page and menu layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -7,10 +7,17 @@
 <MudPopoverProvider />
 
 <MudLayout>
-    <MudAppBar Color="Color.Primary" Fixed="true" Elevation="1">
+    <MudDrawer @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Never" Variant="DrawerVariant.Responsive" Elevation="1">
+        <MudNavMenu Dense="true">
+            <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
+        </MudNavMenu>
+    </MudDrawer>
+
+    <MudAppBar Color="Color.Primary" Elevation="1">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
         <MudText Typo="Typo.h6">DevOpsAssistant</MudText>
         <MudSpacer />
-        <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List" Class="mx-2">Work Items</MudNavLink>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
     </MudAppBar>
 
@@ -22,6 +29,10 @@
 </MudLayout>
 
 @code {
+    private bool _drawerOpen = true;
+
+    private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
+
     private async Task OpenSettings()
     {
         await DialogService.ShowAsync<DevOpsAssistant.Components.SettingsDialog>("Settings");

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -2,7 +2,13 @@
 
 <PageTitle>Home</PageTitle>
 
-<MudPaper Class="p-4">
-    <MudText Typo="Typo.h6">Welcome to DevOpsAssistant</MudText>
-    <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
-</MudPaper>
+<MudGrid>
+    <MudItem xs="12">
+        <MudText Typo="Typo.h4" Class="mb-2">Welcome to DevOpsAssistant</MudText>
+    </MudItem>
+    <MudItem xs="12">
+        <MudPaper Class="pa-4">
+            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
+        </MudPaper>
+    </MudItem>
+</MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -5,21 +5,31 @@
 
 <PageTitle>Work Items</PageTitle>
 
-<MudPaper Class="p-4">
-    <MudTextField @bind-Value="_path" Label="Area Path" />
-    <MudSelect T="string" Label="States" SelectedValues="_selectedStates" SelectedValuesChanged="OnStatesChanged" MultiSelection="true">
-        @foreach (var s in _stateOptions)
-        {
-            <MudSelectItem Value="@s">@s</MudSelectItem>
-        }
-    </MudSelect>
-    <MudSelect T="string" Label="Tags" SelectedValues="_selectedTags" SelectedValuesChanged="OnTagsChanged" MultiSelection="true">
-        @foreach (var t in _tagOptions)
-        {
-            <MudSelectItem Value="@t">@t</MudSelectItem>
-        }
-    </MudSelect>
-    <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
+<MudPaper Class="p-4 mb-4">
+    <MudGrid>
+        <MudItem xs="12" md="4">
+            <MudTextField @bind-Value="_path" Label="Area Path" />
+        </MudItem>
+        <MudItem xs="12" md="4">
+            <MudSelect T="string" Label="States" SelectedValues="_selectedStates" SelectedValuesChanged="OnStatesChanged" MultiSelection="true">
+                @foreach (var s in _stateOptions)
+                {
+                    <MudSelectItem Value="@s">@s</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" md="4">
+            <MudSelect T="string" Label="Tags" SelectedValues="_selectedTags" SelectedValuesChanged="OnTagsChanged" MultiSelection="true">
+                @foreach (var t in _tagOptions)
+                {
+                    <MudSelectItem Value="@t">@t</MudSelectItem>
+                }
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12">
+            <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
+        </MudItem>
+    </MudGrid>
 </MudPaper>
 
 @if (_loading)


### PR DESCRIPTION
## Summary
- add MudDrawer-based menu and toggle in `MainLayout`
- use MudGrid in `Home` and `WorkItems` pages for cleaner layout

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68417e4cae9c8328acdfa1986df52533