### PR TITLE
Update wiki tree parsing

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -472,7 +472,7 @@ public class DevOpsApiServiceTests
             captured = req;
             return new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent("{\"path\":\"/\",\"subPages\":[]}")
+                Content = new StringContent("{\"path\":\"/\",\"order\":0,\"isParentPage\":true,\"gitItemPath\":\"/index.md\",\"subPages\":[{\"path\":\"/Child\",\"order\":1,\"gitItemPath\":\"/Child.md\",\"subPages\":[]}]}")
             };
         });
         var client = new HttpClient(handler);
@@ -488,25 +488,6 @@ public class DevOpsApiServiceTests
         Assert.NotNull(captured.RequestUri);
         Assert.Equal("https://dev.azure.com/Org/Proj/_apis/wiki/wikis/1/pages?recursionLevel=Full&api-version=7.1-preview.1",
             captured.RequestUri.ToString());
-        Assert.NotNull(result);
-    }
-
-    [Fact]
-    public async Task GetWikiPageTreeAsync_Parses_Missing_Value_Property()
-    {
-        var handler = new FakeHttpMessageHandler(_ =>
-            new HttpResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new StringContent("{\"path\":\"/\",\"subPages\":[{\"path\":\"/Child\",\"subPages\":[]}]}")
-            });
-        var client = new HttpClient(handler);
-        var storage = new FakeLocalStorageService();
-        var configService = new DevOpsConfigService(storage);
-        await configService.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
-        var service = new DevOpsApiService(client, configService, new DeploymentConfigService(new HttpClient()));
-
-        var result = await service.GetWikiPageTreeAsync("1");
-
         Assert.NotNull(result);
         Assert.Equal("/", result!.Path);
         Assert.Single(result.Children);

--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -135,31 +135,9 @@ public class UiTests
         await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
         await page.ReloadAsync();
         await page.GotoAsync(_baseUrl.TrimEnd('/') + "/requirements-planner");
-        var item = await page.WaitForSelectorAsync("text=Home");
-        Assert.NotNull(item);
-    }
-
-    [Fact]
-    public async Task RequirementsPlanner_Shows_Tree_With_Alt_Wiki_Format()
-    {
-        if (string.IsNullOrEmpty(_baseUrl))
-            return;
-
-        var altJson = await File.ReadAllTextAsync(Path.Combine(AppContext.BaseDirectory, "wiki-tree-alt.json"));
-
-        using var playwright = await Playwright.CreateAsync();
-        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
-        var page = await browser.NewPageAsync();
-        await page.RouteAsync("**/wiki-tree.json", route => route.FulfillAsync(new RouteFulfillOptions
-        {
-            Body = altJson,
-            ContentType = "application/json"
-        }));
-        await page.GotoAsync(_baseUrl);
-        await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
-        await page.ReloadAsync();
-        await page.GotoAsync(_baseUrl.TrimEnd('/') + "/requirements-planner");
-        var item = await page.WaitForSelectorAsync("text=Home");
-        Assert.NotNull(item);
+        var root = await page.WaitForSelectorAsync("text=Home");
+        var child = await page.WaitForSelectorAsync("text=Setup");
+        Assert.NotNull(root);
+        Assert.NotNull(child);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/wiki-tree-alt.json
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/wiki-tree-alt.json
@@ -1,7 +1,0 @@
-{
-  "path": "/",
-  "order": 0,
-  "subPages": [
-    { "path": "/Page1", "subPages": [] }
-  ]
-}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -737,22 +737,8 @@ public class DevOpsApiService
         if (doc.ValueKind != JsonValueKind.Object)
             return null;
 
-        if (doc.TryGetProperty("value", out var value) && value.ValueKind == JsonValueKind.Array && value.GetArrayLength() > 0)
-        {
-            var pages = value.Deserialize<WikiPage[]>(_jsonOptions);
-            if (pages != null && pages.Length > 0)
-            {
-                var rootPage = pages.FirstOrDefault(p => p.Path == "/") ?? pages[0];
-                return ParseWikiPage(rootPage);
-            }
-        }
-        else if (doc.TryGetProperty("path", out _))
-        {
-            var page = doc.Deserialize<WikiPage>(_jsonOptions);
-            return page != null ? ParseWikiPage(page) : null;
-        }
-
-        return null;
+        var page = doc.Deserialize<WikiPage>(_jsonOptions);
+        return page != null ? ParseWikiPage(page) : null;
     }
 
     private static WikiPageNode ParseWikiPage(WikiPage page)
@@ -862,14 +848,15 @@ public class DevOpsApiService
         public string? Content { get; set; }
     }
 
-    private class WikiPagesResult
-    {
-        public WikiPage[] Value { get; set; } = [];
-    }
-
     private class WikiPage
     {
         public string? Path { get; set; }
+        public int Order { get; set; }
+        public bool IsParentPage { get; set; }
+        public string? GitItemPath { get; set; }
         public WikiPage[]? SubPages { get; set; }
+        public string? Url { get; set; }
+        public string? RemoteUrl { get; set; }
+        public string? Content { get; set; }
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wiki-tree.json
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/mock-data/wiki-tree.json
@@ -1,11 +1,29 @@
 {
-  "value": [
+  "path": "/",
+  "order": 0,
+  "isParentPage": true,
+  "gitItemPath": "/index.md",
+  "subPages": [
     {
-      "path": "/",
-      "subPages": [
-        { "path": "/Home", "subPages": [] },
-        { "path": "/Setup", "subPages": [] }
-      ]
+      "path": "/Home",
+      "order": 1,
+      "isParentPage": false,
+      "gitItemPath": "/Home.md",
+      "subPages": [],
+      "url": "",
+      "remoteUrl": ""
+    },
+    {
+      "path": "/Setup",
+      "order": 2,
+      "isParentPage": false,
+      "gitItemPath": "/Setup.md",
+      "subPages": [],
+      "url": "",
+      "remoteUrl": ""
     }
-  ]
+  ],
+  "url": "",
+  "remoteUrl": "",
+  "content": "# Root"
 }


### PR DESCRIPTION
## Summary
- parse wiki tree using single format
- update mock wiki tree data to reflect the format
- adjust service tests for new wiki tree format
- remove alt-format test and data
- verify child nodes in UI test

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore -v diag`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_684aaeb63590832891861b7525b5f836