### PR TITLE
Fix missing Blazored.LocalStorage js

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
@@ -31,7 +31,6 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-    <script src="_content/Blazored.LocalStorage/blazored-localstorage.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- remove old `blazored-localstorage.js` reference

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj`
- `dotnet test src/DevOpsAssistant.PlaywrightTests/DevOpsAssistant.PlaywrightTests.csproj` *(fails: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_684209b489848328970afeb1a82d25c5