### PR TITLE
Fix analyzer warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ The following guidelines apply to the entire repository and inform how Codex sho
 
 - After modifying files, run `dotnet format --no-restore` to keep style consistent.
 - Run `dotnet restore` and then `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln` to verify the solution builds and tests succeed.
+- Run `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror` to ensure there are no Roslyn warnings.
 - If these commands fail because the environment lacks `dotnet`, note this in the PR's testing section.
 
 ## Commit guidelines

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -273,6 +273,7 @@ public class DevOpsApiServiceTests
 
         Assert.NotNull(captured);
         Assert.Equal(HttpMethod.Patch, captured!.Method);
+        Assert.NotNull(captured.RequestUri);
         Assert.Equal("https://dev.azure.com/Org/Proj/_apis/wit/workitems/42?api-version=7.0",
             captured.RequestUri.ToString());
         var body = await captured.Content!.ReadAsStringAsync();
@@ -431,6 +432,7 @@ public class DevOpsApiServiceTests
 
         Assert.NotNull(captured);
         Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.NotNull(captured.RequestUri);
         Assert.Equal("https://dev.azure.com/Org/Proj/_apis/search/wikis?api-version=7.1-preview.1",
             captured.RequestUri.ToString());
         var body = await captured.Content!.ReadAsStringAsync();

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -23,6 +23,7 @@ public class DevOpsConfigServiceTests
 
         Assert.Equal("Org", service.Config.Organization);
         var stored = await storage.GetItemAsync<DevOpsConfig>("devops-config");
+        Assert.NotNull(stored);
         Assert.Equal("Org", stored.Organization);
         Assert.Equal("Proj", stored.Project);
         Assert.Equal("Token", stored.PatToken);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/FakeLocalStorageService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/FakeLocalStorageService.cs
@@ -7,8 +7,10 @@ public class FakeLocalStorageService : ILocalStorageService
 {
     private readonly Dictionary<string, string?> _store = new();
 
+#pragma warning disable CS0067 // events are not used in tests
     public event EventHandler<ChangingEventArgs>? Changing;
     public event EventHandler<ChangedEventArgs>? Changed;
+#pragma warning restore CS0067
 
     public ValueTask ClearAsync(CancellationToken cancellationToken = default)
     {
@@ -21,26 +23,26 @@ public class FakeLocalStorageService : ILocalStorageService
         return new ValueTask<bool>(_store.ContainsKey(key));
     }
 
-    public ValueTask<T> GetItemAsync<T>(string key, CancellationToken cancellationToken = default)
+    public ValueTask<T?> GetItemAsync<T>(string key, CancellationToken cancellationToken = default)
     {
         if (_store.TryGetValue(key, out var json))
         {
             var value = JsonSerializer.Deserialize<T>(json!);
-            return new ValueTask<T>(value!);
+            return ValueTask.FromResult<T?>(value);
         }
 
-        return new ValueTask<T>(default(T)!);
+        return ValueTask.FromResult<T?>(default);
     }
 
-    public ValueTask<string> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
+    public ValueTask<string?> GetItemAsStringAsync(string key, CancellationToken cancellationToken = default)
     {
         _store.TryGetValue(key, out var value);
-        return new ValueTask<string>(value!);
+        return ValueTask.FromResult<string?>(value);
     }
 
-    public ValueTask<string> KeyAsync(int index, CancellationToken cancellationToken = default)
+    public ValueTask<string?> KeyAsync(int index, CancellationToken cancellationToken = default)
     {
-        return new ValueTask<string>(_store.Keys.ElementAt(index));
+        return ValueTask.FromResult<string?>(_store.Keys.ElementAt(index));
     }
 
     public ValueTask<IEnumerable<string>> KeysAsync(CancellationToken cancellationToken = default)

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
@@ -21,7 +21,7 @@
     {
         var dialog = await DialogService.ShowAsync<SettingsDialog>("Settings");
         var result = await dialog.Result;
-        if (!result.Canceled)
+        if (result != null && !result.Canceled)
         {
             await OnSettingsSaved.InvokeAsync();
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -63,7 +63,7 @@
     {
         var dialog = await DialogService.ShowAsync<SettingsDialog>("Settings");
         var result = await dialog.Result;
-        if (!result.Canceled)
+        if (result != null && !result.Canceled)
         {
             StateHasChanged();
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -190,7 +190,7 @@ else if (_results != null)
     {
         var dialog = await DialogService.ShowAsync<SettingsDialog>("Settings");
         var result = await dialog.Result;
-        if (!result.Canceled)
+        if (result != null && !result.Canceled)
         {
             ComputeRules();
             StateHasChanged();


### PR DESCRIPTION
## Summary
- avoid null-forgiving operators in tests
- keep unused events but silence compiler warning
- enforce Roslyn checks via AGENTS instructions

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6849956832ec8328bc2586222d7f4557