### PR TITLE
Add splash screen when config missing

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/MainLayoutTests.cs
@@ -37,4 +37,33 @@ public class MainLayoutTests : TestContext
 
         Assert.Contains("--mud-native-html-color-scheme: dark", cut.Markup);
     }
+
+    [Fact]
+    public void Layout_Shows_Splash_When_Config_Incomplete()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(new DevOpsConfigService(new FakeLocalStorageService()));
+
+        var cut = RenderComponent<MainLayout>();
+
+        Assert.Contains("Configuration Required", cut.Markup);
+        Assert.Contains("mud-nav-link-disabled", cut.Markup);
+    }
+
+    [Fact]
+    public async Task Layout_Hides_Splash_When_Config_Complete()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        var storage = new FakeLocalStorageService();
+        var configService = new DevOpsConfigService(storage);
+        await configService.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        Services.AddSingleton(configService);
+
+        var cut = RenderComponent<MainLayout>();
+
+        Assert.DoesNotContain("Configuration Required", cut.Markup);
+        Assert.DoesNotContain("mud-nav-link-disabled", cut.Markup);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
@@ -1,0 +1,30 @@
+@using MudBlazor
+@using DevOpsAssistant.Services
+@using Microsoft.AspNetCore.Components
+@inject IDialogService DialogService
+
+<MudPaper Class="pa-4" Style="max-width:500px;margin:auto;">
+    <MudText Typo="Typo.h4" Class="mb-2">Configuration Required</MudText>
+    <MudText>
+        To use DevOpsAssistant you need to configure your Azure DevOps organization,
+        project and a Personal Access Token. You can create a token in Azure DevOps
+        under <b>User settings &gt; Personal access tokens</b>.
+    </MudText>
+    <MudButton StartIcon="@Icons.Material.Filled.Settings" Color="Color.Primary" Class="mt-4" OnClick="OpenSettings">
+        Open Settings
+    </MudButton>
+</MudPaper>
+
+@code {
+    [Parameter] public EventCallback OnSettingsSaved { get; set; }
+
+    private async Task OpenSettings()
+    {
+        var dialog = await DialogService.ShowAsync<SettingsDialog>("Settings");
+        var result = await dialog.Result;
+        if (!result.Canceled)
+        {
+            await OnSettingsSaved.InvokeAsync();
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -20,14 +20,21 @@
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
         <MudNavMenu>
             <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
-            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
-            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule">Validation</MudNavLink>
+            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">Epics &amp; Features</MudNavLink>
+            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Validation</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 
     <MudMainContent>
         <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
-            @Body
+            @if (IsConfigMissing)
+            {
+                <DevOpsAssistant.Components.SplashScreen OnSettingsSaved="StateHasChanged" />
+            }
+            else
+            {
+                @Body
+            }
         </MudContainer>
     </MudMainContent>
 </MudLayout>
@@ -50,4 +57,9 @@
             StateHasChanged();
         }
     }
+
+    private bool IsConfigMissing =>
+        string.IsNullOrWhiteSpace(ConfigService.Config.Organization) ||
+        string.IsNullOrWhiteSpace(ConfigService.Config.Project) ||
+        string.IsNullOrWhiteSpace(ConfigService.Config.PatToken);
 }


### PR DESCRIPTION
## Summary
- show disabled navigation items and splash screen when DevOps settings are not provided
- include new `SplashScreen` component used by `MainLayout`
- test splash screen behavior

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6841f282b7048328b41ce1fafd63ff8a