### PR TITLE
Add release notes generation page

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -46,6 +46,12 @@ public class DevOpsApiServiceTests
         method.Invoke(null, new object?[] { el, list });
     }
 
+    private static string InvokeBuildStorySearchWiql(string term)
+    {
+        var method = typeof(DevOpsApiService).GetMethod("BuildStorySearchWiql", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, new object?[] { term })!;
+    }
+
     [Fact]
     public void BuildWiql_Filters_Closed_Epics()
     {
@@ -237,5 +243,23 @@ public class DevOpsApiServiceTests
         Assert.Equal("https://dev.azure.com/Org/Proj/_apis/wit/workitems/42?api-version=7.0", captured.RequestUri.ToString());
         var body = await captured.Content!.ReadAsStringAsync();
         Assert.Contains("\"Active\"", body);
+    }
+
+    [Fact]
+    public void BuildStorySearchWiql_Contains_Conditions()
+    {
+        var query = InvokeBuildStorySearchWiql("test");
+
+        Assert.Contains("User Story", query);
+        Assert.Contains("CONTAINS 'test'", query);
+    }
+
+    [Fact]
+    public async Task GetStoryHierarchyDetailsAsync_Throws_When_Config_Incomplete()
+    {
+        var configService = new DevOpsConfigService(new FakeLocalStorageService());
+        var service = new DevOpsApiService(new HttpClient(), configService);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetStoryHierarchyDetailsAsync(new[] { 1 }));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
@@ -1,0 +1,42 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Services;
+using MudBlazor.Services;
+using MudBlazor;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using Xunit;
+
+namespace DevOpsAssistant.Tests;
+
+public class ReleaseNotesPageTests : TestContext
+{
+    private class TestPage : ReleaseNotes
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+    }
+
+    private class Wrapper : ComponentBase
+    {
+        protected override void BuildRenderTree(RenderTreeBuilder builder)
+        {
+            builder.OpenComponent<MudPopoverProvider>(0);
+            builder.CloseComponent();
+            builder.OpenComponent<TestPage>(1);
+            builder.CloseComponent();
+        }
+    }
+
+    [Fact]
+    public void ReleaseNotes_Renders_With_PopoverProvider()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(new DevOpsConfigService(new FakeLocalStorageService()));
+        Services.AddSingleton<DevOpsApiService>(sp => new DevOpsApiService(new HttpClient(), sp.GetRequiredService<DevOpsConfigService>()));
+
+        var exception = Record.Exception(() => RenderComponent<Wrapper>());
+        Assert.Null(exception);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -22,6 +22,7 @@
             <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
             <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">Epics &amp; Features</MudNavLink>
             <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Validation</MudNavLink>
+            <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article" Disabled="@IsConfigMissing">Release Notes</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -11,6 +11,8 @@
             <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
             <br />
             <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule">Validation</MudNavLink>
+            <br />
+            <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article">Release Notes Prompt</MudNavLink>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -1,0 +1,74 @@
+@page "/release-notes"
+@using DevOpsAssistant.Services
+@inject DevOpsApiService ApiService
+
+<PageTitle>Release Notes Prompt</PageTitle>
+
+<MudPaper Class="p-4 mb-4">
+    <MudAutocomplete T="WorkItemInfo"
+                     Label="User Stories"
+                     MultiSelection="true"
+                     SearchFunc="SearchStories"
+                     ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
+                     @bind-SelectedValues="_selectedStories" />
+    <MudButton Class="mt-2" Color="Color.Primary" OnClick="Generate">Generate Prompt</MudButton>
+</MudPaper>
+
+@if (_loading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+}
+else if (!string.IsNullOrWhiteSpace(_prompt))
+{
+    <MudPaper Class="pa-2">
+        <MudText Class="white-space-pre-line">@_prompt</MudText>
+    </MudPaper>
+}
+
+@code {
+    private List<WorkItemInfo> _selectedStories = new();
+    private bool _loading;
+    private string? _prompt;
+
+    private Task<IEnumerable<WorkItemInfo>> SearchStories(string value, CancellationToken _)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
+            return Task.FromResult<IEnumerable<WorkItemInfo>>(Array.Empty<WorkItemInfo>());
+        return ApiService.SearchUserStoriesAsync(value).ContinueWith(t => (IEnumerable<WorkItemInfo>)t.Result);
+    }
+
+    private async Task Generate()
+    {
+        if (_selectedStories.Count == 0) return;
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            var ids = _selectedStories.Select(s => s.Id);
+            var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
+            _prompt = BuildPrompt(details);
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("Create release notes and change control details for the following stories:");
+        foreach (var item in details)
+        {
+            sb.AppendLine();
+            sb.AppendLine($"Story {item.Story.Id}: {item.Story.Title}");
+            if (!string.IsNullOrWhiteSpace(item.Description))
+                sb.AppendLine(item.Description);
+            if (item.Feature != null)
+                sb.AppendLine($"Feature {item.Feature.Id}: {item.Feature.Title}");
+            if (item.Epic != null)
+                sb.AppendLine($"Epic {item.Epic.Id}: {item.Epic.Title}");
+        }
+        return sb.ToString();
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
@@ -1,0 +1,9 @@
+namespace DevOpsAssistant.Services;
+
+public class StoryHierarchyDetails
+{
+    public WorkItemInfo Story { get; set; } = new();
+    public string Description { get; set; } = string.Empty;
+    public WorkItemInfo? Feature { get; set; }
+    public WorkItemInfo? Epic { get; set; }
+}


### PR DESCRIPTION
## Summary
- implement `SearchUserStoriesAsync` and `GetStoryHierarchyDetailsAsync` APIs
- add `StoryHierarchyDetails` model
- create `ReleaseNotes` page with autocomplete multi-select and prompt generation
- add navigation links
- add unit tests for new APIs and page

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_6841fc2a91c08328a3b6cda187e02cab