### PR TITLE
Add default story state selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The application communicates with Azure DevOps using a Personal Access Token (PA
    the **Work Items (Read & write)**, **Wiki (Read)** and **Code (Read)** scopes.
 4. Create the token and copy the value.
 
-Run the site and click the settings icon in the top right corner. Enter your organization, project and PAT token, then save. These values are stored in your browser's local storage.
+Run the site and click the settings icon in the top right corner. Enter your organization, project and PAT token, then save. You can also specify a comma separated list of additional default states which will be pre-selected on the story screens. These values are stored in your browser's local storage.
 When you're done, click the **Sign Out** button in the top bar to clear the saved settings.
 
 ## Faking the DevOps API for tests

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -12,7 +12,7 @@ public class SettingsDialogTests : ComponentTestBase
     public async Task SettingsDialog_Shows_Config_Values()
     {
         var config = SetupServices();
-        await config.SaveAsync(new DevOpsConfig { Organization = "Org", MainBranch = "main" });
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", MainBranch = "main", DefaultStates = "Active" });
 
         var cut = RenderComponent<SettingsDialog>();
         var modelField = cut.Instance.GetType().GetField("_model", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -20,5 +20,6 @@ public class SettingsDialogTests : ComponentTestBase
 
         Assert.Equal("Org", model.Organization);
         Assert.Equal("main", model.MainBranch);
+        Assert.Equal("Active", model.DefaultStates);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -16,6 +16,7 @@ public class DevOpsConfigServiceTests
             PatToken = "Token",
             DarkMode = true,
             DefinitionOfReady = "DOR",
+            DefaultStates = "Resolved",
             Rules = new ValidationRules { EpicHasDescription = true }
         };
 
@@ -29,6 +30,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Token", stored.PatToken);
         Assert.True(stored.DarkMode);
         Assert.Equal("DOR", stored.DefinitionOfReady);
+        Assert.Equal("Resolved", stored.DefaultStates);
         Assert.True(stored.Rules.EpicHasDescription);
     }
 
@@ -43,6 +45,7 @@ public class DevOpsConfigServiceTests
             PatToken = "Token",
             DarkMode = true,
             DefinitionOfReady = "DOR",
+            DefaultStates = "Active",
             Rules = new ValidationRules { EpicHasDescription = true }
         };
         await storage.SetItemAsync("devops-config", stored);
@@ -55,6 +58,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Token", service.Config.PatToken);
         Assert.True(service.Config.DarkMode);
         Assert.Equal("DOR", service.Config.DefinitionOfReady);
+        Assert.Equal("Active", service.Config.DefaultStates);
         Assert.True(service.Config.Rules.EpicHasDescription);
     }
 
@@ -70,6 +74,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.Project);
         Assert.Equal(string.Empty, service.Config.PatToken);
         Assert.False(service.Config.DarkMode);
+        Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.NotNull(service.Config.Rules);
     }
 
@@ -83,6 +88,7 @@ public class DevOpsConfigServiceTests
         await service.ClearAsync();
 
         Assert.Equal(string.Empty, service.Config.Organization);
+        Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.False(await storage.ContainKeyAsync("devops-config"));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -9,6 +9,7 @@
                     <MudTextField @bind-Value="_model.Project" Label="Project"/>
                     <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
+                    <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
                     <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
                 </MudStack>
             </MudTabPanel>
@@ -61,6 +62,7 @@
             Project = cfg.Project,
             PatToken = cfg.PatToken,
             MainBranch = cfg.MainBranch,
+            DefaultStates = cfg.DefaultStates,
             DarkMode = cfg.DarkMode,
             DefinitionOfReady = cfg.DefinitionOfReady,
             Rules = new ValidationRules

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -68,7 +68,12 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
             _states = await ApiService.GetStatesAsync();
-            SelectedStates = _states.ToHashSet();
+            var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+            SelectedStates = _states
+                .Where(s => s.Equals("New", StringComparison.OrdinalIgnoreCase) ||
+                            s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
+                            extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
+                .ToHashSet();
             _error = null;
         }
         catch (Exception ex)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -100,7 +100,12 @@ else if (_results != null)
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
             _states = await ApiService.GetStatesAsync();
-            SelectedStates = _states.ToHashSet();
+            var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+            SelectedStates = _states
+                .Where(s => s.Equals("New", StringComparison.OrdinalIgnoreCase) ||
+                            s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
+                            extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
+                .ToHashSet();
             _error = null;
         }
         catch (Exception ex)

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -7,6 +7,7 @@ public class DevOpsConfig
     public string PatToken { get; set; } = string.Empty;
     public string MainBranch { get; set; } = string.Empty;
     public bool DarkMode { get; set; }
+    public string DefaultStates { get; set; } = string.Empty;
     public string DefinitionOfReady { get; set; } = string.Empty;
     public ValidationRules Rules { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- select `New` and `Active` story states by default
- allow additional default states in Settings
- persist new `DefaultStates` option
- update README with details about the setting
- cover new option in unit tests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68500fc1079c8328898f6f1d8d521226