### PR TITLE
Enhance layout with responsive menu

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -3,15 +3,17 @@
 @inject DevOpsConfigService ConfigService
 
 <MudDialog>
-    <DialogContent>
-        <MudTextField @bind-Value="_model.Organization" Label="Organization" />
-        <MudTextField @bind-Value="_model.Project" Label="Project" />
-        <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" />
-    </DialogContent>
-    <DialogActions>
+    <MudDialogContent Class="pa-4">
+        <MudStack Spacing="2">
+            <MudTextField @bind-Value="_model.Organization" Label="Organization" />
+            <MudTextField @bind-Value="_model.Project" Label="Project" />
+            <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" />
+        </MudStack>
+    </MudDialogContent>
+    <MudDialogActions Class="pa-4">
         <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
         <MudButton OnClick="Cancel" Color="Color.Secondary">Cancel</MudButton>
-    </DialogActions>
+    </MudDialogActions>
 </MudDialog>
 
 @code {

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -8,22 +8,36 @@
 
 <MudLayout>
     <MudAppBar Color="Color.Primary" Elevation="1">
-        <MudText Typo="Typo.h6" Class="me-4">
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="ToggleDrawer" />
+        <MudText Typo="Typo.h6" Class="ms-2 me-4">
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer />
-        <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Class="me-2">Epics &amp; Features</MudNavLink>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" />
     </MudAppBar>
 
+    <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
+        <MudNavMenu>
+            <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
+            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
+        </MudNavMenu>
+    </MudDrawer>
+
     <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.Large" Class="mt-4 pa-4">
+        <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
             @Body
         </MudContainer>
     </MudMainContent>
 </MudLayout>
 
 @code {
+
+    private bool _drawerOpen = true;
+
+    private void ToggleDrawer()
+    {
+        _drawerOpen = !_drawerOpen;
+    }
 
     private async Task OpenSettings()
     {


### PR DESCRIPTION
## Summary
- switch `MainLayout` to a standard responsive MudBlazor layout with drawer
- add toggleable drawer menu links
- pad dialog form content for better spacing

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6841e0b342b883288a61b110c21b76ea