### PR TITLE
Fix settings dialog markup

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -2,8 +2,8 @@
 @using DevOpsAssistant.Services
 @inject DevOpsConfigService ConfigService
 
-<MudDialog>
-    <MudDialogContent Class="pa-4">
+<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
+    <DialogContent>
         <MudTabs>
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
@@ -26,11 +26,11 @@
                 </MudStack>
             </MudTabPanel>
         </MudTabs>
-    </MudDialogContent>
-    <MudDialogActions Class="pa-4">
+    </DialogContent>
+    <DialogActions>
         <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
         <MudButton OnClick="Cancel" Color="Color.Secondary">Cancel</MudButton>
-    </MudDialogActions>
+    </DialogActions>
 </MudDialog>
 
 @code {


### PR DESCRIPTION
## Summary
- fix markup for SettingsDialog

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build`
- `dotnet test DevOpsAssistant.PlaywrightTests/DevOpsAssistant.PlaywrightTests.csproj --no-build` *(fails: PlaywrightException - browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68420b66e9788328b28388cacc8bc43d