### PR TITLE
Fix backlog dropdown

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -174,8 +174,15 @@ public class DevOpsApiService
         var baseUri = BuildBaseUri(config);
 
         var result =
-            await GetJsonAsync<JsonElement>($"{baseUri}/classificationnodes/areas?$depth=2&api-version={ApiVersion}");
+            await GetJsonAsync<JsonElement>(
+                $"{baseUri}/classificationnodes/areas?$depth=2&api-version={ApiVersion}");
         var list = new List<string>();
+        if (result.TryGetProperty("path", out var rootPath))
+        {
+            var p = rootPath.GetString();
+            if (!string.IsNullOrEmpty(p))
+                list.Add(p);
+        }
         if (result.TryGetProperty("children", out var children))
             foreach (var child in children.EnumerateArray())
                 ExtractPaths(child, list);


### PR DESCRIPTION
## Summary
- show project root by including classification node path
- revert backlog depth query

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_684370ad333c83289ae14f2b17f7bad0