### PR TITLE
Implement clipboard and tree view tweaks

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -61,7 +61,7 @@
     </MudTreeView>
 }
 
-@if (_selectedItems.Any())
+@if (_selectedItems.Any() && !ConfigService.Config.ReleaseNotesTreeView)
 {
     <MudTable Items="_selectedItems" Dense="true" Class="mb-4">
         <HeaderContent>
@@ -204,6 +204,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
             _prompt = BuildPrompt(details);
             _error = null;
+            await CopyPrompt();
         }
         catch (Exception ex)
         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -142,6 +142,7 @@
             }
             _prompt = BuildPrompt(pages);
             _error = null;
+            await CopyPrompt();
             await (_stepper?.NextStepAsync() ?? Task.CompletedTask);
         }
         catch (Exception ex)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -90,6 +90,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             var items = await ApiService.GetStoriesAsync(_path, SelectedStates);
             _prompt = BuildPrompt(items, ConfigService.Config.DefinitionOfReady);
             _error = null;
+            await CopyPrompt();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- hide the selected items list when Release Notes uses tree view
- automatically copy prompts to the clipboard after generation

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685029f993d883288a0118c0b6114a64