### PR TITLE
Add release notes tree view option

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -12,7 +12,7 @@ public class SettingsDialogTests : ComponentTestBase
     public async Task SettingsDialog_Shows_Config_Values()
     {
         var config = SetupServices();
-        await config.SaveAsync(new DevOpsConfig { Organization = "Org", MainBranch = "main", DefaultStates = "Active" });
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", MainBranch = "main", DefaultStates = "Active", ReleaseNotesTreeView = true });
 
         var cut = RenderComponent<SettingsDialog>();
         var modelField = cut.Instance.GetType().GetField("_model", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -21,5 +21,6 @@ public class SettingsDialogTests : ComponentTestBase
         Assert.Equal("Org", model.Organization);
         Assert.Equal("main", model.MainBranch);
         Assert.Equal("Active", model.DefaultStates);
+        Assert.True(model.ReleaseNotesTreeView);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -57,7 +57,7 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public async Task SearchItems_Filters_Selected_Items()
     {
-        var config = SetupServices();
+        var config = SetupServices(includeApi: true);
         await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
 
         var wiqlJson = "{\"workItems\":[{\"id\":1},{\"id\":2}]}";
@@ -131,6 +131,27 @@ public class ReleaseNotesPageTests : ComponentTestBase
         var result = (string)method.Invoke(null, [new List<StoryHierarchyDetails>()])!;
 
         Assert.Contains("No branding is required.", result);
+    }
+
+    [Fact]
+    public async Task ReleaseNotes_Uses_TreeView_When_Configured()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig { ReleaseNotesTreeView = true });
+
+        var cut = RenderWithProvider<TestPage>();
+
+        Assert.Contains("Load", cut.Markup);
+    }
+
+    [Fact]
+    public void ReleaseNotes_Uses_Autocomplete_By_Default()
+    {
+        SetupServices(includeApi: true);
+
+        var cut = RenderWithProvider<TestPage>();
+
+        Assert.Contains("Work Items", cut.Markup);
     }
 
     private class TestPage : ReleaseNotes

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -15,6 +15,7 @@ public class DevOpsConfigServiceTests
             Project = "Proj",
             PatToken = "Token",
             DarkMode = true,
+            ReleaseNotesTreeView = true,
             DefinitionOfReady = "DOR",
             DefaultStates = "Resolved",
             Rules = new ValidationRules { EpicHasDescription = true }
@@ -29,6 +30,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Proj", stored.Project);
         Assert.Equal("Token", stored.PatToken);
         Assert.True(stored.DarkMode);
+        Assert.True(stored.ReleaseNotesTreeView);
         Assert.Equal("DOR", stored.DefinitionOfReady);
         Assert.Equal("Resolved", stored.DefaultStates);
         Assert.True(stored.Rules.EpicHasDescription);
@@ -44,6 +46,7 @@ public class DevOpsConfigServiceTests
             Project = "Proj",
             PatToken = "Token",
             DarkMode = true,
+            ReleaseNotesTreeView = true,
             DefinitionOfReady = "DOR",
             DefaultStates = "Active",
             Rules = new ValidationRules { EpicHasDescription = true }
@@ -57,6 +60,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Proj", service.Config.Project);
         Assert.Equal("Token", service.Config.PatToken);
         Assert.True(service.Config.DarkMode);
+        Assert.True(service.Config.ReleaseNotesTreeView);
         Assert.Equal("DOR", service.Config.DefinitionOfReady);
         Assert.Equal("Active", service.Config.DefaultStates);
         Assert.True(service.Config.Rules.EpicHasDescription);
@@ -74,6 +78,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.Project);
         Assert.Equal(string.Empty, service.Config.PatToken);
         Assert.False(service.Config.DarkMode);
+        Assert.False(service.Config.ReleaseNotesTreeView);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.NotNull(service.Config.Rules);
     }
@@ -89,6 +94,7 @@ public class DevOpsConfigServiceTests
 
         Assert.Equal(string.Empty, service.Config.Organization);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
+        Assert.False(service.Config.ReleaseNotesTreeView);
         Assert.False(await storage.ContainKeyAsync("devops-config"));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -11,6 +11,7 @@
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
                     <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
+                    <MudSwitch T="bool" @bind-Value="_model.ReleaseNotesTreeView" Color="Color.Primary" Label="Release Notes Tree View"/>
                 </MudStack>
             </MudTabPanel>
             <MudTabPanel Text="Story Quality">
@@ -64,6 +65,7 @@
             MainBranch = cfg.MainBranch,
             DefaultStates = cfg.DefaultStates,
             DarkMode = cfg.DarkMode,
+            ReleaseNotesTreeView = cfg.ReleaseNotesTreeView,
             DefinitionOfReady = cfg.DefinitionOfReady,
             Rules = new ValidationRules
             {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -2,8 +2,10 @@
 @using System.Text
 @using System.Text.Json
 @using DevOpsAssistant.Services
+@using MudBlazor
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
+@inject DevOpsConfigService ConfigService
 
 <PageTitle>DevOpsAssistant - Release Notes</PageTitle>
 
@@ -19,15 +21,45 @@
 
 <MudPaper Class="p-4 mb-4">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
-        <MudAutocomplete T="WorkItemInfo"
-                         Label="Work Items"
-                         SearchFunc="SearchItems"
-                         ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
-                         Value="_searchValue"
-                         ValueChanged="OnItemSelected"/>
+        @if (ConfigService.Config.ReleaseNotesTreeView)
+        {
+            <MudSelect T="string" @bind-Value="_path" Label="Backlog">
+                @foreach (var b in _backlogs)
+                {
+                    <MudSelectItem Value="@b">@b</MudSelectItem>
+                }
+            </MudSelect>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Load">Load</MudButton>
+        }
+        else
+        {
+            <MudAutocomplete T="WorkItemInfo"
+                             Label="Work Items"
+                             SearchFunc="SearchItems"
+                             ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
+                             Value="_searchValue"
+                             ValueChanged="OnItemSelected"/>
+        }
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
     </MudStack>
 </MudPaper>
+
+@if (ConfigService.Config.ReleaseNotesTreeView && _treeItems != null)
+{
+    <MudTreeView T="WorkItemNode"
+                 Items="@_treeItems"
+                 SelectionMode="SelectionMode.MultiSelection"
+                 SelectedValues="@_selectedNodes"
+                 SelectedValuesChanged="OnNodesSelected"
+                 Style="max-height:300px; overflow:auto; width:100%;">
+        <ItemTemplate>
+            <MudTreeViewItem Items="@context.Children"
+                             Value="@context.Value"
+                             Text="@($"{context.Value!.Info.Id} - {context.Value!.Info.Title}")"
+                             @bind-Expanded="@context.Expanded" />
+        </ItemTemplate>
+    </MudTreeView>
+}
 
 @if (_selectedItems.Any())
 {
@@ -78,6 +110,57 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     private bool _loading;
     private string? _prompt;
     private string? _error;
+    private string _path = string.Empty;
+    private string[] _backlogs = [];
+    private List<TreeItemData<WorkItemNode>>? _treeItems;
+    private IReadOnlyCollection<WorkItemNode>? _selectedNodes;
+
+    protected override async Task OnInitializedAsync()
+    {
+        if (ConfigService.Config.ReleaseNotesTreeView)
+        {
+            try
+            {
+                _backlogs = await ApiService.GetBacklogsAsync();
+                if (_backlogs.Length > 0)
+                    _path = _backlogs[0];
+                _error = null;
+            }
+            catch (Exception ex)
+            {
+                _error = ex.Message;
+            }
+        }
+    }
+
+    private async Task Load()
+    {
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            var roots = await ApiService.GetWorkItemHierarchyAsync(_path);
+            _treeItems = roots.Select(BuildTreeItem).ToList();
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private Task OnNodesSelected(IReadOnlyCollection<WorkItemNode> nodes)
+    {
+        _selectedNodes = nodes;
+        _selectedItems.Clear();
+        foreach (var n in nodes)
+            _selectedItems.Add(n.Info);
+        return Task.CompletedTask;
+    }
 
     private async Task<IEnumerable<WorkItemInfo>> SearchItems(string value, CancellationToken _)
     {
@@ -130,6 +213,18 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             _loading = false;
         }
+    }
+
+    private static TreeItemData<WorkItemNode> BuildTreeItem(WorkItemNode node)
+    {
+        var item = new TreeItemData<WorkItemNode>
+        {
+            Value = node,
+            Text = $"{node.Info.Id} - {node.Info.Title}"
+        };
+        if (node.Children.Count > 0)
+            item.Children = node.Children.Select(BuildTreeItem).ToList();
+        return item;
     }
 
     private async Task CopyPrompt()

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -7,6 +7,7 @@ public class DevOpsConfig
     public string PatToken { get; set; } = string.Empty;
     public string MainBranch { get; set; } = string.Empty;
     public bool DarkMode { get; set; }
+    public bool ReleaseNotesTreeView { get; set; }
     public string DefaultStates { get; set; } = string.Empty;
     public string DefinitionOfReady { get; set; } = string.Empty;
     public ValidationRules Rules { get; set; } = new();


### PR DESCRIPTION
## Summary
- allow choosing Release Notes Tree View in settings
- implement tree view selection of work items on release notes page
- save ReleaseNotesTreeView in configuration
- test configuration persistence and new UI

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68501aa59530832884f164557e4aad53