### PR TITLE
Refine menu and page descriptions

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
@@ -7,12 +7,11 @@ namespace DevOpsAssistant.Tests.Pages;
 public class HomePageTests : ComponentTestBase
 {
     [Fact]
-    public void Home_Has_WorkItems_Link()
+    public void Home_Shows_Description()
     {
         SetupServices();
         var cut = RenderComponent<Home>();
 
-        Assert.Contains("href=\"epics-features\"", cut.Markup);
-        Assert.Contains("href=\"validation\"", cut.Markup);
+        Assert.Contains("DevOpsAssistant provides", cut.Markup);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -22,8 +22,8 @@
         <MudNavMenu>
             <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
             <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">Epics &amp; Features</MudNavLink>
-            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Validation</MudNavLink>
             <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article" Disabled="@IsConfigMissing">Release Notes</MudNavLink>
+            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Story Validation</MudNavLink>
             <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check" Disabled="@IsConfigMissing">Story Quality</MudNavLink>
             <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">Metrics</MudNavLink>
         </MudNavMenu>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -1,11 +1,6 @@
-﻿@page "/"
+@page "/"
 
 <PageTitle>Home</PageTitle>
-
-<MudAlert Severity="Severity.Info" Class="mb-4">
-    Use the links below to access each tool. They let you view and manage
-    Azure DevOps work items.
-</MudAlert>
 
 <MudGrid>
     <MudItem xs="12">
@@ -13,13 +8,17 @@
     </MudItem>
     <MudItem xs="12">
         <MudPaper Class="pa-4">
-            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List">Epics &amp; Features</MudNavLink>
-            <br/>
-            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule">Validation</MudNavLink>
-            <br/>
-            <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article">Release Notes Prompt</MudNavLink>
-            <br/>
-            <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check">Story Quality Prompt</MudNavLink>
+            <MudText Typo="Typo.body1">
+                DevOpsAssistant provides tools for viewing and updating Azure DevOps work items.
+                Use the navigation menu to access the following features:
+            </MudText>
+            <MudList T="string" Dense="true" Class="ms-4 mt-2">
+                <MudListItem T="string">Epics &amp; Features &mdash; visualize hierarchy and maintain parent states</MudListItem>
+                <MudListItem T="string">Story Validation &mdash; check items against configurable rules</MudListItem>
+                <MudListItem T="string">Release Notes &mdash; generate a summary prompt for completed stories</MudListItem>
+                <MudListItem T="string">Story Quality &mdash; review stories for INVEST compliance</MudListItem>
+                <MudListItem T="string">Metrics &mdash; analyze throughput and cycle time</MudListItem>
+            </MudList>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -6,7 +6,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 
-<PageTitle>Release Notes Prompt</PageTitle>
+<PageTitle>Release Notes</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Search and select user stories, then click <b>Generate</b> to build a

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -7,7 +7,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 
-<PageTitle>Story Quality Prompt</PageTitle>
+<PageTitle>Story Quality</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Select a backlog and states then click <b>Generate</b> to build a prompt for reviewing user stories.

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -4,7 +4,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
 
-<PageTitle>Validation</PageTitle>
+<PageTitle>Story Validation</PageTitle>
 
 @if (!_hasRules)
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -6,8 +6,8 @@
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Select a backlog and click <b>Load</b> to view epics and features.
-    Items are grouped hierarchically and you can update their state
-    directly from the list.
+    Items are grouped hierarchically and suggested states appear when
+    parents differ from their children. Use <b>Update</b> to keep them in sync.
 </MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {


### PR DESCRIPTION
## Summary
- rename Validation feature to Story Validation
- group story tools together in the navigation
- clarify how Epics & Features keeps parents in sync
- adjust Home page overview

## Testing
- `dotnet format --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_6846cbb94cc083289c38340adbdf1241