### PR TITLE
Handle existing Needs Attention tags

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -345,7 +345,7 @@ public class DevOpsApiServiceTests
     {
         var wiqlJson = "{\"workItems\":[{\"id\":1}]}";
         var itemsJson =
-            "{\"value\":[{\"id\":1,\"fields\":{\"System.Title\":\"Story\",\"System.State\":\"New\",\"System.WorkItemType\":\"User Story\"}}]}";
+            "{\"value\":[{\"id\":1,\"fields\":{\"System.Title\":\"Story\",\"System.State\":\"New\",\"System.WorkItemType\":\"User Story\",\"System.Tags\":\"Needs Attention;UI\"}}]}";
         var call = 0;
         var handler = new FakeHttpMessageHandler(_ =>
         {
@@ -366,6 +366,7 @@ public class DevOpsApiServiceTests
         Assert.Single(result);
         Assert.Equal(1, result[0].Info.Id);
         Assert.Equal("https://dev.azure.com/Org/Proj/_workitems/edit/1", result[0].Info.Url);
+        Assert.True(result[0].NeedsAttention);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -1,5 +1,6 @@
 @page "/validation"
 @using DevOpsAssistant.Components
+@using System
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
@@ -95,7 +96,11 @@ else if (_results != null)
                                 <MudText>
                                     <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType (@r.Info.State)
                                 </MudText>
-                                <MudButton Variant="Variant.Text" Size="Size.Small" Disabled="@_loading" OnClick="() => TagItem(r)">Tag</MudButton>
+                                <MudButton Variant="Variant.Text" Size="Size.Small" Disabled="@(_loading || r.NeedsAttention)" OnClick="() => TagItem(r)">Tag</MudButton>
+                                @if (r.NeedsAttention)
+                                {
+                                    <MudIcon Icon="@Icons.Material.Filled.Flag" Color="Color.Error" Class="ms-1" />
+                                }
                             </MudStack>
                             <ul class="work-item-violations">
                                 @foreach (var v in r.Violations)
@@ -202,7 +207,12 @@ else if (_results != null)
             }
 
             if (v.Count > 0)
-                list.Add(new ResultItem { Info = item.Info, Violations = v });
+                list.Add(new ResultItem
+                {
+                    Info = item.Info,
+                    Violations = v,
+                    NeedsAttention = item.NeedsAttention
+                });
         }
 
         return list;
@@ -259,9 +269,10 @@ else if (_results != null)
         try
         {
             await ApiService.AddTagAsync(item.Info.Id, "Needs Attention");
-            var comment = "Flagged as needing attention\n" +
-                string.Join("\n", item.Violations.Select(v => $"- {v}"));
+            var comment = "Flagged as needing attention<br/>" +
+                string.Join("<br/>", item.Violations.Select(v => $"- {v}"));
             await ApiService.AddCommentAsync(item.Info.Id, comment);
+            item.NeedsAttention = true;
             _error = null;
         }
         catch (Exception ex)
@@ -281,9 +292,10 @@ else if (_results != null)
             foreach (var r in _results)
             {
                 await ApiService.AddTagAsync(r.Info.Id, "Needs Attention");
-                var comment = "Flagged as needing attention\n" +
-                    string.Join("\n", r.Violations.Select(v => $"- {v}"));
+                var comment = "Flagged as needing attention<br/>" +
+                    string.Join("<br/>", r.Violations.Select(v => $"- {v}"));
                 await ApiService.AddCommentAsync(r.Info.Id, comment);
+                r.NeedsAttention = true;
             }
             _error = null;
         }
@@ -301,6 +313,7 @@ else if (_results != null)
     {
         public WorkItemInfo Info { get; set; } = new();
         public List<string> Violations { get; set; } = [];
+        public bool NeedsAttention { get; set; }
     }
 
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -309,7 +309,10 @@ public class DevOpsApiService
                 HasReproSteps = w.Fields.TryGetValue("Microsoft.VSTS.TCM.ReproSteps", out var rs) &&
                                  !string.IsNullOrWhiteSpace(rs.GetString()),
                 HasSystemInfo = w.Fields.TryGetValue("Microsoft.VSTS.TCM.SystemInfo", out var si) &&
-                                 !string.IsNullOrWhiteSpace(si.GetString())
+                                 !string.IsNullOrWhiteSpace(si.GetString()),
+                NeedsAttention = w.Fields.TryGetValue("System.Tags", out var tags) &&
+                                 (tags.GetString()?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                                      .Any(t => t.Equals("Needs Attention", StringComparison.OrdinalIgnoreCase)) ?? false)
             };
             list.Add(details);
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemDetails.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemDetails.cs
@@ -10,4 +10,5 @@ public class WorkItemDetails
     public bool HasAssignee { get; set; }
     public bool HasReproSteps { get; set; }
     public bool HasSystemInfo { get; set; }
+    public bool NeedsAttention { get; set; }
 }


### PR DESCRIPTION
## Summary
- check for `Needs Attention` tag while loading validation items
- disable the Tag button and show a red flag icon if already tagged
- preserve line breaks in validation comments
- mark stories as flagged after tagging
- test `NeedsAttention` flag
- use `<br/>` for line breaks in work item comments

## Testing
- `dotnet format --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68516364e93483288a7737772db582dd