### PR TITLE
Fix nav layout and rename work items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -7,17 +7,13 @@
 <MudPopoverProvider />
 
 <MudLayout>
-    <MudDrawer @bind-Open="_drawerOpen" ClipMode="DrawerClipMode.Never" Variant="DrawerVariant.Responsive" Elevation="1">
-        <MudNavMenu Dense="true">
-            <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
-            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
-        </MudNavMenu>
-    </MudDrawer>
-
     <MudAppBar Color="Color.Primary" Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
         <MudText Typo="Typo.h6">DevOpsAssistant</MudText>
         <MudSpacer />
+        <MudNavMenu Dense="true" Class="d-flex">
+            <MudNavLink Href="" Match="NavLinkMatch.All" Icon="@Icons.Material.Filled.Home">Home</MudNavLink>
+            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
+        </MudNavMenu>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
     </MudAppBar>
 
@@ -29,9 +25,6 @@
 </MudLayout>
 
 @code {
-    private bool _drawerOpen = true;
-
-    private void ToggleDrawer() => _drawerOpen = !_drawerOpen;
 
     private async Task OpenSettings()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -8,7 +8,7 @@
     </MudItem>
     <MudItem xs="12">
         <MudPaper Class="pa-4">
-            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Work Items</MudNavLink>
+            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -3,7 +3,7 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 
-<PageTitle>Work Items</PageTitle>
+<PageTitle>Epics and Features</PageTitle>
 
 <MudPaper Class="p-4 mb-4">
     <MudGrid>
@@ -33,7 +33,7 @@ else if (_roots != null)
         {
             <li>
                 <MudLink Href="@epic.Info.Url" Target="_blank"><b>@epic.Info.Title</b></MudLink> - @epic.Info.WorkItemType (@epic.Info.State)
-                @StatusIcon(epic)
+                @StatusIcon(epic) @SuggestedState(epic)
                 @if (epic.Children.Any())
                 {
                     <ul>
@@ -41,13 +41,15 @@ else if (_roots != null)
                         {
                             <li>
                                 <MudLink Href="@feature.Info.Url" Target="_blank"><b>@feature.Info.Title</b></MudLink> - @feature.Info.WorkItemType (@feature.Info.State)
-                                @StatusIcon(feature)
+                                @StatusIcon(feature) @SuggestedState(feature)
                                 @if (feature.Children.Any())
                                 {
                                     <ul>
                                         @foreach (var item in feature.Children)
                                         {
-                                            <li><MudLink Href="@item.Info.Url" Target="_blank">@item.Info.Title</MudLink> - @item.Info.WorkItemType (@item.Info.State)</li>
+                                            <li><MudLink Href="@item.Info.Url" Target="_blank">@item.Info.Title</MudLink> - @item.Info.WorkItemType (@item.Info.State)
+                                                @SuggestedState(item)
+                                            </li>
                                         }
                                     </ul>
                                 }
@@ -97,6 +99,17 @@ else if (_roots != null)
             builder.AddAttribute(1, "Color", Color.Warning);
             builder.AddAttribute(2, "Icon", Icons.Material.Filled.Warning);
             builder.CloseComponent();
+        }
+    };
+
+    private RenderFragment SuggestedState(WorkItemNode node) => builder =>
+    {
+        if (!node.StatusValid)
+        {
+            builder.OpenElement(0, "span");
+            builder.AddAttribute(1, "class", "ms-1 text-secondary");
+            builder.AddContent(2, $"(Suggested: {node.ExpectedState})");
+            builder.CloseElement();
         }
     };
 }


### PR DESCRIPTION
## Summary
- replace drawer navigation with simple app bar menu
- rename "Work Items" links to "Epics & Features"
- show suggested state when work item status doesn't match

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6841bc10473c83288d2d81e194947d3f