### PR TITLE
Fix DevOps tree query

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -41,6 +41,14 @@ public class DevOpsApiServiceTests
     }
 
     [Fact]
+    public void BuildWiql_Includes_LinkType()
+    {
+        var query = InvokeBuildWiql("Area", null, null);
+
+        Assert.Contains("[System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward'", query);
+    }
+
+    [Fact]
     public void ComputeStatus_Leaf_Node_Always_Valid()
     {
         var node = new WorkItemNode { Info = new WorkItemInfo { State = "Done" } };

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -94,7 +94,8 @@ public class DevOpsApiService
         {
             "[Source].[System.TeamProject] = @project",
             $"[Source].[System.AreaPath] UNDER '{areaPath}'",
-            "[Source].[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')"
+            "[Source].[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')",
+            "[System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward'"
         };
         if (!string.IsNullOrWhiteSpace(state))
         {


### PR DESCRIPTION
## Summary
- ensure WIQL only includes one link type
- verify link type included via new test

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684180891f4883288bcbd6eee6ec0eb0