### PR TITLE
Update page titles with site name

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/App.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/App.razor
@@ -4,7 +4,7 @@
         <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
     </Found>
     <NotFound>
-        <PageTitle>Not found</PageTitle>
+        <PageTitle>DevOpsAssistant - Not found</PageTitle>
         <LayoutView Layout="@typeof(MainLayout)">
             <p role="alert">Sorry, there's nothing at this address.</p>
         </LayoutView>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Home> L
 
-<PageTitle>Home</PageTitle>
+<PageTitle>DevOpsAssistant - Home</PageTitle>
 
 <MudGrid>
     <MudItem xs="12">

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -4,7 +4,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 
-<PageTitle>Metrics</PageTitle>
+<PageTitle>DevOpsAssistant - Metrics</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Choose a backlog and click <b>Load</b> to display weekly throughput,

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -6,7 +6,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 
-<PageTitle>Release Notes</PageTitle>
+<PageTitle>DevOpsAssistant - Release Notes</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Search and select user stories, then click <b>Generate</b> to build a

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -6,7 +6,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 
-<PageTitle>Requirement Planner</PageTitle>
+<PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Search a wiki page and generate a prompt to break requirements into Epics, Features and User Stories.

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -7,7 +7,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 
-<PageTitle>Story Quality</PageTitle>
+<PageTitle>DevOpsAssistant - Story Quality</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Select a backlog and states then click <b>Generate</b> to build a prompt for reviewing user stories.

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -4,7 +4,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
 
-<PageTitle>Story Validation</PageTitle>
+<PageTitle>DevOpsAssistant - Story Validation</PageTitle>
 
 @if (!_hasRules)
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -2,7 +2,7 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 
-<PageTitle>Epics and Features</PageTitle>
+<PageTitle>DevOpsAssistant - Epics and Features</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
     Select a backlog and click <b>Load</b> to view epics and features.


### PR DESCRIPTION
## Summary
- prefix page titles with "DevOpsAssistant"

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684aeaa0f1e8832889db899a4a23ed19