### PR TITLE
Filter closed epics

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -28,11 +28,13 @@ public class DevOpsApiServiceTests
     }
 
     [Fact]
-    public void BuildWiql_Ignores_State_And_Tags()
+    public void BuildWiql_Filters_Closed_Epics()
     {
         var query = InvokeBuildWiql("Area");
 
-        Assert.DoesNotContain("System.State", query);
+        Assert.Contains("[System.State] <> 'Closed'", query);
+        Assert.Contains("[System.State] <> 'Removed'", query);
+        Assert.Contains("[System.WorkItemType] <> 'Epic'", query);
         Assert.DoesNotContain("System.Tags", query);
         Assert.Contains("[System.AreaPath] UNDER 'Area'", query);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -165,7 +165,8 @@ public class DevOpsApiService
         {
             "[System.TeamProject] = @project",
             $"[System.AreaPath] UNDER '{areaPath}'",
-            "[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')"
+            "[System.WorkItemType] in ('Epic','Feature','User Story','Task','Bug')",
+            "([System.WorkItemType] <> 'Epic' OR ([System.State] <> 'Closed' AND [System.State] <> 'Removed'))"
         };
 
         var where = string.Join(" AND ", conditions);


### PR DESCRIPTION
## Summary
- exclude closed or removed epics from WIQL
- update tests for new query logic

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6841aaca9660832886dc5c8ea3dd6a07