### PR TITLE
Improve warning displays

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -71,9 +71,17 @@ else if (_results != null)
                 @foreach (var r in _results)
                 {
                     <MudListItem T="ResultItem">
-                        <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType (@r.Info.State)
-                        <br/>
-                        <span class="text-secondary">@string.Join(", ", r.Violations)</span>
+                        <MudStack Spacing="1">
+                            <MudText>
+                                <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType (@r.Info.State)
+                            </MudText>
+                            <ul class="work-item-violations">
+                                @foreach (var v in r.Violations)
+                                {
+                                    <li>@v</li>
+                                }
+                            </ul>
+                        </MudStack>
                     </MudListItem>
                 }
             </MudList>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -124,9 +124,17 @@ else if (_roots != null)
         {
             if (!node.StatusValid)
             {
-                builder.OpenComponent<MudIcon>(0);
-                builder.AddAttribute(1, "Color", Color.Warning);
-                builder.AddAttribute(2, "Icon", Icons.Material.Filled.Warning);
+                builder.OpenComponent<MudTooltip>(0);
+                builder.AddAttribute(1, "Text",
+                    $"Expected state: {node.ExpectedState}");
+                builder.AddAttribute(2, "ChildContent",
+                    (RenderFragment)(b =>
+                    {
+                        b.OpenComponent<MudIcon>(0);
+                        b.AddAttribute(1, "Color", Color.Warning);
+                        b.AddAttribute(2, "Icon", Icons.Material.Filled.Warning);
+                        b.CloseComponent();
+                    }));
                 builder.CloseComponent();
             }
         };

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -128,6 +128,13 @@ code {
     padding-left: 4px;
 }
 
+.work-item-violations {
+    list-style-type: disc;
+    margin: 0.25rem 0 0 1.5rem;
+    padding-left: 0;
+    color: var(--mud-palette-text-secondary, #6c757d);
+}
+
 /* layout */
 html, body { height: 100%; }
 #app { min-height: 100%; display: flex; flex-direction: column; }


### PR DESCRIPTION
## Summary
- add tooltip to state warning icon
- list validation violations clearly
- style work item warnings

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet restore DevOpsAssistant.sln`
- `dotnet test DevOpsAssistant.sln`
- `dotnet build DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685042203f488328ad81139772be0ec8