### PR TITLE
Add coverage report to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,15 @@ jobs:
           dotnet-version: 8.0.x
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
-      - name: Test
-        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity normal
+      - name: Test with coverage
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+      - name: Install ReportGenerator
+        run: dotnet tool install --global dotnet-reportgenerator-globaltool
+      - name: Generate coverage report
+        run: |
+          reportgenerator -reports:"**/coverage.cobertura.xml" -targetdir:"coverage-report" -reporttypes:Html
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage-report

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The development server listens on <http://localhost:5000>.
 ## Continuous Integration
 
 Pull requests trigger a GitHub Actions workflow which restores the solution and
-runs all tests. The workflow ensures builds remain healthy before merging.
+runs all tests. The workflow ensures builds remain healthy before merging. Test
+execution collects code coverage data and publishes an HTML report as a build
+artifact.
 
 When changes are merged into the `main` branch, the deployment workflow first
 publishes the site to a staging environment. Smoke tests verify that each page


### PR DESCRIPTION
## Summary
- generate code coverage during CI
- publish coverage report artifacts
- document coverage reporting in README

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity diag`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6849a39a1f18832888ab9aaf3e36d74d