### PR TITLE
Add wiki requirement planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The application communicates with Azure DevOps using a Personal Access Token (PA
 
 1. Sign in to <https://dev.azure.com/>.
 2. Open your user menu and choose **Personal access tokens**.
-3. Select **New Token**, provide a name and a short expiration and grant only the
-   **Work Items (Read & write)** scope.
+3. Select **New Token**, provide a name and a short expiration and grant
+   the **Work Items (Read & write)** and **Wiki (Read)** scopes.
 4. Create the token and copy the value.
 
 Run the site and click the settings icon in the top right corner. Enter your organization, project and PAT token, then save. These values are stored in your browser's local storage.

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
@@ -1,0 +1,35 @@
+using System.Reflection;
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class RequirementsPlannerPageTests : ComponentTestBase
+{
+    [Fact]
+    public void Planner_Renders_With_PopoverProvider()
+    {
+        SetupServices(includeApi: true);
+        var exception = Record.Exception(() => RenderWithProvider<TestPage>());
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void ImportPlan_Parses_Json()
+    {
+        SetupServices(includeApi: true);
+        var cut = RenderWithProvider<TestPage>();
+        var responseField = typeof(RequirementsPlanner).GetField("_responseText", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        responseField.SetValue(cut.Instance, "{\"Epics\":[{\"Title\":\"E\",\"Description\":\"D\",\"Features\":[]}]}".Replace("Epics", "epics").Replace("Title", "title").Replace("Description", "description").Replace("Features", "features"));
+        var method = typeof(RequirementsPlanner).GetMethod("ImportPlan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        cut.InvokeAsync(() => method.Invoke(cut.Instance, null));
+        var planField = typeof(RequirementsPlanner).GetField("_plan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        Assert.NotNull(planField.GetValue(cut.Instance));
+    }
+
+    private class TestPage : RequirementsPlanner
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
@@ -6,7 +6,8 @@
         To use DevOpsAssistant you need to configure your Azure DevOps organization,
         project and a Personal Access Token. You can create a token in Azure DevOps
         under <b>User settings &gt; Personal access tokens</b>. When creating the
-        token, only enable the <b>Work Items (Read &amp; write)</b> scope.
+        token, enable the <b>Work Items (Read &amp; write)</b> and
+        <b>Wiki (Read)</b> scopes.
     </MudText>
     <MudButton StartIcon="@Icons.Material.Filled.Settings" Color="Color.Primary" Class="mt-4" OnClick="OpenSettings">
         Open Settings

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -26,6 +26,7 @@
             <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Story Validation</MudNavLink>
             <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check" Disabled="@IsConfigMissing">Story Quality</MudNavLink>
             <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">Metrics</MudNavLink>
+            <MudNavLink Href="requirements-planner" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsConfigMissing">Requirement Planner</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -1,0 +1,232 @@
+@page "/requirements-planner"
+@using System.Text.Json
+@inject DevOpsApiService ApiService
+@inject IJSRuntime JS
+
+<PageTitle>Requirement Planner</PageTitle>
+
+<MudAlert Severity="Severity.Info" Class="mb-4">
+    Search a wiki page and generate a prompt to break requirements into Epics, Features and User Stories.
+    Paste the LLM response below to import items and create them in a backlog.
+</MudAlert>
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
+}
+<MudPaper Class="p-4 mb-4">
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+        <MudAutocomplete T="WikiSearchResult"
+                         Label="Wiki Pages"
+                         SearchFunc="SearchPages"
+                         ToStringFunc="@(p => p?.Path ?? string.Empty)"
+                         Value="_page"
+                         ValueChanged="OnPageSelected" />
+        <MudSelect T="string" @bind-Value="_backlog" Label="Backlog">
+            @foreach (var b in _backlogs)
+            {
+                <MudSelectItem Value="@b">@b</MudSelectItem>
+            }
+        </MudSelect>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_page == null" OnClick="Generate">Generate Prompt</MudButton>
+    </MudStack>
+</MudPaper>
+@if (_loading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+}
+else if (!string.IsNullOrWhiteSpace(_prompt))
+{
+    <MudPaper Class="pa-2 mb-4">
+        <MudStack Spacing="2">
+            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100" />
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">Copy</MudButton>
+        </MudStack>
+    </MudPaper>
+}
+<MudPaper Class="pa-2 mb-4">
+    <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="LLM Response" Class="w-100" />
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">Import</MudButton>
+</MudPaper>
+@if (_plan != null)
+{
+    @foreach (var epic in _plan.Epics)
+    {
+        <MudPaper Class="pa-2 mb-2">
+            <MudTextField T="string" @bind-Value="epic.Title" Label="Epic Title" />
+            <MudTextField T="string" @bind-Value="epic.Description" Label="Epic Description" Lines="3" />
+            @foreach (var feature in epic.Features)
+            {
+                <MudPaper Class="pa-2 ms-4 mb-2">
+                    <MudTextField T="string" @bind-Value="feature.Title" Label="Feature Title" />
+                    <MudTextField T="string" @bind-Value="feature.Description" Label="Feature Description" Lines="3" />
+                    @foreach (var story in feature.Stories)
+                    {
+                        <MudPaper Class="pa-2 ms-4 mb-2">
+                            <MudTextField T="string" @bind-Value="story.Title" Label="Story Title" />
+                            <MudTextField T="string" @bind-Value="story.Description" Label="Story Description" Lines="3" />
+                        </MudPaper>
+                    }
+                </MudPaper>
+            }
+        </MudPaper>
+    }
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">Create Work Items</MudButton>
+}
+
+@code {
+    private WikiSearchResult? _page;
+    private string _prompt = string.Empty;
+    private string _responseText = string.Empty;
+    private bool _loading;
+    private string? _error;
+    private string[] _backlogs = [];
+    private string _backlog = string.Empty;
+    private Plan? _plan;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            _backlogs = await ApiService.GetBacklogsAsync();
+            if (_backlogs.Length > 0)
+                _backlog = _backlogs[0];
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+
+    private async Task<IEnumerable<WikiSearchResult>> SearchPages(string value, CancellationToken _)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
+            return Array.Empty<WikiSearchResult>();
+        try
+        {
+            var results = await ApiService.SearchWikiPagesAsync(value);
+            _error = null;
+            return results;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+            return Array.Empty<WikiSearchResult>();
+        }
+    }
+
+    private void OnPageSelected(WikiSearchResult? page)
+    {
+        _page = page;
+        StateHasChanged();
+    }
+
+    private async Task Generate()
+    {
+        if (_page == null) return;
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            var text = await ApiService.GetWikiPageContentAsync(_page.WikiId, _page.Path);
+            _prompt = BuildPrompt(text);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task CopyPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("copyText", _prompt);
+    }
+
+    private void ImportPlan()
+    {
+        try
+        {
+            _plan = JsonSerializer.Deserialize<Plan>(_responseText);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _plan = null;
+            _error = ex.Message;
+        }
+    }
+
+    private async Task CreateItems()
+    {
+        if (_plan == null) return;
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            foreach (var epic in _plan.Epics)
+            {
+                epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog);
+                foreach (var feature in epic.Features)
+                {
+                    feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id);
+                    foreach (var story in feature.Stories)
+                        story.Id = await ApiService.CreateWorkItemAsync("User Story", story.Title, story.Description, _backlog, feature.Id);
+                }
+            }
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private static string BuildPrompt(string text)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("You are a business analyst. Break down the following requirements into Epics, Features and User Stories.");
+        sb.AppendLine("Return JSON in this format:\n{\"epics\":[{\"title\":\"\",\"description\":\"\",\"features\":[{\"title\":\"\",\"description\":\"\",\"stories\":[{\"title\":\"\",\"description\":\"\"}]}]}]}");
+        sb.AppendLine();
+        sb.AppendLine("Document:");
+        sb.AppendLine(text);
+        return sb.ToString();
+    }
+
+    private class Plan
+    {
+        public List<Epic> Epics { get; set; } = new();
+    }
+
+    private class Epic
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public List<Feature> Features { get; set; } = new();
+    }
+
+    private class Feature
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public List<Story> Stories { get; set; } = new();
+    }
+
+    private class Story
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiSearchResult.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiSearchResult.cs
@@ -1,0 +1,10 @@
+namespace DevOpsAssistant.Services;
+
+public class WikiSearchResult
+{
+    public string WikiId { get; set; } = string.Empty;
+    public string Path { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public string Id { get; set; } = string.Empty;
+    public string Name => System.IO.Path.GetFileName(Path);
+}


### PR DESCRIPTION
## Summary
- support searching wiki pages via DevOps API
- allow fetching wiki content and creating work items
- add Requirement Planner page with LLM prompt generation and import
- expose new page from navigation menu
- test basic page behavior
- document wiki read PAT scope

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_6849704c13e48328a12d0ffb37f9ac09