### PR TITLE
Enable localization support

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -16,6 +16,7 @@ public abstract class ComponentTestBase : TestContext
     protected DevOpsConfigService SetupServices(bool includeApi = false)
     {
         Services.AddMudServices();
+        Services.AddLocalization();
         JSInterop.Mode = JSRuntimeMode.Loose;
         var config = new DevOpsConfigService(new FakeLocalStorageService());
         Services.AddSingleton(config);

--- a/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Home" xml:space="preserve">
+    <value>Inicio</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Épicas y Características</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Notas de lanzamiento</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Validación de historias</value>
+  </data>
+  <data name="StoryReview" xml:space="preserve">
+    <value>Calidad de la historia</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Métricas</value>
+  </data>
+  <data name="RequirementPlanner" xml:space="preserve">
+    <value>Planificador de requisitos</value>
+  </data>
+  <data name="SignOut" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -3,6 +3,8 @@
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
 @inject VersionService VersionService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<MainLayout> L
 
 <MudThemeProvider IsDarkMode="@ConfigService.Config.DarkMode"/>
 <MudDialogProvider/>
@@ -15,19 +17,19 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer/>
-        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings"/>
-        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title="Sign Out"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" title='@L["Settings"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>
 
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
         <MudNavMenu>
-            <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">Home</MudNavLink>
-            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">Epics &amp; Features</MudNavLink>
-            <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article" Disabled="@IsConfigMissing">Release Notes</MudNavLink>
-            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">Story Validation</MudNavLink>
-            <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check" Disabled="@IsConfigMissing">Story Quality</MudNavLink>
-            <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">Metrics</MudNavLink>
-            <MudNavLink Href="requirements-planner" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsConfigMissing">Requirement Planner</MudNavLink>
+            <MudNavLink Href="" Icon="@Icons.Material.Filled.Home" Match="NavLinkMatch.All">@L["Home"]</MudNavLink>
+            <MudNavLink Href="epics-features" Icon="@Icons.Material.Filled.List" Disabled="@IsConfigMissing">@L["Epics"]</MudNavLink>
+            <MudNavLink Href="release-notes" Icon="@Icons.Material.Filled.Article" Disabled="@IsConfigMissing">@L["ReleaseNotes"]</MudNavLink>
+            <MudNavLink Href="validation" Icon="@Icons.Material.Filled.Rule" Disabled="@IsConfigMissing">@L["Validation"]</MudNavLink>
+            <MudNavLink Href="story-review" Icon="@Icons.Material.Filled.Check" Disabled="@IsConfigMissing">@L["StoryReview"]</MudNavLink>
+            <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">@L["Metrics"]</MudNavLink>
+            <MudNavLink Href="requirements-planner" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsConfigMissing">@L["RequirementPlanner"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Home" xml:space="preserve">
+    <value>Home</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Epics &amp; Features</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Release Notes</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Story Validation</value>
+  </data>
+  <data name="StoryReview" xml:space="preserve">
+    <value>Story Quality</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Metrics</value>
+  </data>
+  <data name="RequirementPlanner" xml:space="preserve">
+    <value>Requirement Planner</value>
+  </data>
+  <data name="SignOut" xml:space="preserve">
+    <value>Sign Out</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Welcome" xml:space="preserve">
+    <value>Bienvenido a DevOpsAssistant</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>DevOpsAssistant proporciona herramientas para ver y actualizar elementos de trabajo de Azure DevOps. Use el menú de navegación para acceder a las siguientes funciones:</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Épicas y características — visualice la jerarquía y mantenga los estados padre</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Validación de historias — verifique los elementos con reglas configurables</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Notas de lanzamiento — genere un resumen para las historias completadas</value>
+  </data>
+  <data name="Quality" xml:space="preserve">
+    <value>Calidad de la historia — revise las historias para el cumplimiento de INVEST</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Métricas — analice el rendimiento y el tiempo de ciclo</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -1,23 +1,24 @@
 @page "/"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Home> L
 
 <PageTitle>Home</PageTitle>
 
 <MudGrid>
     <MudItem xs="12">
-        <MudText Typo="Typo.h4" Class="mb-2">Welcome to DevOpsAssistant</MudText>
+        <MudText Typo="Typo.h4" Class="mb-2">@L["Welcome"]</MudText>
     </MudItem>
     <MudItem xs="12">
         <MudPaper Class="pa-4">
             <MudText Typo="Typo.body1">
-                DevOpsAssistant provides tools for viewing and updating Azure DevOps work items.
-                Use the navigation menu to access the following features:
+                @L["Description"]
             </MudText>
             <MudList T="string" Dense="true" Class="ms-4 mt-2">
-                <MudListItem T="string">Epics &amp; Features &mdash; visualize hierarchy and maintain parent states</MudListItem>
-                <MudListItem T="string">Story Validation &mdash; check items against configurable rules</MudListItem>
-                <MudListItem T="string">Release Notes &mdash; generate a summary prompt for completed stories</MudListItem>
-                <MudListItem T="string">Story Quality &mdash; review stories for INVEST compliance</MudListItem>
-                <MudListItem T="string">Metrics &mdash; analyze throughput and cycle time</MudListItem>
+                <MudListItem T="string">@L["Epics"]</MudListItem>
+                <MudListItem T="string">@L["Validation"]</MudListItem>
+                <MudListItem T="string">@L["ReleaseNotes"]</MudListItem>
+                <MudListItem T="string">@L["Quality"]</MudListItem>
+                <MudListItem T="string">@L["Metrics"]</MudListItem>
             </MudList>
         </MudPaper>
     </MudItem>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Welcome" xml:space="preserve">
+    <value>Welcome to DevOpsAssistant</value>
+  </data>
+  <data name="Description" xml:space="preserve">
+    <value>DevOpsAssistant provides tools for viewing and updating Azure DevOps work items. Use the navigation menu to access the following features:</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Epics &amp; Features — visualize hierarchy and maintain parent states</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Story Validation — check items against configurable rules</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Release Notes — generate a summary prompt for completed stories</value>
+  </data>
+  <data name="Quality" xml:space="preserve">
+    <value>Story Quality — review stories for INVEST compliance</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Metrics — analyze throughput and cycle time</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -4,6 +4,8 @@ using DevOpsAssistant.Services;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
+using Microsoft.JSInterop;
+using System.Globalization;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -16,7 +18,16 @@ builder.Services.AddScoped<DevOpsConfigService>();
 builder.Services.AddScoped<DevOpsApiService>();
 builder.Services.AddScoped<VersionService>();
 builder.Services.AddScoped<DeploymentConfigService>();
+builder.Services.AddLocalization();
 
 var host = builder.Build();
+var js = host.Services.GetRequiredService<IJSRuntime>();
+var cultureName = await js.InvokeAsync<string>("blazorCulture.get");
+if (!string.IsNullOrWhiteSpace(cultureName))
+{
+    var culture = new CultureInfo(cultureName);
+    CultureInfo.DefaultThreadCurrentCulture = culture;
+    CultureInfo.DefaultThreadCurrentUICulture = culture;
+}
 await host.Services.GetRequiredService<DeploymentConfigService>().LoadAsync();
 await host.RunAsync();

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -11,3 +11,12 @@ window.downloadCsv = function (filename, text) {
     link.click();
     URL.revokeObjectURL(url);
 };
+
+window.blazorCulture = {
+    get: function () {
+        return localStorage['BlazorCulture'];
+    },
+    set: function (value) {
+        localStorage['BlazorCulture'] = value;
+    }
+};


### PR DESCRIPTION
## Summary
- add localization services and default culture handling
- localize Home page and navigation menu
- persist user culture in browser storage
- update tests for localization

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6849e653a01c832893f8935a69aa58c2