### PR TITLE
Fix wiki search endpoint

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -431,7 +431,7 @@ public class DevOpsApiServiceTests
 
         Assert.NotNull(captured);
         Assert.Equal(HttpMethod.Post, captured!.Method);
-        Assert.Equal("https://dev.azure.com/Org/Proj/_apis/search/wikis?api-version=7.1-preview.1",
+        Assert.Equal("https://almsearch.dev.azure.com/Org/Proj/_apis/search/wikisearchresults?api-version=7.1",
             captured.RequestUri.ToString());
         var body = await captured.Content!.ReadAsStringAsync();
         Assert.Contains("test", body);

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -648,7 +648,7 @@ public class DevOpsApiService
         ApplyAuthentication(config);
 
         var url =
-            $"https://dev.azure.com/{config.Organization}/{config.Project}/_apis/search/wikis?api-version=7.1-preview.1";
+            $"https://almsearch.dev.azure.com/{config.Organization}/{config.Project}/_apis/search/wikisearchresults?api-version=7.1";
         var result = await PostJsonAsync<JsonElement>(url, new { searchText = term });
         var list = new List<WikiSearchResult>();
         if (result.ValueKind != JsonValueKind.Undefined && result.TryGetProperty("results", out var results))


### PR DESCRIPTION
## Summary
- use the `wikisearchresults` endpoint for wiki search
- update unit test expectations

## Testing
- `dotnet format ./src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_6849952e35648328ac23e2066741c97d