### PR TITLE
Refactor services and cleanup code

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -15,9 +15,9 @@ public abstract class ComponentTestBase : TestContext
         Services.AddMudServices();
         JSInterop.Mode = JSRuntimeMode.Loose;
         var config = new DevOpsConfigService(new FakeLocalStorageService());
-        Services.AddSingleton(config);
+        Services.AddSingleton<IDevOpsConfigService>(config);
         if (includeApi)
-            Services.AddSingleton(sp => new DevOpsApiService(new HttpClient(), config));
+            Services.AddSingleton<IDevOpsApiService>(sp => new DevOpsApiService(new HttpClient(), config));
         return config;
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,4 +1,4 @@
-@inject DevOpsConfigService ConfigService
+@inject IDevOpsConfigService ConfigService
 
 <MudDialog ContentClass="pa-4" ActionsClass="pa-4">
     <DialogContent>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -1,7 +1,7 @@
 ﻿@using DevOpsAssistant.Components
 @inherits LayoutComponentBase
 @inject IDialogService DialogService
-@inject DevOpsConfigService ConfigService
+@inject IDevOpsConfigService ConfigService
 
 <MudThemeProvider IsDarkMode="@ConfigService.Config.DarkMode"/>
 <MudDialogProvider/>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -1,5 +1,5 @@
 @page "/metrics"
-@inject DevOpsApiService ApiService
+@inject IDevOpsApiService ApiService
 
 <PageTitle>Metrics</PageTitle>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -3,7 +3,7 @@
 @using System.Text
 @using System.Text.Json
 @using System.Text.RegularExpressions
-@inject DevOpsApiService ApiService
+@inject IDevOpsApiService ApiService
 @inject IJSRuntime JS
 
 <PageTitle>Release Notes Prompt</PageTitle>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -1,7 +1,7 @@
 @page "/validation"
 @using DevOpsAssistant.Components
-@inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
+@inject IDevOpsApiService ApiService
+@inject IDevOpsConfigService ConfigService
 @inject IDialogService DialogService
 
 <PageTitle>Validation</PageTitle>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -1,6 +1,6 @@
 @page "/epics-features"
-@inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
+@inject IDevOpsApiService ApiService
+@inject IDevOpsConfigService ConfigService
 
 <PageTitle>Epics and Features</PageTitle>
 
@@ -141,7 +141,7 @@ else if (_roots != null)
 
         var root = FindRoot(node);
         if (root != null)
-            RecomputeStatus(root);
+            root.ComputeStatus();
 
         StateHasChanged();
     }
@@ -153,50 +153,14 @@ else if (_roots != null)
 
         foreach (var r in _roots)
         {
-            if (Contains(r, node.Info.Id))
+            if (r.Contains(node.Info.Id))
                 return r;
         }
 
         return null;
     }
 
-    private static bool Contains(WorkItemNode parent, int id)
-    {
-        if (parent.Info.Id == id)
-            return true;
-        foreach (var child in parent.Children)
-        {
-            if (Contains(child, id))
-                return true;
-        }
-
-        return false;
-    }
-
-    private static void RecomputeStatus(WorkItemNode node)
-    {
-        foreach (var child in node.Children)
-            RecomputeStatus(child);
-
-        if (!node.Children.Any())
-        {
-            node.ExpectedState = node.Info.State;
-            node.StatusValid = true;
-            return;
-        }
-
-        var allClosed = node.Children.All(c =>
-            c.Info.State.Equals("Closed", StringComparison.OrdinalIgnoreCase) ||
-            c.Info.State.Equals("Removed", StringComparison.OrdinalIgnoreCase) ||
-            c.Info.State.Equals("Done", StringComparison.OrdinalIgnoreCase));
-
-        var anyNotNew = node.Children.Any(c => !c.Info.State.Equals("New", StringComparison.OrdinalIgnoreCase));
-
-        var expected = allClosed ? "Closed" : anyNotNew ? "Active" : "New";
-
-        node.ExpectedState = expected;
-        node.StatusValid = node.Info.State.Equals(expected, StringComparison.OrdinalIgnoreCase);
-    }
+    
 
     private static string GetItemClass(string type)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -12,8 +12,7 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddMudServices();
 builder.Services.AddBlazoredLocalStorage();
-builder.Services.AddScoped<DevOpsConfigService>();
-builder.Services.AddScoped<DevOpsApiService>();
+builder.Services.AddScoped<IDevOpsConfigService, DevOpsConfigService>();
+builder.Services.AddScoped<IDevOpsApiService, DevOpsApiService>();
 
-var host = builder.Build();
-await host.RunAsync();
+await builder.Build().RunAsync();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -2,7 +2,7 @@ using Blazored.LocalStorage;
 
 namespace DevOpsAssistant.Services;
 
-public class DevOpsConfigService
+public class DevOpsConfigService : IDevOpsConfigService
 {
     private const string StorageKey = "devops-config";
     private readonly ILocalStorageService _localStorage;

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/IDevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/IDevOpsApiService.cs
@@ -1,0 +1,12 @@
+namespace DevOpsAssistant.Services;
+
+public interface IDevOpsApiService
+{
+    Task<List<WorkItemNode>> GetWorkItemHierarchyAsync(string areaPath);
+    Task<string[]> GetBacklogsAsync();
+    Task<List<WorkItemDetails>> GetValidationItemsAsync(string areaPath);
+    Task UpdateWorkItemStateAsync(int id, string state);
+    Task<List<WorkItemInfo>> SearchUserStoriesAsync(string term);
+    Task<List<StoryHierarchyDetails>> GetStoryHierarchyDetailsAsync(IEnumerable<int> storyIds);
+    Task<List<StoryMetric>> GetStoryMetricsAsync(string areaPath, DateTime? startDate = null);
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/IDevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/IDevOpsConfigService.cs
@@ -1,0 +1,8 @@
+namespace DevOpsAssistant.Services;
+
+public interface IDevOpsConfigService
+{
+    DevOpsConfig Config { get; }
+    Task LoadAsync();
+    Task SaveAsync(DevOpsConfig config);
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/WorkItemNodeExtensions.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/WorkItemNodeExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Linq;
+
+namespace DevOpsAssistant.Services;
+
+public static class WorkItemNodeExtensions
+{
+    public static bool Contains(this WorkItemNode parent, int id)
+    {
+        if (parent.Info.Id == id)
+            return true;
+        return parent.Children.Any(child => child.Contains(id));
+    }
+
+    public static void ComputeStatus(this WorkItemNode node)
+    {
+        foreach (var child in node.Children)
+            child.ComputeStatus();
+
+        if (!node.Children.Any())
+        {
+            node.ExpectedState = node.Info.State;
+            node.StatusValid = true;
+            return;
+        }
+
+        var allClosed = node.Children.All(c =>
+            c.Info.State.Equals("Closed", StringComparison.OrdinalIgnoreCase) ||
+            c.Info.State.Equals("Removed", StringComparison.OrdinalIgnoreCase) ||
+            c.Info.State.Equals("Done", StringComparison.OrdinalIgnoreCase));
+
+        var anyNotNew = node.Children.Any(c => !c.Info.State.Equals("New", StringComparison.OrdinalIgnoreCase));
+
+        var expected = allClosed ? "Closed" : anyNotNew ? "Active" : "New";
+
+        node.ExpectedState = expected;
+        node.StatusValid = node.Info.State.Equals(expected, StringComparison.OrdinalIgnoreCase);
+    }
+}


### PR DESCRIPTION
## Summary
- expose new `IDevOpsApiService` and `IDevOpsConfigService` interfaces
- add `WorkItemNodeExtensions` to share tree utility logic
- register interfaces in `Program.cs`
- inject interfaces in components and pages
- update component test base to use new interfaces

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6843442c9c70832888cf083f71be1e31