### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore
+      - name: Test
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity normal

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ dotnet run --project src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
 
 The development server listens on <http://localhost:5000>.
 
+## Continuous Integration
+
+Pull requests trigger a GitHub Actions workflow which restores the solution and
+runs all tests. The workflow ensures builds remain healthy before merging.
+
 ## Obtaining a PAT token
 
 The application communicates with Azure DevOps using a Personal Access Token (PAT). To create one:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that restores and tests the solution
- document new CI process in README

## Testing
- `dotnet format --no-restore` *(fails: command not found)*
- `dotnet restore` *(fails: command not found)*
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846997bab708328a6ba67c5b3c01a29