### PR TITLE
Align CI to unit test only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
       - name: Test with coverage
-        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity normal --collect:"XPlat Code Coverage"
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-restore --verbosity normal --collect:"XPlat Code Coverage"
       - name: Install ReportGenerator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
       - name: Generate coverage report


### PR DESCRIPTION
## Summary
- run only unit tests during CI coverage step

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684b2f631e1c8328afb8366a51f8e598