### PR TITLE
Sort release note story suggestions by recent changes

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -252,6 +252,7 @@ public class DevOpsApiServiceTests
 
         Assert.Contains("User Story", query);
         Assert.Contains("CONTAINS 'test'", query);
+        Assert.Contains("ORDER BY [System.ChangedDate] DESC", query);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- sort work item search by changed date instead of ID
- maintain query ordering when returning results
- check ordering in tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6842e0881a60832896af9658afdc1f87