### PR TITLE
Fix ReleaseNotes autocomplete usage

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/ReleaseNotesPageTests.cs
@@ -56,4 +56,26 @@ public class ReleaseNotesPageTests : TestContext
 
         Assert.Contains("Copy", page.Markup);
     }
+
+    [Fact]
+    public void OnStorySelected_Adds_To_SelectedStories()
+    {
+        Services.AddMudServices();
+        JSInterop.Mode = JSRuntimeMode.Loose;
+        Services.AddSingleton(new DevOpsConfigService(new FakeLocalStorageService()));
+        Services.AddSingleton<DevOpsApiService>(sp => new DevOpsApiService(new HttpClient(), sp.GetRequiredService<DevOpsConfigService>()));
+
+        var cut = RenderComponent<Wrapper>();
+        var page = cut.FindComponent<TestPage>();
+        var method = typeof(ReleaseNotes).GetMethod("OnStorySelected", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var setField = typeof(ReleaseNotes).GetField("_selectedStories", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+
+        var item = new WorkItemInfo { Id = 1, Title = "Test" };
+        page.InvokeAsync(() => method.Invoke(page.Instance, new object?[] { item }));
+        page.Render();
+
+        var set = (HashSet<WorkItemInfo>)setField.GetValue(page.Instance)!;
+        Assert.Contains(item, set);
+        Assert.Contains("Test", page.Markup);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -9,11 +9,10 @@
 <MudPaper Class="p-4 mb-4">
     <MudAutocomplete T="WorkItemInfo"
                      Label="User Stories"
-                     MultiSelection="true"
                      SearchFunc="SearchStories"
                      ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
-                     SelectedValues="_autocompleteSelected"
-                     SelectedValuesChanged="OnSelectedStoriesChanged" />
+                     Value="_searchValue"
+                     ValueChanged="OnStorySelected" />
     <MudButton Class="mt-2" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
 </MudPaper>
 
@@ -56,7 +55,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
 
 @code {
     private HashSet<WorkItemInfo> _selectedStories = new();
-    private HashSet<WorkItemInfo> _autocompleteSelected = new();
+    private WorkItemInfo? _searchValue;
     private bool _loading;
     private string? _prompt;
 
@@ -67,11 +66,11 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         return ApiService.SearchUserStoriesAsync(value).ContinueWith(t => (IEnumerable<WorkItemInfo>)t.Result);
     }
 
-    private void OnSelectedStoriesChanged(IEnumerable<WorkItemInfo> stories)
+    private void OnStorySelected(WorkItemInfo? item)
     {
-        foreach (var s in stories)
-            _selectedStories.Add(s);
-        _autocompleteSelected.Clear();
+        if (item != null)
+            _selectedStories.Add(item);
+        _searchValue = null;
         StateHasChanged();
     }
 


### PR DESCRIPTION
## Summary
- correct MudAutocomplete usage by removing unsupported multi-selection
- hook into ValueChanged to add selected story
- add unit test for selection logic

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6842d7f326a48328a12ff93185fc9192