### PR TITLE
Add NuGet cache in CI

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
+++ b/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
@@ -39,6 +39,13 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
       - name: Run UI tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
       - name: Test with coverage


### PR DESCRIPTION
## Summary
- cache NuGet packages in CI workflow
- cache NuGet packages in deployment UI test job

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684b2f624a94832894bef73dee242d10