### PR TITLE
Fix deep linking with static web app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ publishes the site to a staging environment. Smoke tests verify that each page
 loads correctly before the same build is promoted to production. Deployments do
 not run during pull requests.
 
+### Azure Static Web Apps
+
+Production hosting uses Azure Static Web Apps. The configuration file
+`staticwebapp.config.json` rewrites unknown URLs to `index.html` so deep links
+(for example `/requirements-planner`) work correctly.
+
 ## Obtaining a PAT token
 
 The application communicates with Azure DevOps using a Personal Access Token (PAT). To create one:

--- a/src/DevOpsAssistant/DevOpsAssistant/staticwebapp.config.json
+++ b/src/DevOpsAssistant/DevOpsAssistant/staticwebapp.config.json
@@ -1,0 +1,8 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/api/*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add `staticwebapp.config.json` to rewrite deep links to index.html
- document Azure Static Web Apps hosting

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68499efd1fac8328b0a66ee340c3f46d