### PR TITLE
Improve Release Notes prompt display

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -45,7 +45,11 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
 {
     <MudPaper Class="pa-2">
         <MudStack Spacing="2">
-            <MudText Class="white-space-pre-line">@_prompt</MudText>
+            <MudTextField T="string"
+                          Text="@_prompt"
+                          Lines="10"
+                          ReadOnly="true"
+                          Class="w-100" />
             <MudButton Variant="Variant.Text"
                        StartIcon="@Icons.Material.Filled.ContentCopy"
                        OnClick="CopyPrompt">


### PR DESCRIPTION
## Summary
- show generated release notes prompt in a `MudTextField` so it appears in a textarea

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -v m`

------
https://chatgpt.com/codex/tasks/task_e_6842f47a35ac8328a5ce82ad66de76e9