### PR TITLE
Fix Requirements import case sensitivity

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
@@ -25,7 +25,27 @@ public class RequirementsPlannerPageTests : ComponentTestBase
         var method = typeof(RequirementsPlanner).GetMethod("ImportPlan", BindingFlags.NonPublic | BindingFlags.Instance)!;
         cut.InvokeAsync(() => method.Invoke(cut.Instance, null));
         var planField = typeof(RequirementsPlanner).GetField("_plan", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        Assert.NotNull(planField.GetValue(cut.Instance));
+        var plan = planField.GetValue(cut.Instance);
+        Assert.NotNull(plan);
+        var epics = (System.Collections.ICollection?)plan!.GetType().GetProperty("Epics")!.GetValue(plan);
+        Assert.Equal(1, epics?.Count);
+    }
+
+    [Fact]
+    public void ImportPlan_Parses_Json_With_CodeFence()
+    {
+        SetupServices(includeApi: true);
+        var cut = RenderWithProvider<TestPage>();
+        var responseField = typeof(RequirementsPlanner).GetField("_responseText", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var json = "{\"epics\":[{\"title\":\"E\",\"description\":\"D\",\"features\":[]}]}";
+        responseField.SetValue(cut.Instance, $"```json\n{json}\n```\nExtra");
+        var method = typeof(RequirementsPlanner).GetMethod("ImportPlan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        cut.InvokeAsync(() => method.Invoke(cut.Instance, null));
+        var planField = typeof(RequirementsPlanner).GetField("_plan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var plan = planField.GetValue(cut.Instance);
+        Assert.NotNull(plan);
+        var epics = (System.Collections.ICollection?)plan!.GetType().GetProperty("Epics")!.GetValue(plan);
+        Assert.Equal(1, epics?.Count);
     }
 
     private class TestPage : RequirementsPlanner

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -166,7 +166,9 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         try
         {
-            _plan = JsonSerializer.Deserialize<Plan>(_responseText);
+            var json = ExtractJson(_responseText);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            _plan = JsonSerializer.Deserialize<Plan>(json, options);
             _error = null;
         }
         catch (Exception ex)
@@ -174,6 +176,15 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             _plan = null;
             _error = ex.Message;
         }
+    }
+
+    private static string ExtractJson(string text)
+    {
+        var start = text.IndexOf('{');
+        var end = text.LastIndexOf('}');
+        return start >= 0 && end > start
+            ? text[start..(end + 1)]
+            : text;
     }
 
     private async Task CreateItems()


### PR DESCRIPTION
## Summary
- handle code fences in LLM output when importing a requirements plan
- deserialize plan JSON with case-insensitive property names
- verify epics load in tests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684ad229084083288d41eac105dc9109