### PR TITLE
Add state filtering to validation

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -13,11 +13,11 @@ public class DevOpsApiServiceTests
         return (string)method.Invoke(null, [area])!;
     }
 
-    private static string InvokeBuildValidationWiql(string area)
+    private static string InvokeBuildValidationWiql(string area, IEnumerable<string> states)
     {
         var method =
             typeof(DevOpsApiService).GetMethod("BuildValidationWiql", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return (string)method.Invoke(null, [area])!;
+        return (string)method.Invoke(null, [area, states])!;
     }
 
     private static void InvokeComputeStatus(WorkItemNode node)
@@ -108,7 +108,7 @@ public class DevOpsApiServiceTests
     [Fact]
     public void BuildValidationWiql_Selects_Epic_Feature_Story()
     {
-        var query = InvokeBuildValidationWiql("Area");
+        var query = InvokeBuildValidationWiql("Area", ["New", "Active"]);
 
         Assert.Contains("'Epic'", query);
         Assert.Contains("'Feature'", query);
@@ -181,7 +181,7 @@ public class DevOpsApiServiceTests
         var configService = new DevOpsConfigService(new FakeLocalStorageService());
         var service = new DevOpsApiService(new HttpClient(), configService);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetValidationItemsAsync("Area"));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetValidationItemsAsync("Area", new[] { "New" }));
     }
 
     [Theory]
@@ -285,7 +285,7 @@ public class DevOpsApiServiceTests
         await configService.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
         var service = new DevOpsApiService(client, configService);
 
-        var result = await service.GetValidationItemsAsync("Area");
+        var result = await service.GetValidationItemsAsync("Area", new[] { "New" });
 
         Assert.Single(result);
         Assert.Equal(1, result[0].Info.Id);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -68,8 +68,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
             _states = await ApiService.GetStatesAsync();
-            if (_states.Length > 0)
-                SelectedStates.Add(_states[0]);
+            SelectedStates = _states.ToHashSet();
             _error = null;
         }
         catch (Exception ex)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -24,7 +24,7 @@
 else
 {
     <MudAlert Severity="Severity.Info" Class="mb-4">
-        Select a backlog and click <b>Check</b> to validate work items against
+        Select a backlog and states then click <b>Check</b> to validate work items against
         your configured rules. Any violations will be listed below.
         <MudText Typo="Typo.subtitle2" Class="mt-2">Rules:</MudText>
         <MudList T="string" Dense="true" Class="ms-4">
@@ -42,6 +42,12 @@ else
             @foreach (var b in _backlogs)
             {
                 <MudSelectItem Value="@b">@b</MudSelectItem>
+            }
+        </MudSelect>
+        <MudSelect T="string" MultiSelection="true" SelectedValues="SelectedStates" SelectedValuesChanged="@(vals => OnStatesChanged(vals))" Label="States">
+            @foreach (var s in _states)
+            {
+                <MudSelectItem Value="@s">@s</MudSelectItem>
             }
         </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load" Disabled="!_hasRules">Check</MudButton>
@@ -78,6 +84,8 @@ else if (_results != null)
 @code {
     private string _path = string.Empty;
     private string[] _backlogs = [];
+    private string[] _states = [];
+    private HashSet<string> SelectedStates { get; set; } = new();
     private bool _loading;
     private bool _hasRules;
     private string[] _activeRules = [];
@@ -91,6 +99,8 @@ else if (_results != null)
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
+            _states = await ApiService.GetStatesAsync();
+            SelectedStates = _states.ToHashSet();
             _error = null;
         }
         catch (Exception ex)
@@ -108,7 +118,7 @@ else if (_results != null)
         StateHasChanged();
         try
         {
-            var items = await ApiService.GetValidationItemsAsync(_path);
+            var items = await ApiService.GetValidationItemsAsync(_path, SelectedStates);
             _results = Validate(items);
             _error = null;
         }
@@ -152,6 +162,12 @@ else if (_results != null)
         }
 
         return list;
+    }
+
+    private Task OnStatesChanged(IEnumerable<string> values)
+    {
+        SelectedStates = new HashSet<string>(values);
+        return Task.CompletedTask;
     }
 
     private void ComputeRules()


### PR DESCRIPTION
## Summary
- allow selecting states for validation
- select all states by default in story review and validation
- update DevOps API for new state filter
- adjust tests for new parameter

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`

------
https://chatgpt.com/codex/tasks/task_e_68483332ff988328abf3c97d9d9d414c