### PR TITLE
Fix version footer build output

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
@@ -25,4 +25,11 @@
     </Content>
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="wwwroot/version.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- ensure version.txt is copied when building the Blazor app

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_684aea62c1408328ab2fc1967c1657ad