### PR TITLE
Add state to validation results

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
@@ -2,6 +2,9 @@ using Bunit;
 using DevOpsAssistant.Pages;
 using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace DevOpsAssistant.Tests.Pages;
 
@@ -14,6 +17,34 @@ public class ValidationPageTests : ComponentTestBase
 
         var exception = Record.Exception(() => RenderWithProvider<TestPage>());
         Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Results_Show_State_When_Set()
+    {
+        SetupServices(includeApi: true);
+
+        var cut = RenderWithProvider<TestPage>();
+        var type = typeof(Validation);
+        var nested = type.GetNestedType("ResultItem", BindingFlags.NonPublic)!;
+        var listType = typeof(List<>).MakeGenericType(nested);
+        var list = (IList)Activator.CreateInstance(listType)!;
+        var item = Activator.CreateInstance(nested)!;
+        nested.GetProperty("Info")!.SetValue(item, new WorkItemInfo
+        {
+            Id = 1,
+            Title = "Story",
+            State = "Active",
+            WorkItemType = "User Story",
+            Url = "http://localhost"
+        });
+        nested.GetProperty("Violations")!.SetValue(item, new List<string> { "V" });
+        list.Add(item);
+        var field = type.GetField("_results", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(cut.Instance, list);
+        cut.Render();
+
+        Assert.Contains("Active", cut.Markup);
     }
 
     private class TestPage : Validation

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -71,7 +71,7 @@ else if (_results != null)
                 @foreach (var r in _results)
                 {
                     <MudListItem T="ResultItem">
-                        <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType
+                        <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType (@r.Info.State)
                         <br/>
                         <span class="text-secondary">@string.Join(", ", r.Violations)</span>
                     </MudListItem>


### PR DESCRIPTION
## Summary
- show each work item's state in the validation results list
- add a regression test verifying states render

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_684ff769bd20832889aa3b83a61bf098