### PR TITLE
Fix requirements planner initialization

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -120,4 +120,21 @@ public class UiTests
         var splash = await page.QuerySelectorAsync("text=Open Settings");
         Assert.NotNull(splash);
     }
+
+    [Fact]
+    public async Task RequirementsPlanner_Shows_WikiTree()
+    {
+        if (string.IsNullOrEmpty(_baseUrl))
+            return;
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+        await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
+        await page.ReloadAsync();
+        await page.GotoAsync(_baseUrl.TrimEnd('/') + "/requirements-planner");
+        var item = await page.WaitForSelectorAsync("text=Home");
+        Assert.NotNull(item);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -3,6 +3,7 @@
 @using MudBlazor
 @using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
+@inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 
 <PageTitle>Requirement Planner</PageTitle>
@@ -89,6 +90,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         try
         {
+            await ConfigService.LoadAsync();
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _backlog = _backlogs[0];


### PR DESCRIPTION
## Summary
- ensure configuration is loaded before fetching wiki data
- add UI test verifying wiki tree loads on Requirements Planner page

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6849fe36af048328a233d60c38f83756