### PR TITLE
Improve metrics aggregation options

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsApiServiceTests.cs
@@ -53,6 +53,13 @@ public class DevOpsApiServiceTests
         return (string)method.Invoke(null, [term])!;
     }
 
+    private static string InvokeBuildMetricsWiql(string area, DateTime start)
+    {
+        var method =
+            typeof(DevOpsApiService).GetMethod("BuildMetricsWiql", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, [area, start])!;
+    }
+
     [Fact]
     public void BuildWiql_Filters_Closed_Epics()
     {
@@ -295,5 +302,13 @@ public class DevOpsApiServiceTests
         var service = new DevOpsApiService(new HttpClient(), configService);
 
         await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetStoryHierarchyDetailsAsync([1]));
+    }
+
+    [Fact]
+    public void BuildMetricsWiql_Uses_Start_Date()
+    {
+        var query = InvokeBuildMetricsWiql("Area", new DateTime(2024, 1, 1));
+
+        Assert.Contains("2024-01-01", query);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -5,7 +5,7 @@
 
 <MudPaper Class="p-4 mb-4">
     <MudGrid>
-        <MudItem xs="12" md="4">
+        <MudItem xs="12" md="3">
             <MudSelect T="string" @bind-Value="_path" Label="Backlog">
                 @foreach (var b in _backlogs)
                 {
@@ -13,7 +13,16 @@
                 }
             </MudSelect>
         </MudItem>
-        <MudItem xs="12">
+        <MudItem xs="12" md="3">
+            <MudSelect T="AggregateMode" @bind-Value="_mode" Label="Aggregate By">
+                <MudSelectItem Value="AggregateMode.Week">Week</MudSelectItem>
+                <MudSelectItem Value="AggregateMode.Month">Month</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" md="3">
+            <MudDatePicker @bind-Date="_startDate" Label="Start Date" />
+        </MudItem>
+        <MudItem xs="12" md="3">
             <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
         </MudItem>
     </MudGrid>
@@ -23,17 +32,17 @@
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
 }
-else if (_weeks.Any())
+else if (_periods.Any())
 {
-    <MudTable Items="_weeks" Dense="true" Hover="true">
+    <MudTable Items="_periods" Dense="true" Hover="true">
         <HeaderContent>
-            <MudTh>Week</MudTh>
+            <MudTh>Period Ending</MudTh>
             <MudTh>Avg Lead Time (days)</MudTh>
             <MudTh>Avg Cycle Time (days)</MudTh>
             <MudTh>Throughput</MudTh>
         </HeaderContent>
         <RowTemplate>
-            <MudTd DataLabel="Week">@context.WeekStart.ToString("yyyy-MM-dd")</MudTd>
+            <MudTd DataLabel="Period">@context.End.ToString("yyyy-MM-dd")</MudTd>
             <MudTd DataLabel="Lead">@context.AvgLeadTime.ToString("0.0")</MudTd>
             <MudTd DataLabel="Cycle">@context.AvgCycleTime.ToString("0.0")</MudTd>
             <MudTd DataLabel="Throughput">@context.Throughput</MudTd>
@@ -52,7 +61,9 @@ else if (_weeks.Any())
     private string _path = string.Empty;
     private string[] _backlogs = [];
     private bool _loading;
-    private List<WeekMetrics> _weeks = new();
+    private AggregateMode _mode = AggregateMode.Week;
+    private DateTime? _startDate = DateTime.Today.AddDays(-84);
+    private List<PeriodMetrics> _periods = new();
 
     private string[] _labels = [];
     private double[][] _leadCycleDatasets = [];
@@ -71,8 +82,8 @@ else if (_weeks.Any())
         StateHasChanged();
         try
         {
-            var items = await ApiService.GetStoryMetricsAsync(_path);
-            ComputeWeeks(items);
+            var items = await ApiService.GetStoryMetricsAsync(_path, _startDate);
+            ComputePeriods(items);
         }
         finally
         {
@@ -80,29 +91,36 @@ else if (_weeks.Any())
         }
     }
 
-    private void ComputeWeeks(List<StoryMetric> items)
+    private void ComputePeriods(List<StoryMetric> items)
     {
-        _weeks.Clear();
-        var startOfCurrentWeek = StartOfWeek(DateTime.Today);
-        for (int i = 11; i >= 0; i--)
+        _periods.Clear();
+        var startDate = _startDate ?? DateTime.Today.AddDays(-84);
+        DateTime start = _mode == AggregateMode.Week
+            ? StartOfWeek(startDate)
+            : new DateTime(startDate.Year, startDate.Month, 1);
+        var endBoundary = DateTime.Today;
+        while (start <= endBoundary)
         {
-            var start = startOfCurrentWeek.AddDays(-7 * i);
-            var end = start.AddDays(7);
-            var weekItems = items.Where(x => x.ClosedDate >= start && x.ClosedDate < end).ToList();
-            var metrics = new WeekMetrics
+            DateTime next = _mode == AggregateMode.Week ? start.AddDays(7) : start.AddMonths(1);
+            var rangeItems = items.Where(x => x.ClosedDate >= start && x.ClosedDate < next).ToList();
+            var metrics = new PeriodMetrics
             {
-                WeekStart = start,
-                Throughput = weekItems.Count,
-                AvgLeadTime = weekItems.Any() ? weekItems.Average(w => (w.ClosedDate - w.CreatedDate).TotalDays) : 0,
-                AvgCycleTime = weekItems.Any() ? weekItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0
+                Start = start,
+                End = next.AddDays(-1),
+                Throughput = rangeItems.Count,
+                AvgLeadTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.CreatedDate).TotalDays) : 0,
+                AvgCycleTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0
             };
-            _weeks.Add(metrics);
+            _periods.Add(metrics);
+            start = next;
         }
 
-        _labels = _weeks.Select(w => w.WeekStart.ToString("MM/dd")).ToArray();
-        var lead = _weeks.Select(w => w.AvgLeadTime).ToArray();
-        var cycle = _weeks.Select(w => w.AvgCycleTime).ToArray();
-        var throughput = _weeks.Select(w => (double)w.Throughput).ToArray();
+        _labels = _periods.Select(p => _mode == AggregateMode.Week
+                ? p.End.ToString("MM/dd")
+                : p.End.ToString("yyyy-MM")).ToArray();
+        var lead = _periods.Select(p => p.AvgLeadTime).ToArray();
+        var cycle = _periods.Select(p => p.AvgCycleTime).ToArray();
+        var throughput = _periods.Select(p => (double)p.Throughput).ToArray();
         _leadCycleDatasets = new[] { lead, cycle };
         _throughputDataset = new[] { throughput };
     }
@@ -113,9 +131,10 @@ else if (_weeks.Any())
         return dt.Date.AddDays(-diff);
     }
 
-    private class WeekMetrics
+    private class PeriodMetrics
     {
-        public DateTime WeekStart { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
         public double AvgLeadTime { get; set; }
         public double AvgCycleTime { get; set; }
         public int Throughput { get; set; }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/AggregateMode.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/AggregateMode.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public enum AggregateMode
+{
+    Week,
+    Month
+}


### PR DESCRIPTION
## Summary
- support weekly or monthly metrics aggregation
- allow passing a custom start date to metrics query
- update metrics page to show period ending, aggregation mode and start date
- test BuildMetricsWiql accepts start date

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6842f97612b48328829275a2913fc5dc