### PR TITLE
Improve release notes story selection

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -12,9 +12,31 @@
                      MultiSelection="true"
                      SearchFunc="SearchStories"
                      ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
-                     @bind-SelectedValues="_selectedStories" />
+                     SelectedValues="_autocompleteSelected"
+                     SelectedValuesChanged="OnSelectedStoriesChanged" />
     <MudButton Class="mt-2" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
 </MudPaper>
+
+@if (_selectedStories.Any())
+{
+    <MudTable Items="_selectedStories" Dense="true" Class="mb-4">
+        <HeaderContent>
+            <MudTh>ID</MudTh>
+            <MudTh>Title</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="ID">@context.Id</MudTd>
+            <MudTd DataLabel="Title">@context.Title</MudTd>
+            <MudTd>
+                <MudIconButton Icon="@Icons.Material.Filled.Delete"
+                               Color="Color.Error"
+                               Size="Size.Small"
+                               OnClick="(() => Remove(context))" />
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
 
 @if (_loading)
 {
@@ -34,6 +56,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
 
 @code {
     private HashSet<WorkItemInfo> _selectedStories = new();
+    private HashSet<WorkItemInfo> _autocompleteSelected = new();
     private bool _loading;
     private string? _prompt;
 
@@ -42,6 +65,20 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
             return Task.FromResult<IEnumerable<WorkItemInfo>>(Array.Empty<WorkItemInfo>());
         return ApiService.SearchUserStoriesAsync(value).ContinueWith(t => (IEnumerable<WorkItemInfo>)t.Result);
+    }
+
+    private void OnSelectedStoriesChanged(IEnumerable<WorkItemInfo> stories)
+    {
+        foreach (var s in stories)
+            _selectedStories.Add(s);
+        _autocompleteSelected.Clear();
+        StateHasChanged();
+    }
+
+    private void Remove(WorkItemInfo story)
+    {
+        _selectedStories.Remove(story);
+        StateHasChanged();
     }
 
     private async Task Generate()

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemInfo.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemInfo.cs
@@ -1,10 +1,16 @@
 namespace DevOpsAssistant.Services;
 
-public class WorkItemInfo
+public class WorkItemInfo : IEquatable<WorkItemInfo>
 {
     public int Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string State { get; set; } = string.Empty;
     public string WorkItemType { get; set; } = string.Empty;
     public string Url { get; set; } = string.Empty;
+
+    public bool Equals(WorkItemInfo? other) => other != null && other.Id == Id;
+
+    public override bool Equals(object? obj) => obj is WorkItemInfo wi && Equals(wi);
+
+    public override int GetHashCode() => Id.GetHashCode();
 }


### PR DESCRIPTION
## Summary
- make `WorkItemInfo` equatable so selected stories dedupe correctly
- rework release notes story picker to list selected stories in a table with delete buttons
- clear autocomplete once a story is selected

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842d3711a38832899caf82b1b830898