### PR TITLE
Remove unused state and tag code

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsConfigServiceTests.cs
@@ -15,9 +15,7 @@ public class DevOpsConfigServiceTests
         {
             Organization = "Org",
             Project = "Proj",
-            PatToken = "Token",
-            States = "New,Active",
-            Tags = "tag1,tag2"
+            PatToken = "Token"
         };
 
         await service.SaveAsync(config);
@@ -27,15 +25,13 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Org", stored.Organization);
         Assert.Equal("Proj", stored.Project);
         Assert.Equal("Token", stored.PatToken);
-        Assert.Equal("New,Active", stored.States);
-        Assert.Equal("tag1,tag2", stored.Tags);
     }
 
     [Fact]
     public async Task LoadAsync_Loads_Config_When_Present()
     {
         var storage = new FakeLocalStorageService();
-        var stored = new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "Token", States = "New", Tags = "tag1" };
+        var stored = new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "Token" };
         await storage.SetItemAsync("devops-config", stored);
         var service = new DevOpsConfigService(storage);
 
@@ -44,8 +40,6 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Org", service.Config.Organization);
         Assert.Equal("Proj", service.Config.Project);
         Assert.Equal("Token", service.Config.PatToken);
-        Assert.Equal("New", service.Config.States);
-        Assert.Equal("tag1", service.Config.Tags);
     }
 
     [Fact]
@@ -59,7 +53,5 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.Organization);
         Assert.Equal(string.Empty, service.Config.Project);
         Assert.Equal(string.Empty, service.Config.PatToken);
-        Assert.Equal(string.Empty, service.Config.States);
-        Assert.Equal(string.Empty, service.Config.Tags);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -7,8 +7,6 @@
         <MudTextField @bind-Value="_model.Organization" Label="Organization" />
         <MudTextField @bind-Value="_model.Project" Label="Project" />
         <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" />
-        <MudTextField @bind-Value="_model.States" Label="States" Placeholder="Comma separated states" />
-        <MudTextField @bind-Value="_model.Tags" Label="Tags" Placeholder="Comma separated tags" />
     </DialogContent>
     <DialogActions>
         <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
@@ -27,9 +25,7 @@
         {
             Organization = ConfigService.Config.Organization,
             Project = ConfigService.Config.Project,
-            PatToken = ConfigService.Config.PatToken,
-            States = ConfigService.Config.States,
-            Tags = ConfigService.Config.Tags
+            PatToken = ConfigService.Config.PatToken
         };
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -15,22 +15,6 @@
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="12" md="4">
-            <MudSelect T="string" Label="States" SelectedValues="_selectedStates" SelectedValuesChanged="OnStatesChanged" MultiSelection="true">
-                @foreach (var s in _stateOptions)
-                {
-                    <MudSelectItem Value="@s">@s</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12" md="4">
-            <MudSelect T="string" Label="Tags" SelectedValues="_selectedTags" SelectedValuesChanged="OnTagsChanged" MultiSelection="true">
-                @foreach (var t in _tagOptions)
-                {
-                    <MudSelectItem Value="@t">@t</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
         <MudItem xs="12">
             <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
         </MudItem>
@@ -80,17 +64,11 @@ else if (_roots != null)
 @code {
     private string _path = string.Empty;
     private string[] _backlogs = Array.Empty<string>();
-    private string[] _stateOptions = Array.Empty<string>();
-    private string[] _tagOptions = Array.Empty<string>();
-    private IEnumerable<string> _selectedStates = Array.Empty<string>();
-    private IEnumerable<string> _selectedTags = Array.Empty<string>();
     private bool _loading;
     private List<WorkItemNode>? _roots;
 
     protected override async Task OnInitializedAsync()
     {
-        _stateOptions = ConfigService.Config.States.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        _tagOptions = ConfigService.Config.Tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         _backlogs = await ApiService.GetBacklogsAsync();
         if (_backlogs.Length > 0)
             _path = _backlogs[0];
@@ -102,9 +80,7 @@ else if (_roots != null)
         StateHasChanged();
         try
         {
-            var state = _selectedStates.Any() ? string.Join(',', _selectedStates) : null;
-            var tags = _selectedTags.Any() ? string.Join(',', _selectedTags) : null;
-            _roots = await ApiService.GetWorkItemHierarchyAsync(_path, state, tags);
+            _roots = await ApiService.GetWorkItemHierarchyAsync(_path);
         }
         finally
         {
@@ -112,8 +88,6 @@ else if (_roots != null)
         }
     }
 
-    private void OnStatesChanged(IEnumerable<string> values) => _selectedStates = values;
-    private void OnTagsChanged(IEnumerable<string> values) => _selectedTags = values;
 
     private RenderFragment StatusIcon(WorkItemNode node) => builder =>
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -17,7 +17,7 @@ public class DevOpsApiService
         _configService = configService;
     }
 
-    public async Task<List<WorkItemNode>> GetWorkItemHierarchyAsync(string areaPath, string? state = null, string? tags = null)
+    public async Task<List<WorkItemNode>> GetWorkItemHierarchyAsync(string areaPath)
     {
         var config = _configService.Config;
         if (string.IsNullOrWhiteSpace(config.Organization) ||
@@ -70,7 +70,6 @@ public class DevOpsApiService
                 Title = w.Fields["System.Title"].GetString() ?? string.Empty,
                 State = w.Fields["System.State"].GetString() ?? string.Empty,
                 WorkItemType = w.Fields["System.WorkItemType"].GetString() ?? string.Empty,
-                Tags = w.Fields.TryGetValue("System.Tags", out var tagEl) ? tagEl.GetString() ?? string.Empty : string.Empty,
                 Url = $"{itemUrlBase}{w.Id}"
             }
         }).ToDictionary(n => n.Info.Id);
@@ -233,7 +232,6 @@ public class WorkItemInfo
     public string Title { get; set; } = string.Empty;
     public string State { get; set; } = string.Empty;
     public string WorkItemType { get; set; } = string.Empty;
-    public string Tags { get; set; } = string.Empty;
     public string Url { get; set; } = string.Empty;
 }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -5,7 +5,5 @@ namespace DevOpsAssistant.Services
         public string Organization { get; set; } = string.Empty;
         public string Project { get; set; } = string.Empty;
         public string PatToken { get; set; } = string.Empty;
-        public string States { get; set; } = string.Empty;
-        public string Tags { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
## Summary
- drop unused `States` and `Tags` settings
- simplify settings dialog and work items page
- remove unused parameters in DevOps API service
- clean up tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841b444a2088328bab51c1733be8118