### PR TITLE
Improve Requirement Planner flow

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -16,89 +16,91 @@
 {
     <MudAlert Severity="Severity.Error" Class="mb-4">@_error</MudAlert>
 }
-<MudPaper Class="p-4 mb-4">
-    <MudStack Spacing="2">
-        @if (_wikiItems != null)
-        {
-            <MudTreeView T="WikiPageNode" Items="@_wikiItems" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="_selectedPages" Style="max-height:300px; overflow:auto; width:100%;">
-                <ItemTemplate>
-                    <MudTreeViewItem Items="@context.Children" Value="@context.Value" Text="@context.Text" @bind-Expanded="@context.Expanded" />
-                </ItemTemplate>
-            </MudTreeView>
-        }
-        <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
-            <MudSelect T="string" @bind-Value="_backlog" Label="Backlog">
-                @foreach (var b in _backlogs)
-                {
-                    <MudSelectItem Value="@b">@b</MudSelectItem>
-                }
-            </MudSelect>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_selectedPages == null || _selectedPages.Count == 0" OnClick="Generate">Generate Prompt</MudButton>
+
+<MudStepper @ref="_stepper" Class="mb-4" ActionContent="@(_ => (RenderFragment)(builder => { }) )">
+    <MudStep Title="Select Requirements">
+        <MudStack Spacing="2">
+            @if (_wikiItems != null)
+            {
+                <MudTreeView T="WikiPageNode" Items="@_wikiItems" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="_selectedPages" Style="max-height:300px; overflow:auto; width:100%;">
+                    <ItemTemplate>
+                        <MudTreeViewItem Items="@context.Children" Value="@context.Value" Text="@context.Text" @bind-Expanded="@context.Expanded" />
+                    </ItemTemplate>
+                </MudTreeView>
+            }
+            <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
+                <MudSelect T="string" @bind-Value="_backlog" Label="Backlog">
+                    @foreach (var b in _backlogs)
+                    {
+                        <MudSelectItem Value="@b">@b</MudSelectItem>
+                    }
+                </MudSelect>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_selectedPages == null || _selectedPages.Count == 0" OnClick="Generate">Generate Prompt</MudButton>
+            </MudStack>
         </MudStack>
-    </MudStack>
-</MudPaper>
+    </MudStep>
+    <MudStep Title="Import Response" Disabled="@string.IsNullOrWhiteSpace(_prompt)">
+        <MudStack Spacing="2">
+            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100" />
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">Copy</MudButton>
+            <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="LLM Response" Class="w-100" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">Import</MudButton>
+        </MudStack>
+    </MudStep>
+    <MudStep Title="Create Work Items" Disabled="@(_plan == null)">
+        @if (_plan != null)
+        {
+            <MudList T="string" Dense="true" Class="mb-2">
+                @foreach (var epic in _plan.Epics)
+                {
+                    <MudListItem T="string">
+                        <div class='@WorkItemHelpers.GetItemClass("Epic")'>
+                            <b>Epic:</b> @epic.Title
+                            <MudText Class="d-block ms-4">@epic.Description</MudText>
+                            @if (epic.Features.Count > 0)
+                            {
+                                <MudList T="string" Dense="true" Class="ms-4">
+                                    @foreach (var feature in epic.Features)
+                                    {
+                                        <MudListItem T="string">
+                                            <div class='@WorkItemHelpers.GetItemClass("Feature")'>
+                                                <b>Feature:</b> @feature.Title
+                                                <MudText Class="d-block ms-4">@feature.Description</MudText>
+                                                @if (feature.Stories.Count > 0)
+                                                {
+                                                    <MudList T="string" Dense="true" Class="ms-4">
+                                                        @foreach (var story in feature.Stories)
+                                                        {
+                                                            <MudListItem T="string">
+                                                                <div class='@WorkItemHelpers.GetItemClass("User Story")'>
+                                                                    <b>Story:</b> @story.Title
+                                                                    <MudText Class="d-block ms-4">@story.Description</MudText>
+                                                                </div>
+                                                            </MudListItem>
+                                                        }
+                                                    </MudList>
+                                                }
+                                            </div>
+                                        </MudListItem>
+                                    }
+                                </MudList>
+                            }
+                        </div>
+                    </MudListItem>
+                }
+            </MudList>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">Create Work Items</MudButton>
+        }
+    </MudStep>
+</MudStepper>
+
 @if (_loading)
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
 }
-else if (!string.IsNullOrWhiteSpace(_prompt))
-{
-    <MudPaper Class="pa-2 mb-4">
-        <MudStack Spacing="2">
-            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100" />
-            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">Copy</MudButton>
-        </MudStack>
-    </MudPaper>
-    <MudPaper Class="pa-2 mb-4">
-        <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="LLM Response" Class="w-100" />
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">Import</MudButton>
-    </MudPaper>
-}
-@if (_plan != null)
-{
-        <MudList T="string" Dense="true" Class="mb-2">
-            @foreach (var epic in _plan.Epics)
-            {
-                <MudListItem T="string">
-                    <div class='@WorkItemHelpers.GetItemClass("Epic")'>
-                        <b>Epic:</b> @epic.Title
-                        <MudText Class="d-block ms-4">@epic.Description</MudText>
-                        @if (epic.Features.Count > 0)
-                        {
-                            <MudList T="string" Dense="true" Class="ms-4">
-                                @foreach (var feature in epic.Features)
-                                {
-                                    <MudListItem T="string">
-                                        <div class='@WorkItemHelpers.GetItemClass("Feature")'>
-                                            <b>Feature:</b> @feature.Title
-                                            <MudText Class="d-block ms-4">@feature.Description</MudText>
-                                            @if (feature.Stories.Count > 0)
-                                            {
-                                                <MudList T="string" Dense="true" Class="ms-4">
-                                                    @foreach (var story in feature.Stories)
-                                                    {
-                                                        <MudListItem T="string">
-                                                            <div class='@WorkItemHelpers.GetItemClass("User Story")'>
-                                                                <b>Story:</b> @story.Title
-                                                                <MudText Class="d-block ms-4">@story.Description</MudText>
-                                                            </div>
-                                                        </MudListItem>
-                                                    }
-                                                </MudList>
-                                            }
-                                        </div>
-                                    </MudListItem>
-                                }
-                            </MudList>
-                        }
-                    </div>
-                </MudListItem>
-            }
-        </MudList>
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">Create Work Items</MudButton>
-}
 
 @code {
+    private MudStepper? _stepper;
     private List<TreeItemData<WikiPageNode>>? _wikiItems;
     private IReadOnlyCollection<WikiPageNode>? _selectedPages;
     private string _wikiId = string.Empty;
@@ -151,6 +153,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             }
             _prompt = BuildPrompt(pages);
             _error = null;
+            await (_stepper?.NextStepAsync() ?? Task.CompletedTask);
         }
         catch (Exception ex)
         {
@@ -176,6 +179,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             _plan = JsonSerializer.Deserialize<Plan>(json, options);
             _error = null;
+            _ = _stepper?.NextStepAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- organize the Requirement Planner page into a MudStepper flow
- advance steps after generating the prompt and importing the plan

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_684ae3d056e48328ba7dfdad873671c8