### PR TITLE
Add velocity metrics and CSV export

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -1,4 +1,7 @@
 using Bunit;
+using System;
+using System.Reflection;
+using System.Collections.Generic;
 using DevOpsAssistant.Pages;
 using DevOpsAssistant.Tests.Utils;
 
@@ -14,6 +17,29 @@ public class MetricsPageTests : ComponentTestBase
         var cut = RenderWithProvider<TestMetrics>();
 
         Assert.Contains("Load", cut.Markup);
+        Assert.Contains("Export CSV", cut.Markup);
+    }
+
+    [Fact]
+    public void BuildCsv_Produces_Csv_String()
+    {
+        SetupServices();
+
+        var method = typeof(Metrics).GetMethod("BuildCsv", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var periodType = typeof(Metrics).GetNestedType("PeriodMetrics", BindingFlags.NonPublic)!;
+        var array = Array.CreateInstance(periodType, 1);
+        var period = Activator.CreateInstance(periodType)!;
+        periodType.GetProperty("End")!.SetValue(period, new DateTime(2024,1,1));
+        periodType.GetProperty("AvgLeadTime")!.SetValue(period, 1.0);
+        periodType.GetProperty("AvgCycleTime")!.SetValue(period, 2.0);
+        periodType.GetProperty("Throughput")!.SetValue(period, 3);
+        periodType.GetProperty("Velocity")!.SetValue(period, 4.0);
+        array.SetValue(period, 0);
+
+        var csv = (string)method.Invoke(null, new object?[] { array })!;
+
+        Assert.Contains("Velocity", csv);
+        Assert.Contains("4.0", csv);
     }
 
     private class TestMetrics : Metrics

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -342,7 +342,7 @@ public class DevOpsApiServiceTests
     public async Task GetStoryMetricsAsync_Returns_Metrics()
     {
         var wiqlJson = "{\"workItems\":[{\"id\":1}]}";
-        var itemsJson = "{\"value\":[{\"id\":1,\"fields\":{\"System.CreatedDate\":\"2024-01-01T00:00:00Z\",\"Microsoft.VSTS.Common.ActivatedDate\":\"2024-01-02T00:00:00Z\",\"Microsoft.VSTS.Common.ClosedDate\":\"2024-01-03T00:00:00Z\"}}]}";
+        var itemsJson = "{\"value\":[{\"id\":1,\"fields\":{\"System.CreatedDate\":\"2024-01-01T00:00:00Z\",\"Microsoft.VSTS.Common.ActivatedDate\":\"2024-01-02T00:00:00Z\",\"Microsoft.VSTS.Common.ClosedDate\":\"2024-01-03T00:00:00Z\",\"Microsoft.VSTS.Scheduling.StoryPoints\":5,\"Microsoft.VSTS.Scheduling.OriginalEstimate\":8}}]}";
         var call = 0;
         var handler = new FakeHttpMessageHandler(_ =>
         {
@@ -365,5 +365,7 @@ public class DevOpsApiServiceTests
         Assert.Equal(new DateTime(2024, 1, 1), result[0].CreatedDate);
         Assert.Equal(new DateTime(2024, 1, 2), result[0].ActivatedDate);
         Assert.Equal(new DateTime(2024, 1, 3), result[0].ClosedDate);
+        Assert.Equal(5, result[0].StoryPoints);
+        Assert.Equal(8, result[0].OriginalEstimate);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -1,5 +1,8 @@
 @page "/metrics"
+@using System.Text
+@using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
+@inject IJSRuntime JS
 
 <PageTitle>Metrics</PageTitle>
 
@@ -29,7 +32,16 @@
             <MudDatePicker @bind-Date="_startDate" Label="Start Date" />
         </MudItem>
         <MudItem xs="12" md="3">
-            <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
+            <MudSelect T="VelocityMode" @bind-Value="_velocityMode" Label="Velocity By">
+                <MudSelectItem Value="VelocityMode.StoryPoints">Story Points</MudSelectItem>
+                <MudSelectItem Value="VelocityMode.OriginalEstimate">Original Estimate</MudSelectItem>
+            </MudSelect>
+        </MudItem>
+        <MudItem xs="12" md="3">
+            <MudStack Row="true" Spacing="1">
+                <MudButton Color="Color.Primary" OnClick="Load">Load</MudButton>
+                <MudButton Variant="Variant.Outlined" OnClick="ExportCsv">Export CSV</MudButton>
+            </MudStack>
         </MudItem>
     </MudGrid>
 </MudPaper>
@@ -46,12 +58,14 @@ else if (_periods.Any())
             <MudTh>Avg Lead Time (days)</MudTh>
             <MudTh>Avg Cycle Time (days)</MudTh>
             <MudTh>Throughput</MudTh>
+            <MudTh>Velocity</MudTh>
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="Period">@context.End.ToString("yyyy-MM-dd")</MudTd>
             <MudTd DataLabel="Lead">@context.AvgLeadTime.ToString("0.0")</MudTd>
             <MudTd DataLabel="Cycle">@context.AvgCycleTime.ToString("0.0")</MudTd>
             <MudTd DataLabel="Throughput">@context.Throughput</MudTd>
+            <MudTd DataLabel="Velocity">@context.Velocity.ToString("0.0")</MudTd>
         </RowTemplate>
     </MudTable>
 
@@ -59,7 +73,7 @@ else if (_periods.Any())
         <MudChart ChartType="ChartType.Line" ChartSeries="_leadCycleSeries" XAxisLabels="_xAxisLabels" Height="300" />
     </MudPaper>
     <MudPaper Class="pa-2 mt-4">
-        <MudChart ChartType="ChartType.Bar" ChartSeries="_throughputSeries" XAxisLabels="_xAxisLabels" Height="300" />
+        <MudChart ChartType="ChartType.Bar" ChartSeries="_barSeries" XAxisLabels="_xAxisLabels" Height="300" />
     </MudPaper>
 }
 
@@ -68,12 +82,13 @@ else if (_periods.Any())
     private string[] _backlogs = [];
     private bool _loading;
     private AggregateMode _mode = AggregateMode.Week;
+    private VelocityMode _velocityMode = VelocityMode.StoryPoints;
     private DateTime? _startDate = DateTime.Today.AddDays(-84);
     private List<PeriodMetrics> _periods = new();
 
     private string[] _xAxisLabels = [];
     private List<ChartSeries> _leadCycleSeries = [];
-    private List<ChartSeries> _throughputSeries = [];
+    private List<ChartSeries> _barSeries = [];
 
     protected override async Task OnInitializedAsync()
     {
@@ -115,7 +130,8 @@ else if (_periods.Any())
                 End = next.AddDays(-1),
                 Throughput = rangeItems.Count,
                 AvgLeadTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.CreatedDate).TotalDays) : 0,
-                AvgCycleTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0
+                AvgCycleTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0,
+                Velocity = rangeItems.Sum(w => _velocityMode == VelocityMode.StoryPoints ? w.StoryPoints : w.OriginalEstimate)
             };
             _periods.Add(metrics);
             start = next;
@@ -127,15 +143,33 @@ else if (_periods.Any())
         var lead = _periods.Select(p => p.AvgLeadTime).ToArray();
         var cycle = _periods.Select(p => p.AvgCycleTime).ToArray();
         var throughput = _periods.Select(p => (double)p.Throughput).ToArray();
+        var velocity = _periods.Select(p => p.Velocity).ToArray();
         _leadCycleSeries =
         [
             new ChartSeries { Name = "Lead Time", Data = lead },
             new ChartSeries { Name = "Cycle Time", Data = cycle }
         ];
-        _throughputSeries =
+        _barSeries =
         [
-            new ChartSeries { Name = "Throughput", Data = throughput }
+            new ChartSeries { Name = "Throughput", Data = throughput },
+            new ChartSeries { Name = "Velocity", Data = velocity }
         ];
+    }
+
+    private static string BuildCsv(IEnumerable<PeriodMetrics> periods)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Period End,Avg Lead Time,Avg Cycle Time,Throughput,Velocity");
+        foreach (var p in periods)
+            sb.AppendLine($"{p.End:yyyy-MM-dd},{p.AvgLeadTime:0.0},{p.AvgCycleTime:0.0},{p.Throughput},{p.Velocity:0.0}");
+        return sb.ToString();
+    }
+
+    private async Task ExportCsv()
+    {
+        if (_periods.Count == 0) return;
+        var csv = BuildCsv(_periods);
+        await JS.InvokeVoidAsync("downloadCsv", "metrics.csv", csv);
     }
 
     private static DateTime StartOfWeek(DateTime dt)
@@ -151,5 +185,6 @@ else if (_periods.Any())
         public double AvgLeadTime { get; set; }
         public double AvgCycleTime { get; set; }
         public int Throughput { get; set; }
+        public double Velocity { get; set; }
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -471,7 +471,7 @@ public class DevOpsApiService
             {
                 var idList = string.Join(',', chunk);
                 return _httpClient.GetFromJsonAsync<WorkItemsResult>(
-                    $"{baseUri}/workitems?ids={idList}&fields=System.CreatedDate,Microsoft.VSTS.Common.ActivatedDate,Microsoft.VSTS.Common.ClosedDate&api-version={ApiVersion}");
+                    $"{baseUri}/workitems?ids={idList}&fields=System.CreatedDate,Microsoft.VSTS.Common.ActivatedDate,Microsoft.VSTS.Common.ClosedDate,Microsoft.VSTS.Scheduling.StoryPoints,Microsoft.VSTS.Scheduling.OriginalEstimate&api-version={ApiVersion}");
             })
             .ToArray();
 
@@ -494,12 +494,21 @@ public class DevOpsApiService
                 ? ad.GetDateTime()
                 : created;
 
+            var storyPoints = w.Fields.TryGetValue("Microsoft.VSTS.Scheduling.StoryPoints", out var sp) && sp.ValueKind == JsonValueKind.Number
+                ? sp.GetDouble()
+                : 0;
+            var originalEstimate = w.Fields.TryGetValue("Microsoft.VSTS.Scheduling.OriginalEstimate", out var oe) && oe.ValueKind == JsonValueKind.Number
+                ? oe.GetDouble()
+                : 0;
+
             list.Add(new StoryMetric
             {
                 Id = w.Id,
                 CreatedDate = created,
                 ActivatedDate = activated,
-                ClosedDate = closed
+                ClosedDate = closed,
+                StoryPoints = storyPoints,
+                OriginalEstimate = originalEstimate
             });
         }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryMetric.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryMetric.cs
@@ -6,4 +6,6 @@ public class StoryMetric
     public DateTime CreatedDate { get; set; }
     public DateTime ActivatedDate { get; set; }
     public DateTime ClosedDate { get; set; }
+    public double StoryPoints { get; set; }
+    public double OriginalEstimate { get; set; }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/VelocityMode.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/VelocityMode.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public enum VelocityMode
+{
+    StoryPoints,
+    OriginalEstimate
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -1,3 +1,13 @@
 window.copyText = function (text) {
     navigator.clipboard.writeText(text);
 };
+
+window.downloadCsv = function (filename, text) {
+    const blob = new Blob([text], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- compute StoryMetrics with StoryPoints and OriginalEstimate
- show velocity on metrics page and support Story Points or Original Estimate
- add CSV export with download helper
- support metrics configuration via new VelocityMode enum
- test updated metrics and CSV build

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_684348cf8d5883289952fdc1f4d80a73