### PR TITLE
Add wiki tree selection

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -1,5 +1,7 @@
 @page "/requirements-planner"
 @using System.Text.Json
+@using MudBlazor
+@using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 
@@ -14,20 +16,18 @@
     <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
 }
 <MudPaper Class="p-4 mb-4">
-    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
-        <MudAutocomplete T="WikiSearchResult"
-                         Label="Wiki Pages"
-                         SearchFunc="SearchPages"
-                         ToStringFunc="@(p => p?.Path ?? string.Empty)"
-                         Value="_page"
-                         ValueChanged="OnPageSelected" />
+    <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Start" Wrap="Wrap.Wrap">
+        @if (_wikiItems != null)
+        {
+            <MudTreeView T="WikiPageNode" Items="@_wikiItems" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="_selectedPages" Style="max-height:300px; overflow:auto; width:300px;" />
+        }
         <MudSelect T="string" @bind-Value="_backlog" Label="Backlog">
             @foreach (var b in _backlogs)
             {
                 <MudSelectItem Value="@b">@b</MudSelectItem>
             }
         </MudSelect>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_page == null" OnClick="Generate">Generate Prompt</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_selectedPages == null || _selectedPages.Count == 0" OnClick="Generate">Generate Prompt</MudButton>
     </MudStack>
 </MudPaper>
 @if (_loading)
@@ -74,7 +74,9 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
 }
 
 @code {
-    private WikiSearchResult? _page;
+    private List<TreeItemData<WikiPageNode>>? _wikiItems;
+    private IReadOnlyCollection<WikiPageNode>? _selectedPages;
+    private string _wikiId = string.Empty;
     private string _prompt = string.Empty;
     private string _responseText = string.Empty;
     private bool _loading;
@@ -90,46 +92,38 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _backlog = _backlogs[0];
+
+            var wikis = await ApiService.GetWikisAsync();
+            if (wikis.Count > 0)
+            {
+                _wikiId = wikis[0].Id;
+                var root = await ApiService.GetWikiPageTreeAsync(_wikiId);
+                if (root != null)
+                    _wikiItems = [BuildTreeItem(root)];
+            }
+
             _error = null;
         }
         catch (Exception ex)
         {
             _error = ex.Message;
         }
-    }
-
-    private async Task<IEnumerable<WikiSearchResult>> SearchPages(string value, CancellationToken _)
-    {
-        if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
-            return Array.Empty<WikiSearchResult>();
-        try
-        {
-            var results = await ApiService.SearchWikiPagesAsync(value);
-            _error = null;
-            return results;
-        }
-        catch (Exception ex)
-        {
-            _error = ex.Message;
-            return Array.Empty<WikiSearchResult>();
-        }
-    }
-
-    private void OnPageSelected(WikiSearchResult? page)
-    {
-        _page = page;
-        StateHasChanged();
     }
 
     private async Task Generate()
     {
-        if (_page == null) return;
+        if (_selectedPages == null || _selectedPages.Count == 0) return;
         _loading = true;
         StateHasChanged();
         try
         {
-            var text = await ApiService.GetWikiPageContentAsync(_page.WikiId, _page.Path);
-            _prompt = BuildPrompt(text);
+            var sb = new System.Text.StringBuilder();
+            foreach (var p in _selectedPages)
+            {
+                var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
+                sb.AppendLine(text);
+            }
+            _prompt = BuildPrompt(sb.ToString());
             _error = null;
         }
         catch (Exception ex)
@@ -189,6 +183,14 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             _loading = false;
         }
+    }
+
+    private static TreeItemData<WikiPageNode> BuildTreeItem(WikiPageNode node)
+    {
+        var item = new TreeItemData<WikiPageNode> { Value = node, Text = node.Name };
+        if (node.Children.Count > 0)
+            item.Children = node.Children.Select(BuildTreeItem).ToList();
+        return item;
     }
 
     private static string BuildPrompt(string text)

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiInfo.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiInfo.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public class WikiInfo
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiPageNode.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WikiPageNode.cs
@@ -1,0 +1,8 @@
+namespace DevOpsAssistant.Services;
+
+public class WikiPageNode
+{
+    public string Path { get; set; } = string.Empty;
+    public List<WikiPageNode> Children { get; set; } = new();
+    public string Name => string.IsNullOrEmpty(Path) || Path == "/" ? "Home" : System.IO.Path.GetFileName(Path);
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wiki-tree.json
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wiki-tree.json
@@ -1,0 +1,11 @@
+{
+  "value": [
+    {
+      "path": "/",
+      "subPages": [
+        { "path": "/Home", "subPages": [] },
+        { "path": "/Setup", "subPages": [] }
+      ]
+    }
+  ]
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wikis.json
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wikis.json
@@ -1,0 +1,5 @@
+{
+  "value": [
+    { "id": "1", "name": "Project Wiki" }
+  ]
+}


### PR DESCRIPTION
## Summary
- fetch project wiki structure and display as a tree
- allow selecting multiple pages and generating a prompt from them
- add models for wiki info and page node
- update tests for new API methods

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6849d9f13df083288bfb359573a7cc5c