### PR TITLE
Add usage descriptions to pages

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -2,6 +2,11 @@
 
 <PageTitle>Home</PageTitle>
 
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Use the links below to access each tool. They let you view and manage
+    Azure DevOps work items.
+</MudAlert>
+
 <MudGrid>
     <MudItem xs="12">
         <MudText Typo="Typo.h4" Class="mb-2">Welcome to DevOpsAssistant</MudText>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -3,6 +3,12 @@
 
 <PageTitle>Metrics</PageTitle>
 
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Choose a backlog and click <b>Load</b> to display weekly throughput,
+    lead time and cycle time statistics. Charts visualize these metrics
+    for the last twelve weeks.
+</MudAlert>
+
 <MudPaper Class="p-4 mb-4">
     <MudGrid>
         <MudItem xs="12" md="4">

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -6,6 +6,12 @@
 
 <PageTitle>Release Notes Prompt</PageTitle>
 
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Search and select user stories, then click <b>Generate</b> to build a
+    prompt summarizing them for release notes. Use the copy button to
+    copy the generated text to the clipboard.
+</MudAlert>
+
 <MudPaper Class="p-4 mb-4">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
         <MudAutocomplete T="WorkItemInfo"

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -4,6 +4,11 @@
 
 <PageTitle>Validation</PageTitle>
 
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Select a backlog and click <b>Check</b> to validate work items against
+    your configured rules. Any violations will be listed below.
+</MudAlert>
+
 <MudPaper Class="p-4 mb-4">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
         <MudSelect T="string" @bind-Value="_path" Label="Backlog">

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -4,6 +4,12 @@
 
 <PageTitle>Epics and Features</PageTitle>
 
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Select a backlog and click <b>Load</b> to view epics and features.
+    Items are grouped hierarchically and you can update their state
+    directly from the list.
+</MudAlert>
+
 <MudPaper Class="p-4 mb-4">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
         <MudSelect T="string" @bind-Value="_path" Label="Backlog">


### PR DESCRIPTION
## Summary
- explain Home links
- add instructions on Epics & Features page
- document metrics page usage
- describe release notes prompt
- add details on the validation page

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842f83da4848328a52ffd9c7dfb6324