### PR TITLE
Update backlog selector style and story color

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -5,7 +5,7 @@
 
 <PageTitle>Epics and Features</PageTitle>
 
-<MudPaper Class="p-4 mb-4">
+<MudPaper Class="backlog-selector p-4 mb-4">
     <MudGrid>
         <MudItem xs="12" md="4">
             <MudSelect T="string" @bind-Value="_path" Label="Backlog">

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -101,6 +101,12 @@ code {
     border-left: 1px solid var(--mud-palette-lines, #e0e0e0);
 }
 
+/* Styling for backlog selection area */
+.backlog-selector {
+    background-color: var(--mud-palette-background-grey, #f5f5f5);
+    padding: 1.5rem;
+}
+
 /* Colour coding similar to Azure DevOps */
 .work-item-epic {
     border-left: 3px solid #F7630C;
@@ -115,9 +121,9 @@ code {
 }
 
 .work-item-story {
-    border-left: 3px solid #207752;
+    border-left: 3px solid #0D6EFD;
     padding-left: 4px;
-    color: #207752;
+    color: #0D6EFD;
 }
 
 .work-item-task {


### PR DESCRIPTION
## Summary
- style backlog selection area with padding and background
- colour user stories blue

## Testing
- `dotnet test ./src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6841e2ff757c832896725fff6c1aa8f8