### PR TITLE
Add sign out option and token guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ The application communicates with Azure DevOps using a Personal Access Token (PA
 
 1. Sign in to <https://dev.azure.com/>.
 2. Open your user menu and choose **Personal access tokens**.
-3. Select **New Token**, provide a name and expiration and grant at least **Work Items (Read & write)** scope.
+3. Select **New Token**, provide a name and a short expiration and grant only the
+   **Work Items (Read & write)** scope.
 4. Create the token and copy the value.
 
 Run the site and click the settings icon in the top right corner. Enter your organization, project and PAT token, then save. These values are stored in your browser's local storage.
+When you're done, click the **Sign Out** button in the top bar to clear the saved settings.

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -50,4 +50,16 @@ public class MainLayoutTests : ComponentTestBase
         Assert.DoesNotContain("Configuration Required", cut.Markup);
         Assert.DoesNotContain("mud-nav-link-disabled", cut.Markup);
     }
+
+    [Fact]
+    public async Task SignOut_Clears_Config()
+    {
+        var config = SetupServices();
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+
+        var cut = RenderComponent<MainLayout>();
+        cut.Find("button[title='Sign Out']").Click();
+
+        Assert.Contains("Configuration Required", cut.Markup);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -71,4 +71,17 @@ public class DevOpsConfigServiceTests
         Assert.False(service.Config.DarkMode);
         Assert.NotNull(service.Config.Rules);
     }
+
+    [Fact]
+    public async Task ClearAsync_Removes_Config_And_Resets_Property()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "Token" });
+
+        await service.ClearAsync();
+
+        Assert.Equal(string.Empty, service.Config.Organization);
+        Assert.False(await storage.ContainKeyAsync("devops-config"));
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -15,6 +15,7 @@
         </MudText>
         <MudSpacer/>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title="Sign Out"/>
     </MudAppBar>
 
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
@@ -65,6 +66,12 @@
         {
             StateHasChanged();
         }
+    }
+
+    private async Task SignOut()
+    {
+        await ConfigService.ClearAsync();
+        StateHasChanged();
     }
 
     private bool IsConfigMissing =>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -25,4 +25,10 @@ public class DevOpsConfigService
         Config = config;
         await _localStorage.SetItemAsync(StorageKey, config);
     }
+
+    public async Task ClearAsync()
+    {
+        Config = new DevOpsConfig();
+        await _localStorage.RemoveItemAsync(StorageKey);
+    }
 }


### PR DESCRIPTION
## Summary
- add `ClearAsync` to `DevOpsConfigService`
- show Sign Out button in the layout
- document shorter PAT expiry and sign out in README
- test clearing the config and signing out

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_6846b3bdc80483289ad96e8d054f6183