### PR TITLE
Add descriptions for epics and features

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -143,8 +143,22 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         var hierarchy = details.Select(d => new
         {
-            Epic = d.Epic == null ? null : new { d.Epic.Id, d.Epic.Title },
-            Feature = d.Feature == null ? null : new { d.Feature.Id, d.Feature.Title },
+            Epic = d.Epic == null
+                ? null
+                : new
+                {
+                    d.Epic.Id,
+                    d.Epic.Title,
+                    Description = Sanitize(d.EpicDescription)
+                },
+            Feature = d.Feature == null
+                ? null
+                : new
+                {
+                    d.Feature.Id,
+                    d.Feature.Title,
+                    Description = Sanitize(d.FeatureDescription)
+                },
             Story = new { d.Story.Id, d.Story.Title, Description = Sanitize(d.Description) }
         });
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -114,8 +114,20 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         var items = details.Select(d => new
         {
-            Epic = d.Epic?.Title,
-            Feature = d.Feature?.Title,
+            Epic = d.Epic == null
+                ? null
+                : new
+                {
+                    d.Epic.Title,
+                    Description = Sanitize(d.EpicDescription)
+                },
+            Feature = d.Feature == null
+                ? null
+                : new
+                {
+                    d.Feature.Title,
+                    Description = Sanitize(d.FeatureDescription)
+                },
             Story = new { d.Story.Id, d.Story.Title, Description = Sanitize(d.Description) }
         });
         var json = JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -514,6 +514,8 @@ public class DevOpsApiService
 
             WorkItemInfo? featureInfo = null;
             WorkItemInfo? epicInfo = null;
+            string featureDesc = string.Empty;
+            string epicDesc = string.Empty;
             var featureId = story.Relations?.FirstOrDefault(r => r.Rel == "System.LinkTypes.Hierarchy-Reverse")?.Url
                 .Split('/').Last();
             if (featureId != null && int.TryParse(featureId, out var fid) && items.TryGetValue(fid, out var feature))
@@ -526,9 +528,13 @@ public class DevOpsApiService
                     WorkItemType = feature.Fields["System.WorkItemType"].GetString() ?? string.Empty,
                     Url = $"{itemUrlBase}{feature.Id}"
                 };
+                featureDesc = feature.Fields.TryGetValue("System.Description", out var fd)
+                    ? fd.GetString() ?? string.Empty
+                    : string.Empty;
                 var epicId = feature.Relations?.FirstOrDefault(r => r.Rel == "System.LinkTypes.Hierarchy-Reverse")?.Url
                     .Split('/').Last();
                 if (epicId != null && int.TryParse(epicId, out var eid) && items.TryGetValue(eid, out var epic))
+                {
                     epicInfo = new WorkItemInfo
                     {
                         Id = epic.Id,
@@ -537,6 +543,10 @@ public class DevOpsApiService
                         WorkItemType = epic.Fields["System.WorkItemType"].GetString() ?? string.Empty,
                         Url = $"{itemUrlBase}{epic.Id}"
                     };
+                    epicDesc = epic.Fields.TryGetValue("System.Description", out var ed)
+                        ? ed.GetString() ?? string.Empty
+                        : string.Empty;
+                }
             }
 
             list.Add(new StoryHierarchyDetails
@@ -544,7 +554,9 @@ public class DevOpsApiService
                 Story = storyInfo,
                 Description = desc,
                 Feature = featureInfo,
-                Epic = epicInfo
+                Epic = epicInfo,
+                FeatureDescription = featureDesc,
+                EpicDescription = epicDesc
             });
         }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
@@ -6,4 +6,6 @@ public class StoryHierarchyDetails
     public string Description { get; set; } = string.Empty;
     public WorkItemInfo? Feature { get; set; }
     public WorkItemInfo? Epic { get; set; }
+    public string FeatureDescription { get; set; } = string.Empty;
+    public string EpicDescription { get; set; } = string.Empty;
 }


### PR DESCRIPTION
## Summary
- include description fields in `StoryHierarchyDetails`
- fetch epic and feature descriptions
- output epic and feature descriptions in JSON prompts

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6846af24242c832884f7995570a7e120