### PR TITLE
Install Playwright browsers in workflow

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
+++ b/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
@@ -41,6 +41,8 @@ jobs:
           dotnet-version: 8.0.x
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
       - name: Run UI tests
         run: dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --no-restore --verbosity normal
         env:


### PR DESCRIPTION
## Summary
- install Playwright browser binaries in `ui_tests` job before running tests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_684b2f618df08328b9733819dcddb417