### PR TITLE
Improve release notes prompt

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
@@ -39,4 +39,21 @@ public class ReleaseNotesPageTests : TestContext
         var exception = Record.Exception(() => RenderComponent<Wrapper>());
         Assert.Null(exception);
     }
+
+    [Fact]
+    public void ReleaseNotes_Shows_Copy_Button_When_Prompt_Set()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(new DevOpsConfigService(new FakeLocalStorageService()));
+        Services.AddSingleton<DevOpsApiService>(sp => new DevOpsApiService(new HttpClient(), sp.GetRequiredService<DevOpsConfigService>()));
+
+        var cut = RenderComponent<Wrapper>();
+        var page = cut.FindComponent<TestPage>();
+        var field = typeof(ReleaseNotes).GetField("_prompt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        field.SetValue(page.Instance, "text");
+        page.Render();
+
+        Assert.Contains("Copy", page.Markup);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -1,6 +1,8 @@
 @page "/release-notes"
 @using DevOpsAssistant.Services
+@using Microsoft.JSInterop
 @inject DevOpsApiService ApiService
+@inject IJSRuntime JS
 
 <PageTitle>Release Notes Prompt</PageTitle>
 
@@ -11,7 +13,7 @@
                      SearchFunc="SearchStories"
                      ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
                      @bind-SelectedValues="_selectedStories" />
-    <MudButton Class="mt-2" Color="Color.Primary" OnClick="Generate">Generate Prompt</MudButton>
+    <MudButton Class="mt-2" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
 </MudPaper>
 
 @if (_loading)
@@ -21,12 +23,17 @@
 else if (!string.IsNullOrWhiteSpace(_prompt))
 {
     <MudPaper Class="pa-2">
-        <MudText Class="white-space-pre-line">@_prompt</MudText>
+        <MudStack Spacing="2">
+            <MudText Class="white-space-pre-line">@_prompt</MudText>
+            <MudButton Variant="Variant.Text"
+                       StartIcon="@Icons.Material.Filled.ContentCopy"
+                       OnClick="CopyPrompt">Copy</MudButton>
+        </MudStack>
     </MudPaper>
 }
 
 @code {
-    private List<WorkItemInfo> _selectedStories = new();
+    private HashSet<WorkItemInfo> _selectedStories = new();
     private bool _loading;
     private string? _prompt;
 
@@ -52,6 +59,12 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             _loading = false;
         }
+    }
+
+    private async Task CopyPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("copyText", _prompt);
     }
 
     private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details)

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
@@ -31,6 +31,7 @@
         <a class="dismiss">🗙</a>
     </div>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="scripts.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -1,0 +1,3 @@
+window.copyText = function(text) {
+    navigator.clipboard.writeText(text);
+};


### PR DESCRIPTION
## Summary
- allow multiple user stories to be selected
- show generated prompt with a copy button
- expose clipboard JS helper
- test copy button is rendered

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6842cdb35db88328aac4c54b6b1e6e83