### PR TITLE
Add subtle highlight for incorrect item state

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
@@ -30,6 +30,17 @@ public class WorkItemsPageTests : ComponentTestBase
     }
 
     [Fact]
+    public void Invalid_Items_Are_Highlighted()
+    {
+        SetupServices(includeApi: true);
+
+        var cut = RenderWithProvider<LoadedWorkItems>();
+
+        var invalid = cut.FindAll(".work-item-invalid-state");
+        Assert.NotEmpty(invalid);
+    }
+
+    [Fact]
     public void IssuesOnly_Hides_Epics_Without_Issues()
     {
         SetupServices(includeApi: true);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -40,7 +40,7 @@ else if (_roots != null)
         <MudList T="WorkItemNode" Dense="true" Class="work-item-tree">
             @foreach (var epic in DisplayRoots)
             {
-                <MudListItem T="WorkItemNode">
+                <MudListItem T="WorkItemNode" Class="@InvalidClass(epic)">
                     <MudLink Href="@epic.Info.Url" Class="@WorkItemHelpers.GetItemClass(epic.Info.WorkItemType)" Target="_blank">
                         <b>@epic.Info.Title</b>
                     </MudLink> - @epic.Info.WorkItemType (@epic.Info.State)
@@ -50,7 +50,7 @@ else if (_roots != null)
                         <MudList T="WorkItemNode" Dense="true" Class="ms-4">
                             @foreach (var feature in epic.Children)
                             {
-                                <MudListItem T="WorkItemNode">
+                                <MudListItem T="WorkItemNode" Class="@InvalidClass(feature)">
                                     <MudLink Href="@feature.Info.Url" Class="@WorkItemHelpers.GetItemClass(feature.Info.WorkItemType)" Target="_blank">
                                         <b>@feature.Info.Title</b>
                                     </MudLink> - @feature.Info.WorkItemType (@feature.Info.State)
@@ -60,7 +60,7 @@ else if (_roots != null)
                                         <MudList T="WorkItemNode" Dense="true" Class="ms-4">
                                             @foreach (var item in feature.Children)
                                             {
-                                                <MudListItem T="WorkItemNode">
+                                                <MudListItem T="WorkItemNode" Class="@InvalidClass(item)">
                                                     <MudLink Href="@item.Info.Url" Class="@WorkItemHelpers.GetItemClass(item.Info.WorkItemType)" Target="_blank">@item.Info.Title</MudLink> - @item.Info.WorkItemType (@item.Info.State)
                                                     @SuggestedState(item)
                                                 </MudListItem>
@@ -215,6 +215,11 @@ else if (_roots != null)
     }
 
     private bool HasPendingUpdates => _roots != null && EnumerateNodes(_roots).Any(n => !n.StatusValid);
+
+    private static string? InvalidClass(WorkItemNode node)
+    {
+        return node.StatusValid ? null : "work-item-invalid-state";
+    }
 
     private static IEnumerable<WorkItemNode> EnumerateNodes(IEnumerable<WorkItemNode> nodes)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -128,6 +128,10 @@ code {
     padding-left: 4px;
 }
 
+.work-item-invalid-state {
+    background-color: #fff8e1;
+}
+
 .work-item-violations {
     list-style-type: disc;
     margin: 0.25rem 0 0 1.5rem;


### PR DESCRIPTION
## Summary
- mark work items with mismatched states via CSS class
- style highlighted items with a light yellow background
- test that invalid items are highlighted in the UI

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -v minimal`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_685137f8eae083289bbf65f46cc23c51