### PR TITLE
Include story acceptance criteria

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -21,18 +21,18 @@
 <MudPaper Class="p-4 mb-4">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
         <MudAutocomplete T="WorkItemInfo"
-                         Label="User Stories"
-                         SearchFunc="SearchStories"
+                         Label="Work Items"
+                         SearchFunc="SearchItems"
                          ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
                          Value="_searchValue"
-                         ValueChanged="OnStorySelected"/>
+                         ValueChanged="OnItemSelected"/>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
     </MudStack>
 </MudPaper>
 
-@if (_selectedStories.Any())
+@if (_selectedItems.Any())
 {
-    <MudTable Items="_selectedStories" Dense="true" Class="mb-4">
+    <MudTable Items="_selectedItems" Dense="true" Class="mb-4">
         <HeaderContent>
             <MudTh>ID</MudTh>
             <MudTh>Title</MudTh>
@@ -74,21 +74,21 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
 }
 
 @code {
-    private readonly HashSet<WorkItemInfo> _selectedStories = [];
+    private readonly HashSet<WorkItemInfo> _selectedItems = [];
     private WorkItemInfo? _searchValue;
     private bool _loading;
     private string? _prompt;
     private string? _error;
 
-    private async Task<IEnumerable<WorkItemInfo>> SearchStories(string value, CancellationToken _)
+    private async Task<IEnumerable<WorkItemInfo>> SearchItems(string value, CancellationToken _)
     {
         if (string.IsNullOrWhiteSpace(value) || value.Length < 2)
             return Array.Empty<WorkItemInfo>();
         try
         {
-            var result = await ApiService.SearchUserStoriesAsync(value);
+            var result = await ApiService.SearchReleaseItemsAsync(value);
             _error = null;
-            return result.Where(r => !_selectedStories.Contains(r));
+            return result.Where(r => !_selectedItems.Contains(r));
         }
         catch (Exception ex)
         {
@@ -97,28 +97,28 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         }
     }
 
-    private void OnStorySelected(WorkItemInfo? item)
+    private void OnItemSelected(WorkItemInfo? item)
     {
         if (item != null)
-            _selectedStories.Add(item);
+            _selectedItems.Add(item);
         _searchValue = null;
         StateHasChanged();
     }
 
     private void Remove(WorkItemInfo story)
     {
-        _selectedStories.Remove(story);
+        _selectedItems.Remove(story);
         StateHasChanged();
     }
 
     private async Task Generate()
     {
-        if (_selectedStories.Count == 0) return;
+        if (_selectedItems.Count == 0) return;
         _loading = true;
         StateHasChanged();
         try
         {
-            var ids = _selectedStories.Select(s => s.Id);
+            var ids = _selectedItems.Select(s => s.Id);
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
             _prompt = BuildPrompt(details);
             _error = null;
@@ -159,7 +159,16 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
                     d.Feature.Title,
                     Description = Sanitize(d.FeatureDescription)
                 },
-            Story = new { d.Story.Id, d.Story.Title, Description = Sanitize(d.Description) }
+            Item = new
+            {
+                d.Story.Id,
+                d.Story.Title,
+                d.Story.WorkItemType,
+                Description = Sanitize(d.Description),
+                ReproSteps = Sanitize(d.ReproSteps),
+                SystemInfo = Sanitize(d.SystemInfo),
+                AcceptanceCriteria = Sanitize(d.AcceptanceCriteria)
+            }
         });
 
         var json = JsonSerializer.Serialize(

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
@@ -4,6 +4,9 @@ public class StoryHierarchyDetails
 {
     public WorkItemInfo Story { get; set; } = new();
     public string Description { get; set; } = string.Empty;
+    public string AcceptanceCriteria { get; set; } = string.Empty;
+    public string ReproSteps { get; set; } = string.Empty;
+    public string SystemInfo { get; set; } = string.Empty;
     public WorkItemInfo? Feature { get; set; }
     public WorkItemInfo? Epic { get; set; }
     public string FeatureDescription { get; set; } = string.Empty;


### PR DESCRIPTION
## Summary
- store AcceptanceCriteria in `StoryHierarchyDetails`
- fetch acceptance criteria when retrieving work item details
- show acceptance criteria in release notes prompt
- test prompt generation for acceptance criteria

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684fe5c680688328832b60b05529e207