### PR TITLE
Fix config service trimming bug

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -37,6 +37,7 @@ public class DevOpsConfigService
             PatToken = config.PatToken.Trim(),
             MainBranch = config.MainBranch.Trim(),
             DarkMode = config.DarkMode,
+            ReleaseNotesTreeView = config.ReleaseNotesTreeView,
             DefaultStates = config.DefaultStates.Trim(),
             DefinitionOfReady = config.DefinitionOfReady.Trim(),
             Rules = config.Rules


### PR DESCRIPTION
## Summary
- ensure `ReleaseNotesTreeView` property is persisted in `DevOpsConfigService`

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6850231c47b08328beceecbbd738501c