### PR TITLE
Fix build configuration for CI tests

### DIFF
--- a/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
+++ b/.github/workflows/azure-static-web-apps-brave-rock-022b8fe03.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build
         run: dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror
       - name: Test
-        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-build --no-restore --verbosity normal
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release --no-build --no-restore --verbosity normal
       - name: Set version
         run: echo "1.0.${{ github.run_number }}" > src/DevOpsAssistant/DevOpsAssistant/wwwroot/version.txt
       - name: Deploy to Staging
@@ -83,7 +83,7 @@ jobs:
       - name: Build
         run: dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror
       - name: Test
-        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --no-build --no-restore --verbosity normal
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release --no-build --no-restore --verbosity normal
       - name: Set version
         run: echo "1.0.${{ github.run_number }}" > src/DevOpsAssistant/DevOpsAssistant/wwwroot/version.txt
       - name: Deploy to Production


### PR DESCRIPTION
## Summary
- ensure the staging and production workflows run tests using Release configuration

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684bd827c8e08328bd59ad9662cb7e1d