### PR TITLE
Remove GB prefix from base branch

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -587,7 +587,7 @@ public class DevOpsApiServiceTests
         Assert.NotNull(captured);
         Assert.Equal(HttpMethod.Get, captured!.Method);
         Assert.NotNull(captured.RequestUri);
-        Assert.Equal("https://dev.azure.com/Org/Proj/_apis/git/repositories/1/stats/branches?api-version=7.1&baseVersion=GBmain", captured.RequestUri.ToString());
+        Assert.Equal("https://dev.azure.com/Org/Proj/_apis/git/repositories/1/stats/branches?api-version=7.1&baseVersion=main", captured.RequestUri.ToString());
         Assert.Single(results);
         Assert.Equal("feature", results[0].Name);
         Assert.Equal(new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc), results[0].CommitDate);

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -849,7 +849,7 @@ public class DevOpsApiService
         var url = $"{ApiBaseUrl}/{config.Organization}/{config.Project}/_apis/git/repositories/{repositoryId}/stats/branches?api-version=7.1";
         var branch = baseBranch?.Trim();
         if (!string.IsNullOrWhiteSpace(branch))
-            url += "&baseVersion=GB" + Uri.EscapeDataString(branch);
+            url += "&baseVersion=" + Uri.EscapeDataString(branch);
         var result = await GetJsonAsync<BranchStatsResult>(url);
         return result?.Value.Select(b => new BranchInfo
         {


### PR DESCRIPTION
## Summary
- update `GetBranchesAsync` to omit `GB` prefix when requesting a base branch
- adjust expected API URL in DevOpsApiServiceTests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68502f06b350832888d4870abc2622b5