### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY src/DevOpsAssistant/DevOpsAssistant.sln ./
+COPY src/DevOpsAssistant ./DevOpsAssistant
+RUN dotnet publish DevOpsAssistant/DevOpsAssistant.csproj -c Release -o /app/publish
+
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/publish/wwwroot /usr/share/nginx/html
+EXPOSE 5678
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # DevOpsAssistant
+
+This project is a Blazor WebAssembly application. A Dockerfile and compose file are provided to run the app using Nginx. The HTTP service listens on port **5678**.
+
+```bash
+# Build and run with Docker Compose
+docker compose up --build
+```
+
+The site will be available at [http://localhost:5678](http://localhost:5678).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  devopsassistant:
+    build: .
+    ports:
+      - "5678:5678"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,9 @@
+server {
+    listen 5678;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add Dockerfile with Nginx runtime for static Blazor site
- create docker-compose.yml exposing port 5678
- configure Nginx to serve the app on port 5678
- document docker usage in README

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68418a63e8588328a5474ee7f3996861