### PR TITLE
Implement item type filter and config options

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -12,7 +12,21 @@ public class SettingsDialogTests : ComponentTestBase
     public async Task SettingsDialog_Shows_Config_Values()
     {
         var config = SetupServices();
-        await config.SaveAsync(new DevOpsConfig { Organization = "Org", MainBranch = "main", DefaultStates = "Active", ReleaseNotesTreeView = true });
+        await config.SaveAsync(new DevOpsConfig
+        {
+            Organization = "Org",
+            MainBranch = "main",
+            DefaultStates = "Active",
+            ReleaseNotesTreeView = true,
+            Rules = new ValidationRules
+            {
+                Bug = new BugRules
+                {
+                    IncludeReproSteps = false,
+                    IncludeSystemInfo = false
+                }
+            }
+        });
 
         var cut = RenderComponent<SettingsDialog>();
         var modelField = cut.Instance.GetType().GetField("_model", BindingFlags.NonPublic | BindingFlags.Instance)!;
@@ -22,5 +36,7 @@ public class SettingsDialogTests : ComponentTestBase
         Assert.Equal("main", model.MainBranch);
         Assert.Equal("Active", model.DefaultStates);
         Assert.True(model.ReleaseNotesTreeView);
+        Assert.False(model.Rules.Bug.IncludeReproSteps);
+        Assert.False(model.Rules.Bug.IncludeSystemInfo);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
@@ -53,7 +53,7 @@ public class ValidationPageTests : ComponentTestBase
         var config = SetupServices(includeApi: true);
         await config.SaveAsync(new DevOpsConfig
         {
-            Rules = new ValidationRules { StoryHasDescription = true }
+            Rules = new ValidationRules { Story = new StoryRules { HasDescription = true } }
         });
 
         var cut = RenderWithProvider<TestPage>();

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -13,11 +13,11 @@ public class DevOpsApiServiceTests
         return (string)method.Invoke(null, [area])!;
     }
 
-    private static string InvokeBuildValidationWiql(string area, IEnumerable<string> states)
+    private static string InvokeBuildValidationWiql(string area, IEnumerable<string> states, IEnumerable<string> types)
     {
         var method =
             typeof(DevOpsApiService).GetMethod("BuildValidationWiql", BindingFlags.NonPublic | BindingFlags.Static)!;
-        return (string)method.Invoke(null, [area, states])!;
+        return (string)method.Invoke(null, [area, states, types])!;
     }
 
 
@@ -110,7 +110,7 @@ public class DevOpsApiServiceTests
     [Fact]
     public void BuildValidationWiql_Selects_Epic_Feature_Story()
     {
-        var query = InvokeBuildValidationWiql("Area", ["New", "Active"]);
+        var query = InvokeBuildValidationWiql("Area", ["New", "Active"], ["Epic", "Feature", "User Story"]);
 
         Assert.Contains("'Epic'", query);
         Assert.Contains("'Feature'", query);
@@ -198,7 +198,7 @@ public class DevOpsApiServiceTests
         var configService = new DevOpsConfigService(new FakeLocalStorageService());
         var service = new DevOpsApiService(new HttpClient(), configService, new DeploymentConfigService(new HttpClient()));
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetValidationItemsAsync("Area", new[] { "New" }));
+        await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetValidationItemsAsync("Area", new[] { "New" }, ["User Story"]));
     }
 
     [Theory]
@@ -303,7 +303,7 @@ public class DevOpsApiServiceTests
         await configService.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
         var service = new DevOpsApiService(client, configService, new DeploymentConfigService(new HttpClient()));
 
-        var result = await service.GetValidationItemsAsync("Area", new[] { "New" });
+        var result = await service.GetValidationItemsAsync("Area", new[] { "New" }, ["User Story"]);
 
         Assert.Single(result);
         Assert.Equal(1, result[0].Info.Id);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -19,7 +19,15 @@ public class DevOpsConfigServiceTests
             DefinitionOfReady = "DOR",
             DefaultStates = "Resolved",
             MainBranch = " main ",
-            Rules = new ValidationRules { EpicHasDescription = true }
+            Rules = new ValidationRules
+            {
+                Epic = new EpicRules { HasDescription = true },
+                Bug = new BugRules
+                {
+                    IncludeReproSteps = false,
+                    IncludeSystemInfo = false
+                }
+            }
         };
 
         await service.SaveAsync(config);
@@ -32,10 +40,12 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Token", stored.PatToken);
         Assert.True(stored.DarkMode);
         Assert.True(stored.ReleaseNotesTreeView);
+        Assert.False(stored.Rules.Bug.IncludeReproSteps);
+        Assert.False(stored.Rules.Bug.IncludeSystemInfo);
         Assert.Equal("DOR", stored.DefinitionOfReady);
         Assert.Equal("Resolved", stored.DefaultStates);
         Assert.Equal("main", stored.MainBranch);
-        Assert.True(stored.Rules.EpicHasDescription);
+        Assert.True(stored.Rules.Epic.HasDescription);
     }
 
     [Fact]
@@ -51,7 +61,15 @@ public class DevOpsConfigServiceTests
             ReleaseNotesTreeView = true,
             DefinitionOfReady = "DOR",
             DefaultStates = "Active",
-            Rules = new ValidationRules { EpicHasDescription = true }
+            Rules = new ValidationRules
+            {
+                Epic = new EpicRules { HasDescription = true },
+                Bug = new BugRules
+                {
+                    IncludeReproSteps = false,
+                    IncludeSystemInfo = false
+                }
+            }
         };
         await storage.SetItemAsync("devops-config", stored);
         var service = new DevOpsConfigService(storage);
@@ -63,9 +81,11 @@ public class DevOpsConfigServiceTests
         Assert.Equal("Token", service.Config.PatToken);
         Assert.True(service.Config.DarkMode);
         Assert.True(service.Config.ReleaseNotesTreeView);
+        Assert.False(service.Config.Rules.Bug.IncludeReproSteps);
+        Assert.False(service.Config.Rules.Bug.IncludeSystemInfo);
         Assert.Equal("DOR", service.Config.DefinitionOfReady);
         Assert.Equal("Active", service.Config.DefaultStates);
-        Assert.True(service.Config.Rules.EpicHasDescription);
+        Assert.True(service.Config.Rules.Epic.HasDescription);
     }
 
     [Fact]
@@ -108,6 +128,8 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.PatToken);
         Assert.False(service.Config.DarkMode);
         Assert.False(service.Config.ReleaseNotesTreeView);
+        Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
+        Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.NotNull(service.Config.Rules);
     }
@@ -124,6 +146,8 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.Organization);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.False(service.Config.ReleaseNotesTreeView);
+        Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
+        Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
         Assert.False(await storage.ContainKeyAsync("devops-config"));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -22,22 +22,28 @@
             <MudTabPanel Text="Validation Rules">
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.h6" Class="mt-2">Epic</MudText>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.EpicHasDescription" Label="Has description"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Epic.HasDescription" Label="Has description"/>
 
                     <MudDivider Class="my-2"/>
 
                     <MudText Typo="Typo.h6" Class="mt-2">Feature</MudText>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.FeatureHasDescription" Label="Has description"/>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.FeatureHasParent" Label="Has parent"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Feature.HasDescription" Label="Has description"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Feature.HasParent" Label="Has parent"/>
 
                     <MudDivider Class="my-2"/>
 
                     <MudText Typo="Typo.h6" Class="mt-2">User Story</MudText>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.StoryHasDescription" Label="Has description"/>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.StoryHasParent" Label="Has parent"/>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.StoryHasStoryPoints" Label="Has story points"/>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.StoryHasAcceptanceCriteria" Label="Has acceptance criteria"/>
-                    <MudSwitch T="bool" @bind-Value="_model.Rules.StoryHasAssignee" Label="Has assignee"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Story.HasDescription" Label="Has description"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Story.HasParent" Label="Has parent"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Story.HasStoryPoints" Label="Has story points"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Story.HasAcceptanceCriteria" Label="Has acceptance criteria"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Story.HasAssignee" Label="Has assignee"/>
+
+                    <MudDivider Class="my-2"/>
+
+                    <MudText Typo="Typo.h6" Class="mt-2">Bug</MudText>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Bug.IncludeReproSteps" Color="Color.Primary" Label="Include Repro Steps"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Bug.IncludeSystemInfo" Color="Color.Primary" Label="Include System Info"/>
                 </MudStack>
             </MudTabPanel>
         </MudTabs>
@@ -69,14 +75,25 @@
             DefinitionOfReady = cfg.DefinitionOfReady,
             Rules = new ValidationRules
             {
-                EpicHasDescription = cfg.Rules.EpicHasDescription,
-                FeatureHasDescription = cfg.Rules.FeatureHasDescription,
-                FeatureHasParent = cfg.Rules.FeatureHasParent,
-                StoryHasDescription = cfg.Rules.StoryHasDescription,
-                StoryHasParent = cfg.Rules.StoryHasParent,
-                StoryHasStoryPoints = cfg.Rules.StoryHasStoryPoints,
-                StoryHasAcceptanceCriteria = cfg.Rules.StoryHasAcceptanceCriteria,
-                StoryHasAssignee = cfg.Rules.StoryHasAssignee
+                Epic = new EpicRules { HasDescription = cfg.Rules.Epic.HasDescription },
+                Feature = new FeatureRules
+                {
+                    HasDescription = cfg.Rules.Feature.HasDescription,
+                    HasParent = cfg.Rules.Feature.HasParent
+                },
+                Story = new StoryRules
+                {
+                    HasDescription = cfg.Rules.Story.HasDescription,
+                    HasParent = cfg.Rules.Story.HasParent,
+                    HasStoryPoints = cfg.Rules.Story.HasStoryPoints,
+                    HasAcceptanceCriteria = cfg.Rules.Story.HasAcceptanceCriteria,
+                    HasAssignee = cfg.Rules.Story.HasAssignee
+                },
+                Bug = new BugRules
+                {
+                    IncludeReproSteps = cfg.Rules.Bug.IncludeReproSteps,
+                    IncludeSystemInfo = cfg.Rules.Bug.IncludeSystemInfo
+                }
             }
         };
         StateHasChanged();

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -1,6 +1,7 @@
 @page "/release-notes"
 @using System.Text
 @using System.Text.Json
+@using System.Text.Json.Serialization
 @using DevOpsAssistant.Services
 @using MudBlazor
 @inject DevOpsApiService ApiService
@@ -202,7 +203,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             var ids = _selectedItems.Select(s => s.Id);
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
-            _prompt = BuildPrompt(details);
+            _prompt = BuildPrompt(details, ConfigService.Config);
             _error = null;
             await CopyPrompt();
         }
@@ -234,7 +235,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
     }
 
-    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details)
+    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
     {
         var hierarchy = details.Select(d => new
         {
@@ -260,15 +261,19 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
                 d.Story.Title,
                 d.Story.WorkItemType,
                 Description = TextHelpers.Sanitize(d.Description),
-                ReproSteps = TextHelpers.Sanitize(d.ReproSteps),
-                SystemInfo = TextHelpers.Sanitize(d.SystemInfo),
+                ReproSteps = config.Rules.Bug.IncludeReproSteps ? TextHelpers.Sanitize(d.ReproSteps) : null,
+                SystemInfo = config.Rules.Bug.IncludeSystemInfo ? TextHelpers.Sanitize(d.SystemInfo) : null,
                 AcceptanceCriteria = TextHelpers.Sanitize(d.AcceptanceCriteria)
             }
         });
 
         var json = JsonSerializer.Serialize(
             hierarchy,
-            new JsonSerializerOptions { WriteIndented = true });
+            new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            });
 
         var sb = new StringBuilder();
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -60,6 +60,12 @@ else
                 <MudSelectItem Value="@s">@s</MudSelectItem>
             }
         </MudSelect>
+        <MudSelect T="string" MultiSelection="true" SelectedValues="SelectedTypes" SelectedValuesChanged="@(vals => OnTypesChanged(vals))" Label="Types">
+            @foreach (var t in _types)
+            {
+                <MudSelectItem Value="@t">@t</MudSelectItem>
+            }
+        </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load" Disabled="!_hasRules">Check</MudButton>
     </MudStack>
 </MudPaper>
@@ -103,7 +109,9 @@ else if (_results != null)
     private string _path = string.Empty;
     private string[] _backlogs = [];
     private string[] _states = [];
+    private readonly string[] _types = ["Epic", "Feature", "User Story", "Bug"];
     private HashSet<string> SelectedStates { get; set; } = new();
+    private HashSet<string> SelectedTypes { get; set; } = new();
     private bool _loading;
     private bool _hasRules;
     private string[] _activeRules = [];
@@ -125,6 +133,7 @@ else if (_results != null)
                             s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
                             extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
                 .ToHashSet();
+            SelectedTypes = _types.ToHashSet();
             _error = null;
         }
         catch (Exception ex)
@@ -142,7 +151,7 @@ else if (_results != null)
         StateHasChanged();
         try
         {
-            var items = await ApiService.GetValidationItemsAsync(_path, SelectedStates);
+            var items = await ApiService.GetValidationItemsAsync(_path, SelectedStates, SelectedTypes);
             _results = Validate(items);
             _error = null;
         }
@@ -165,20 +174,25 @@ else if (_results != null)
             List<string> v = [];
             if (item.Info.WorkItemType.Equals("Epic", StringComparison.OrdinalIgnoreCase))
             {
-                if (rules.EpicHasDescription && !item.HasDescription) v.Add("Missing description");
+                if (rules.Epic.HasDescription && !item.HasDescription) v.Add("Missing description");
             }
             else if (item.Info.WorkItemType.Equals("Feature", StringComparison.OrdinalIgnoreCase))
             {
-                if (rules.FeatureHasDescription && !item.HasDescription) v.Add("Missing description");
-                if (rules.FeatureHasParent && !item.HasParent) v.Add("Missing parent");
+                if (rules.Feature.HasDescription && !item.HasDescription) v.Add("Missing description");
+                if (rules.Feature.HasParent && !item.HasParent) v.Add("Missing parent");
             }
             else if (item.Info.WorkItemType.Equals("User Story", StringComparison.OrdinalIgnoreCase))
             {
-                if (rules.StoryHasDescription && !item.HasDescription) v.Add("Missing description");
-                if (rules.StoryHasParent && !item.HasParent) v.Add("Missing parent");
-                if (rules.StoryHasStoryPoints && !item.HasStoryPoints) v.Add("Missing story points");
-                if (rules.StoryHasAcceptanceCriteria && !item.HasAcceptanceCriteria) v.Add("Missing acceptance criteria");
-                if (rules.StoryHasAssignee && !item.HasAssignee) v.Add("Unassigned");
+                if (rules.Story.HasDescription && !item.HasDescription) v.Add("Missing description");
+                if (rules.Story.HasParent && !item.HasParent) v.Add("Missing parent");
+                if (rules.Story.HasStoryPoints && !item.HasStoryPoints) v.Add("Missing story points");
+                if (rules.Story.HasAcceptanceCriteria && !item.HasAcceptanceCriteria) v.Add("Missing acceptance criteria");
+                if (rules.Story.HasAssignee && !item.HasAssignee) v.Add("Unassigned");
+            }
+            else if (item.Info.WorkItemType.Equals("Bug", StringComparison.OrdinalIgnoreCase))
+            {
+                if (rules.Bug.IncludeReproSteps && !item.HasReproSteps) v.Add("Missing repro steps");
+                if (rules.Bug.IncludeSystemInfo && !item.HasSystemInfo) v.Add("Missing system info");
             }
 
             if (v.Count > 0)
@@ -194,18 +208,26 @@ else if (_results != null)
         return Task.CompletedTask;
     }
 
+    private Task OnTypesChanged(IEnumerable<string> values)
+    {
+        SelectedTypes = new HashSet<string>(values);
+        return Task.CompletedTask;
+    }
+
     private void ComputeRules()
     {
         var r = ConfigService.Config.Rules;
         List<string> list = [];
-        if (r.EpicHasDescription) list.Add("Epics must have a description");
-        if (r.FeatureHasDescription) list.Add("Features must have a description");
-        if (r.FeatureHasParent) list.Add("Features must have a parent");
-        if (r.StoryHasDescription) list.Add("Stories must have a description");
-        if (r.StoryHasParent) list.Add("Stories must have a parent");
-        if (r.StoryHasStoryPoints) list.Add("Stories must have story points");
-        if (r.StoryHasAcceptanceCriteria) list.Add("Stories must have acceptance criteria");
-        if (r.StoryHasAssignee) list.Add("Stories must have an assignee");
+        if (r.Epic.HasDescription) list.Add("Epics must have a description");
+        if (r.Feature.HasDescription) list.Add("Features must have a description");
+        if (r.Feature.HasParent) list.Add("Features must have a parent");
+        if (r.Story.HasDescription) list.Add("Stories must have a description");
+        if (r.Story.HasParent) list.Add("Stories must have a parent");
+        if (r.Story.HasStoryPoints) list.Add("Stories must have story points");
+        if (r.Story.HasAcceptanceCriteria) list.Add("Stories must have acceptance criteria");
+        if (r.Story.HasAssignee) list.Add("Stories must have an assignee");
+        if (r.Bug.IncludeReproSteps) list.Add("Bugs must have repro steps");
+        if (r.Bug.IncludeSystemInfo) list.Add("Bugs must have system info");
         _activeRules = list.ToArray();
         _hasRules = _activeRules.Length > 0;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public class BugRules
+{
+    public bool IncludeReproSteps { get; set; } = true;
+    public bool IncludeSystemInfo { get; set; } = true;
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/EpicRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/EpicRules.cs
@@ -1,0 +1,6 @@
+namespace DevOpsAssistant.Services;
+
+public class EpicRules
+{
+    public bool HasDescription { get; set; }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/FeatureRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/FeatureRules.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public class FeatureRules
+{
+    public bool HasDescription { get; set; }
+    public bool HasParent { get; set; }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryRules.cs
@@ -1,13 +1,10 @@
 namespace DevOpsAssistant.Services;
 
-public class WorkItemDetails
+public class StoryRules
 {
-    public WorkItemInfo Info { get; set; } = new();
     public bool HasDescription { get; set; }
     public bool HasParent { get; set; }
     public bool HasStoryPoints { get; set; }
     public bool HasAcceptanceCriteria { get; set; }
     public bool HasAssignee { get; set; }
-    public bool HasReproSteps { get; set; }
-    public bool HasSystemInfo { get; set; }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/ValidationRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/ValidationRules.cs
@@ -2,12 +2,8 @@ namespace DevOpsAssistant.Services;
 
 public class ValidationRules
 {
-    public bool EpicHasDescription { get; set; }
-    public bool FeatureHasDescription { get; set; }
-    public bool FeatureHasParent { get; set; }
-    public bool StoryHasDescription { get; set; }
-    public bool StoryHasParent { get; set; }
-    public bool StoryHasStoryPoints { get; set; }
-    public bool StoryHasAcceptanceCriteria { get; set; }
-    public bool StoryHasAssignee { get; set; }
+    public EpicRules Epic { get; set; } = new();
+    public FeatureRules Feature { get; set; } = new();
+    public StoryRules Story { get; set; } = new();
+    public BugRules Bug { get; set; } = new();
 }


### PR DESCRIPTION
## Summary
- add bug detail flags to validation rules instead of top-level config
- update settings UI to show switches under validation rules
- respect the new rule flags when generating release notes
- adjust unit tests for updated configuration structure
- add bug rules to validation checks
- nest the item type rules under Epic, Feature, and Story sections

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685140c044808328bfef45d5170db885