### PR TITLE
Add update buttons and rename work items route

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/HomePageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/HomePageTests.cs
@@ -15,6 +15,6 @@ public class HomePageTests : TestContext
 
         var cut = RenderComponent<Home>();
 
-        Assert.Contains("href=\"work-items\"", cut.Markup);
+        Assert.Contains("href=\"epics-features\"", cut.Markup);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -12,7 +12,7 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer />
-        <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List" Class="me-2">Epics &amp; Features</MudNavLink>
+        <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Class="me-2">Epics &amp; Features</MudNavLink>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
     </MudAppBar>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -8,7 +8,7 @@
     </MudItem>
     <MudItem xs="12">
         <MudPaper Class="pa-4">
-            <MudNavLink Href="work-items" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
+            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -1,4 +1,4 @@
-@page "/work-items"
+@page "/epics-features"
 @using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
@@ -110,8 +110,23 @@ else if (_roots != null)
             builder.AddAttribute(1, "class", "ms-1 text-secondary");
             builder.AddContent(2, $"(Suggested: {node.ExpectedState})");
             builder.CloseElement();
+            builder.AddMarkupContent(3, "&nbsp;");
+            builder.OpenComponent<MudButton>(4);
+            builder.AddAttribute(5, "Variant", Variant.Text);
+            builder.AddAttribute(6, "Size", Size.Small);
+            builder.AddAttribute(7, "OnClick", EventCallback.Factory.Create(this, () => UpdateState(node)));
+            builder.AddContent(8, "Apply");
+            builder.CloseComponent();
         }
     };
+
+    private async Task UpdateState(WorkItemNode node)
+    {
+        await ApiService.UpdateWorkItemStateAsync(node.Info.Id, node.ExpectedState);
+        node.Info.State = node.ExpectedState;
+        node.StatusValid = true;
+        StateHasChanged();
+    }
 
     private static string GetItemClass(string type) => type.ToLowerInvariant() switch
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -208,6 +208,26 @@ public class DevOpsApiService
         node.StatusValid = node.Info.State.Equals(expected, StringComparison.OrdinalIgnoreCase);
     }
 
+    public async Task UpdateWorkItemStateAsync(int id, string state)
+    {
+        var config = GetValidatedConfig();
+        ApplyAuthentication(config);
+
+        var baseUri = BuildBaseUri(config);
+        var patch = new[]
+        {
+            new { op = "add", path = "/fields/System.State", value = state }
+        };
+        var content = new StringContent(JsonSerializer.Serialize(patch));
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json-patch+json");
+        var request = new HttpRequestMessage(HttpMethod.Patch, $"{baseUri}/workitems/{id}?api-version={ApiVersion}")
+        {
+            Content = content
+        };
+        var response = await _httpClient.SendAsync(request);
+        response.EnsureSuccessStatusCode();
+    }
+
     private class WiqlResult
     {
         public WorkItemRef[] WorkItems { get; set; } = Array.Empty<WorkItemRef>();


### PR DESCRIPTION
## Summary
- allow updating a work item's state from the UI
- rename the work items page route to `/epics-features`
- adjust navigation links and tests for the new route

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6841c2b4e2fc8328b23b599168c99904