### PR TITLE
Add story quality review page

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -29,7 +29,7 @@ public class MetricsPageTests : ComponentTestBase
         var periodType = typeof(Metrics).GetNestedType("PeriodMetrics", BindingFlags.NonPublic)!;
         var array = Array.CreateInstance(periodType, 1);
         var period = Activator.CreateInstance(periodType)!;
-        periodType.GetProperty("End")!.SetValue(period, new DateTime(2024,1,1));
+        periodType.GetProperty("End")!.SetValue(period, new DateTime(2024, 1, 1));
         periodType.GetProperty("AvgLeadTime")!.SetValue(period, 1.0);
         periodType.GetProperty("AvgCycleTime")!.SetValue(period, 2.0);
         periodType.GetProperty("Throughput")!.SetValue(period, 3);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/StoryReviewPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/StoryReviewPageTests.cs
@@ -1,0 +1,25 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class StoryReviewPageTests : ComponentTestBase
+{
+    [Fact]
+    public void StoryReview_Renders_With_PopoverProvider()
+    {
+        SetupServices(includeApi: true);
+
+        var exception = Record.Exception(() => RenderWithProvider<TestPage>());
+        Assert.Null(exception);
+    }
+
+    private class TestPage : StoryReview
+    {
+        protected override Task OnInitializedAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -60,6 +60,13 @@ public class DevOpsApiServiceTests
         return (string)method.Invoke(null, [area, start])!;
     }
 
+    private static string InvokeBuildStoriesWiql(string area, string[] states)
+    {
+        var method =
+            typeof(DevOpsApiService).GetMethod("BuildStoriesWiql", BindingFlags.NonPublic | BindingFlags.Static)!;
+        return (string)method.Invoke(null, [area, states])!;
+    }
+
     [Fact]
     public void BuildEpicsWiql_Filters_Closed_Epics()
     {
@@ -310,6 +317,24 @@ public class DevOpsApiServiceTests
         var query = InvokeBuildMetricsWiql("Area", new DateTime(2024, 1, 1));
 
         Assert.Contains("2024-01-01", query);
+    }
+
+    [Fact]
+    public void BuildStoriesWiql_Includes_States_When_Provided()
+    {
+        var query = InvokeBuildStoriesWiql("Area", new[] { "New", "Active" });
+
+        Assert.Contains("'New'", query);
+        Assert.Contains("'Active'", query);
+        Assert.Contains("User Story", query);
+    }
+
+    [Fact]
+    public void BuildStoriesWiql_Omits_State_Filter_When_None()
+    {
+        var query = InvokeBuildStoriesWiql("Area", []);
+
+        Assert.DoesNotContain("System.State", query);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -15,6 +15,7 @@ public class DevOpsConfigServiceTests
             Project = "Proj",
             PatToken = "Token",
             DarkMode = true,
+            DefinitionOfReady = "DOR",
             Rules = new ValidationRules { EpicHasDescription = true }
         };
 
@@ -26,6 +27,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Proj", stored.Project);
         Assert.Equal("Token", stored.PatToken);
         Assert.True(stored.DarkMode);
+        Assert.Equal("DOR", stored.DefinitionOfReady);
         Assert.True(stored.Rules.EpicHasDescription);
     }
 
@@ -35,7 +37,11 @@ public class DevOpsConfigServiceTests
         var storage = new FakeLocalStorageService();
         var stored = new DevOpsConfig
         {
-            Organization = "Org", Project = "Proj", PatToken = "Token", DarkMode = true,
+            Organization = "Org",
+            Project = "Proj",
+            PatToken = "Token",
+            DarkMode = true,
+            DefinitionOfReady = "DOR",
             Rules = new ValidationRules { EpicHasDescription = true }
         };
         await storage.SetItemAsync("devops-config", stored);
@@ -47,6 +53,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Proj", service.Config.Project);
         Assert.Equal("Token", service.Config.PatToken);
         Assert.True(service.Config.DarkMode);
+        Assert.Equal("DOR", service.Config.DefinitionOfReady);
         Assert.True(service.Config.Rules.EpicHasDescription);
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -11,6 +11,11 @@
                     <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
                 </MudStack>
             </MudTabPanel>
+            <MudTabPanel Text="Story Quality">
+                <MudStack Spacing="2">
+                    <MudTextField @bind-Value="_model.DefinitionOfReady" Label="Definition of Ready" Lines="3"/>
+                </MudStack>
+            </MudTabPanel>
             <MudTabPanel Text="Validation Rules">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.h6" Class="mt-2">Epic</MudText>
@@ -55,6 +60,7 @@
             Project = cfg.Project,
             PatToken = cfg.PatToken,
             DarkMode = cfg.DarkMode,
+            DefinitionOfReady = cfg.DefinitionOfReady,
             Rules = new ValidationRules
             {
                 EpicHasDescription = cfg.Rules.EpicHasDescription,

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -23,6 +23,7 @@
             <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">Epics &amp; Features</MudNavLink>
             <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Validation</MudNavLink>
             <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article" Disabled="@IsConfigMissing">Release Notes</MudNavLink>
+            <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check" Disabled="@IsConfigMissing">Story Quality</MudNavLink>
             <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">Metrics</MudNavLink>
         </MudNavMenu>
     </MudDrawer>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -18,6 +18,8 @@
             <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule">Validation</MudNavLink>
             <br/>
             <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article">Release Notes Prompt</MudNavLink>
+            <br/>
+            <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check">Story Quality Prompt</MudNavLink>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -1,0 +1,147 @@
+@page "/story-review"
+@using System.Text
+@using System.Text.Json
+@using System.Net
+@using System.Text.RegularExpressions
+@inject DevOpsApiService ApiService
+@inject DevOpsConfigService ConfigService
+@inject IJSRuntime JS
+
+<PageTitle>Story Quality Prompt</PageTitle>
+
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Select a backlog and states then click <b>Generate</b> to build a prompt for reviewing user stories.
+</MudAlert>
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+}
+
+<MudPaper Class="p-4 mb-4">
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+        <MudSelect T="string" @bind-Value="_path" Label="Backlog">
+            @foreach (var b in _backlogs)
+            {
+                <MudSelectItem Value="@b">@b</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="string" MultiSelection="true" SelectedValues="SelectedStates" SelectedValuesChanged="@(vals => OnStatesChanged(vals))" Label="States">
+            @foreach (var s in _states)
+            {
+                <MudSelectItem Value="@s">@s</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Generate">Generate</MudButton>
+    </MudStack>
+</MudPaper>
+
+@if (_loading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
+}
+else if (!string.IsNullOrWhiteSpace(_prompt))
+{
+    <MudPaper Class="pa-2">
+        <MudStack Spacing="2">
+            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100"/>
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">
+                Copy
+            </MudButton>
+        </MudStack>
+    </MudPaper>
+}
+
+@code {
+    private string _path = string.Empty;
+    private string[] _backlogs = [];
+    private string[] _states = [];
+    private HashSet<string> SelectedStates { get; set; } = new();
+    private bool _loading;
+    private string? _prompt;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _backlogs = await ApiService.GetBacklogsAsync();
+            if (_backlogs.Length > 0)
+                _path = _backlogs[0];
+            _states = await ApiService.GetStatesAsync();
+            if (_states.Length > 0)
+                SelectedStates.Add(_states[0]);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+
+    private async Task Generate()
+    {
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            var items = await ApiService.GetStoriesAsync(_path, SelectedStates);
+            _prompt = BuildPrompt(items, ConfigService.Config.DefinitionOfReady);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task CopyPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("copyText", _prompt);
+    }
+
+    private Task OnStatesChanged(IEnumerable<string> values)
+    {
+        SelectedStates = new HashSet<string>(values);
+        return Task.CompletedTask;
+    }
+
+    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details, string dor)
+    {
+        var items = details.Select(d => new
+        {
+            Epic = d.Epic?.Title,
+            Feature = d.Feature?.Title,
+            Story = new { d.Story.Id, d.Story.Title, Description = Sanitize(d.Description) }
+        });
+        var json = JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });
+        var sb = new StringBuilder();
+        sb.AppendLine("You are an Agile coach. Review each story for adherence to the INVEST principles.");
+        if (!string.IsNullOrWhiteSpace(dor))
+        {
+            sb.AppendLine();
+            sb.AppendLine("Also confirm each story meets this Definition of Ready:");
+            sb.AppendLine(dor);
+        }
+        sb.AppendLine();
+        sb.AppendLine("Provide feedback for each story.");
+        sb.AppendLine();
+        sb.AppendLine("Work items:");
+        sb.AppendLine(json);
+        return sb.ToString();
+    }
+
+    private static string Sanitize(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+            return string.Empty;
+        var text = WebUtility.HtmlDecode(input);
+        text = Regex.Replace(text, "<.*?>", string.Empty);
+        text = Regex.Replace(text, "\\s+", " ");
+        return text.Trim();
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -6,5 +6,6 @@ public class DevOpsConfig
     public string Project { get; set; } = string.Empty;
     public string PatToken { get; set; } = string.Empty;
     public bool DarkMode { get; set; }
+    public string DefinitionOfReady { get; set; } = string.Empty;
     public ValidationRules Rules { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- allow configuring Definition of Ready in settings
- support fetching states and stories from DevOps API
- add StoryReview page for INVEST/DOR prompt generation
- link new page from navigation
- test new API helpers and page rendering
- move the Definition of Ready input to a new "Story Quality" settings tab

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_68469a30e51483289044d3fc46ffb131