### PR TITLE
Improve layout of page forms

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -7,13 +7,15 @@
 <PageTitle>Release Notes Prompt</PageTitle>
 
 <MudPaper Class="p-4 mb-4">
-    <MudAutocomplete T="WorkItemInfo"
-                     Label="User Stories"
-                     SearchFunc="SearchStories"
-                     ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
-                     Value="_searchValue"
-                     ValueChanged="OnStorySelected"/>
-    <MudButton Class="mt-2" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+        <MudAutocomplete T="WorkItemInfo"
+                         Label="User Stories"
+                         SearchFunc="SearchStories"
+                         ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
+                         Value="_searchValue"
+                         ValueChanged="OnStorySelected"/>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
+    </MudStack>
 </MudPaper>
 
 @if (_selectedStories.Any())

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -5,19 +5,15 @@
 <PageTitle>Validation</PageTitle>
 
 <MudPaper Class="p-4 mb-4">
-    <MudGrid>
-        <MudItem xs="12" md="4">
-            <MudSelect T="string" @bind-Value="_path" Label="Backlog">
-                @foreach (var b in _backlogs)
-                {
-                    <MudSelectItem Value="@b">@b</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12">
-            <MudButton Color="Color.Primary" OnClick="Load">Check</MudButton>
-        </MudItem>
-    </MudGrid>
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+        <MudSelect T="string" @bind-Value="_path" Label="Backlog">
+            @foreach (var b in _backlogs)
+            {
+                <MudSelectItem Value="@b">@b</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load">Check</MudButton>
+    </MudStack>
 </MudPaper>
 
 @if (_loading)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -5,19 +5,15 @@
 <PageTitle>Epics and Features</PageTitle>
 
 <MudPaper Class="p-4 mb-4">
-    <MudGrid>
-        <MudItem xs="12" md="4">
-            <MudSelect T="string" @bind-Value="_path" Label="Backlog">
-                @foreach (var b in _backlogs)
-                {
-                    <MudSelectItem Value="@b">@b</MudSelectItem>
-                }
-            </MudSelect>
-        </MudItem>
-        <MudItem xs="12">
-            <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
-        </MudItem>
-    </MudGrid>
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+        <MudSelect T="string" @bind-Value="_path" Label="Backlog">
+            @foreach (var b in _backlogs)
+            {
+                <MudSelectItem Value="@b">@b</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load">Load</MudButton>
+    </MudStack>
 </MudPaper>
 
 @if (_loading)


### PR DESCRIPTION
## Summary
- use `MudStack` for backlog selector forms
- align items neatly with `Wrap` and `AlignItems.End`
- emphasize primary buttons using the filled variant

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842f4e9b8e483289e136a48f66c487d