### PR TITLE
Refactor work item hierarchy query

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -54,11 +54,13 @@ public class DevOpsApiServiceTests
     }
 
     [Fact]
-    public void BuildWiql_Includes_LinkType()
+    public void BuildWiql_Selects_WorkItems()
     {
         var query = InvokeBuildWiql("Area");
 
-        Assert.Contains("[System.Links.LinkType] = 'System.LinkTypes.Hierarchy-Forward'", query);
+        Assert.DoesNotContain("WorkItemLinks", query);
+        Assert.DoesNotContain("System.Links.LinkType", query);
+        Assert.Contains("FROM WorkItems", query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- switch DevOps hierarchy search from recursive link query to simple work item query
- update tests for new query format

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -c Release --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68419a6ebb8c8328a3390b076d78ff66