### PR TITLE
Add option to filter epics by issues

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
@@ -29,6 +29,29 @@ public class WorkItemsPageTests : ComponentTestBase
         Assert.NotNull(button);
     }
 
+    [Fact]
+    public void IssuesOnly_Hides_Epics_Without_Issues()
+    {
+        SetupServices(includeApi: true);
+
+        var cut = RenderWithProvider<IssuesOnlyWorkItems>();
+
+        Assert.Contains("Epic 1", cut.Markup);
+        Assert.Contains("Feature OK", cut.Markup);
+        Assert.DoesNotContain("Epic 2", cut.Markup);
+    }
+
+    [Fact]
+    public void IssuesOnly_Disabled_Shows_All_Epics()
+    {
+        SetupServices(includeApi: true);
+
+        var cut = RenderWithProvider<IssuesOnlyDisabledWorkItems>();
+
+        Assert.Contains("Epic 1", cut.Markup);
+        Assert.Contains("Epic 2", cut.Markup);
+    }
+
     private class TestWorkItems : WorkItems
     {
         protected override Task OnInitializedAsync()
@@ -55,6 +78,54 @@ public class WorkItemsPageTests : ComponentTestBase
             var rootsField = typeof(WorkItems).GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
             rootsField.SetValue(this, new List<WorkItemNode> { root });
 
+            return Task.CompletedTask;
+        }
+    }
+
+    private class IssuesOnlyWorkItems : WorkItems
+    {
+        protected override Task OnInitializedAsync()
+        {
+            var epic1 = new WorkItemNode
+            {
+                Info = new WorkItemInfo { Id = 1, Title = "Epic 1", State = "New", WorkItemType = "Epic" },
+                StatusValid = true
+            };
+            epic1.Children.Add(new WorkItemNode
+            {
+                Info = new WorkItemInfo { Id = 2, Title = "Feature OK", State = "New", WorkItemType = "Feature" },
+                StatusValid = true
+            });
+            epic1.Children.Add(new WorkItemNode
+            {
+                Info = new WorkItemInfo { Id = 3, Title = "Feature Issue", State = "New", WorkItemType = "Feature" },
+                StatusValid = false
+            });
+
+            var epic2 = new WorkItemNode
+            {
+                Info = new WorkItemInfo { Id = 4, Title = "Epic 2", State = "New", WorkItemType = "Epic" },
+                StatusValid = true
+            };
+
+            var backlogsField = typeof(WorkItems).GetField("_backlogs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            backlogsField.SetValue(this, new[] { "Area" });
+            var pathField = typeof(WorkItems).GetField("_path", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            pathField.SetValue(this, "Area");
+            var rootsField = typeof(WorkItems).GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            rootsField.SetValue(this, new List<WorkItemNode> { epic1, epic2 });
+
+            return Task.CompletedTask;
+        }
+    }
+
+    private class IssuesOnlyDisabledWorkItems : IssuesOnlyWorkItems
+    {
+        protected override Task OnInitializedAsync()
+        {
+            base.OnInitializedAsync();
+            var field = typeof(WorkItems).GetField("_issuesOnly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            field.SetValue(this, false);
             return Task.CompletedTask;
         }
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -32,12 +32,13 @@
 }
 else if (_roots != null)
 {
-    <MudStack Row="true" Spacing="2" Class="mb-2">
+    <MudStack Row="true" Spacing="2" Class="mb-2" AlignItems="AlignItems.Center">
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="UpdateAll" Disabled="@(!HasPendingUpdates)">Update All</MudButton>
+        <MudSwitch T="bool" @bind-Value="_issuesOnly" Color="Color.Primary" Label="Show only items with issues" Class="ms-2" />
     </MudStack>
     <MudPaper Class="work-item-container">
         <MudList T="WorkItemNode" Dense="true" Class="work-item-tree">
-            @foreach (var epic in _roots)
+            @foreach (var epic in DisplayRoots)
             {
                 <MudListItem T="WorkItemNode">
                     <MudLink Href="@epic.Info.Url" Class="@WorkItemHelpers.GetItemClass(epic.Info.WorkItemType)" Target="_blank">
@@ -82,6 +83,14 @@ else if (_roots != null)
     private bool _loading;
     private List<WorkItemNode>? _roots;
     private string? _error;
+    private bool _issuesOnly = true;
+
+    private IEnumerable<WorkItemNode> DisplayRoots =>
+        _roots == null
+            ? Enumerable.Empty<WorkItemNode>()
+            : _issuesOnly
+                ? _roots.Where(HasIssue)
+                : _roots;
 
     protected override async Task OnInitializedAsync()
     {
@@ -223,6 +232,16 @@ else if (_roots != null)
         foreach (var child in node.Children)
             foreach (var c in EnumerateNodes(child))
                 yield return c;
+    }
+
+    private static bool HasIssue(WorkItemNode node)
+    {
+        if (!node.StatusValid)
+            return true;
+        foreach (var child in node.Children)
+            if (HasIssue(child))
+                return true;
+        return false;
     }
 
     private WorkItemNode? FindRoot(WorkItemNode node)


### PR DESCRIPTION
## Summary
- add toggle to show only items with issues on Epics/Features page
- implement filtering logic in `WorkItems.razor`
- test new option in `WorkItemsPageTests`

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68511c3cdb508328ac0f45d64389d9ac