### PR TITLE
Persist per-page state

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
@@ -1,0 +1,22 @@
+using DevOpsAssistant.Services;
+
+namespace DevOpsAssistant.Tests;
+
+public class PageStateServiceTests
+{
+    [Fact]
+    public async Task Save_And_Load_State()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new PageStateService(storage);
+        await service.SaveAsync("key", new TestState { Value = 1 });
+        var loaded = await service.LoadAsync<TestState>("key");
+        Assert.NotNull(loaded);
+        Assert.Equal(1, loaded!.Value);
+    }
+
+    private class TestState
+    {
+        public int Value { get; set; }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -20,6 +20,7 @@ public abstract class ComponentTestBase : TestContext
         JSInterop.Mode = JSRuntimeMode.Loose;
         var config = new DevOpsConfigService(new FakeLocalStorageService());
         Services.AddSingleton(config);
+        Services.AddSingleton(new PageStateService(new FakeLocalStorageService()));
         if (includeApi)
         {
             var deployment = new DeploymentConfigService(new HttpClient());

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
@@ -2,6 +2,7 @@
 @using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Branch Health</PageTitle>
 
@@ -24,6 +25,7 @@
         </MudSelect>
         <MudAutocomplete T="string" Label="Base Branch" @bind-Value="_baseBranch" SearchFunc="SearchBranches" Disabled="_repo == null" />
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_repo == null" OnClick="Load">Load</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -70,6 +72,7 @@ else if (_branches != null)
     private bool _loading;
     private string? _error;
     private bool ShowAheadBehind => !string.IsNullOrWhiteSpace(_baseBranch);
+    private const string StateKey = "branch-health";
 
     protected override async Task OnInitializedAsync()
     {
@@ -83,6 +86,15 @@ else if (_branches != null)
                 await LoadBranchList();
             }
             _baseBranch = ConfigService.Config.MainBranch;
+
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null)
+            {
+                _repo = _repos.FirstOrDefault(r => r.Id == state.RepoId) ?? _repo;
+                if (!string.IsNullOrWhiteSpace(state.BaseBranch))
+                    _baseBranch = state.BaseBranch;
+            }
+
             _error = null;
         }
         catch (Exception ex)
@@ -99,6 +111,11 @@ else if (_branches != null)
         try
         {
             _branches = await ApiService.GetBranchesAsync(_repo.Id, _baseBranch);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                RepoId = _repo.Id,
+                BaseBranch = _baseBranch
+            });
             _error = null;
         }
         catch (Exception ex)
@@ -144,5 +161,24 @@ else if (_branches != null)
     private static bool IsStale(BranchInfo branch)
     {
         return branch.CommitDate < DateTime.UtcNow.AddDays(-30);
+    }
+
+    private async Task Reset()
+    {
+        if (_repos.Count > 0)
+        {
+            _repo = _repos[0];
+            await LoadBranchList();
+        }
+        _baseBranch = ConfigService.Config.MainBranch;
+        _branches = null;
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
+    }
+
+    private class PageState
+    {
+        public string RepoId { get; set; } = string.Empty;
+        public string BaseBranch { get; set; } = string.Empty;
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -3,6 +3,7 @@
 @using DevOpsAssistant.Services
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Metrics</PageTitle>
 
@@ -35,6 +36,7 @@
         </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load">Load</MudButton>
         <MudButton Variant="Variant.Outlined" OnClick="ExportCsv">Export CSV</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -82,6 +84,7 @@ else if (_periods.Any())
     private List<ChartSeries> _leadCycleSeries = [];
     private List<ChartSeries> _barSeries = [];
     private string? _error;
+    private const string StateKey = "metrics";
 
     protected override async Task OnInitializedAsync()
     {
@@ -90,6 +93,17 @@ else if (_periods.Any())
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
+
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null)
+            {
+                if (!string.IsNullOrWhiteSpace(state.Path))
+                    _path = state.Path;
+                _mode = state.Mode;
+                _velocityMode = state.VelocityMode;
+                _startDate = state.StartDate;
+            }
+
             _error = null;
         }
         catch (Exception ex)
@@ -106,6 +120,13 @@ else if (_periods.Any())
         {
             var items = await ApiService.GetStoryMetricsAsync(_path, _startDate);
             ComputePeriods(items);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                Path = _path,
+                Mode = _mode,
+                VelocityMode = _velocityMode,
+                StartDate = _startDate
+            });
             _error = null;
         }
         catch (Exception ex)
@@ -178,6 +199,18 @@ else if (_periods.Any())
         await JS.InvokeVoidAsync("downloadCsv", "metrics.csv", csv);
     }
 
+    private async Task Reset()
+    {
+        if (_backlogs.Length > 0)
+            _path = _backlogs[0];
+        _mode = AggregateMode.Week;
+        _velocityMode = VelocityMode.StoryPoints;
+        _startDate = DateTime.Today.AddDays(-84);
+        _periods.Clear();
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
+    }
+
     private static DateTime StartOfWeek(DateTime dt)
     {
         int diff = (7 + (int)dt.DayOfWeek - (int)DayOfWeek.Monday) % 7;
@@ -192,5 +225,13 @@ else if (_periods.Any())
         public double AvgCycleTime { get; set; }
         public int Throughput { get; set; }
         public double Velocity { get; set; }
+    }
+
+    private class PageState
+    {
+        public string Path { get; set; } = string.Empty;
+        public AggregateMode Mode { get; set; }
+        public VelocityMode VelocityMode { get; set; }
+        public DateTime? StartDate { get; set; }
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -7,6 +7,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject DevOpsConfigService ConfigService
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Release Notes</PageTitle>
 
@@ -42,6 +43,7 @@
                              ValueChanged="OnItemSelected"/>
         }
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -115,6 +117,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     private string[] _backlogs = [];
     private List<TreeItemData<WorkItemNode>>? _treeItems;
     private IReadOnlyCollection<WorkItemNode>? _selectedNodes;
+    private const string StateKey = "release-notes";
 
     protected override async Task OnInitializedAsync()
     {
@@ -125,6 +128,10 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
                 _backlogs = await ApiService.GetBacklogsAsync();
                 if (_backlogs.Length > 0)
                     _path = _backlogs[0];
+
+                var state = await StateService.LoadAsync<PageState>(StateKey);
+                if (state != null && !string.IsNullOrWhiteSpace(state.Path))
+                    _path = state.Path;
                 _error = null;
             }
             catch (Exception ex)
@@ -142,6 +149,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             var roots = await ApiService.GetWorkItemHierarchyAsync(_path);
             _treeItems = roots.Select(BuildTreeItem).ToList();
+            await StateService.SaveAsync(StateKey, new PageState { Path = _path });
             _error = null;
         }
         catch (Exception ex)
@@ -233,6 +241,23 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
+    }
+
+    private async Task Reset()
+    {
+        if (ConfigService.Config.ReleaseNotesTreeView && _backlogs.Length > 0)
+            _path = _backlogs[0];
+        _selectedItems.Clear();
+        _treeItems = null;
+        _selectedNodes = null;
+        _prompt = null;
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
+    }
+
+    private class PageState
+    {
+        public string Path { get; set; } = string.Empty;
     }
 
     private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -5,6 +5,7 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
@@ -29,6 +30,7 @@
                 </MudTreeView>
             }
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_selectedPages == null || _selectedPages.Count == 0" OnClick="Generate">Generate Prompt</MudButton>
+            <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
         </MudStack>
     </MudStep>
     <MudStep Title="Import Response" Disabled="@string.IsNullOrWhiteSpace(_prompt)">
@@ -100,6 +102,7 @@
     private string[] _backlogs = [];
     private string _backlog = string.Empty;
     private Plan? _plan;
+    private const string StateKey = "requirements-planner";
 
     protected override async Task OnInitializedAsync()
     {
@@ -110,10 +113,20 @@
             if (_backlogs.Length > 0)
                 _backlog = _backlogs[0];
 
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null)
+            {
+                if (!string.IsNullOrWhiteSpace(state.Backlog))
+                    _backlog = state.Backlog;
+                if (!string.IsNullOrWhiteSpace(state.WikiId))
+                    _wikiId = state.WikiId;
+            }
+
             var wikis = await ApiService.GetWikisAsync();
             if (wikis.Count > 0)
             {
-                _wikiId = wikis[0].Id;
+                if (string.IsNullOrWhiteSpace(_wikiId))
+                    _wikiId = wikis[0].Id;
                 var root = await ApiService.GetWikiPageTreeAsync(_wikiId);
                 if (root != null)
                     _wikiItems = [BuildTreeItem(root)];
@@ -141,6 +154,11 @@
                 pages.Add((p.Name, text));
             }
             _prompt = BuildPrompt(pages);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                Backlog = _backlog,
+                WikiId = _wikiId
+            });
             _error = null;
             await CopyPrompt();
             await (_stepper?.NextStepAsync() ?? Task.CompletedTask);
@@ -159,6 +177,18 @@
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
+    }
+
+    private async Task Reset()
+    {
+        _selectedPages = null;
+        _prompt = string.Empty;
+        _responseText = string.Empty;
+        _plan = null;
+        if (_backlogs.Length > 0)
+            _backlog = _backlogs[0];
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
     }
 
     private void ImportPlan()
@@ -277,5 +307,11 @@
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public string AcceptanceCriteria { get; set; } = string.Empty;
+    }
+
+    private class PageState
+    {
+        public string Backlog { get; set; } = string.Empty;
+        public string WikiId { get; set; } = string.Empty;
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -5,6 +5,7 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Story Quality</PageTitle>
 
@@ -31,6 +32,7 @@
             }
         </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Generate">Generate</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -58,6 +60,7 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     private bool _loading;
     private string? _prompt;
     private string? _error;
+    private const string StateKey = "story-review";
 
     protected override async Task OnInitializedAsync()
     {
@@ -66,6 +69,10 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null && !string.IsNullOrWhiteSpace(state.Path))
+                _path = state.Path;
+
             _states = await ApiService.GetStatesAsync();
             var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
             SelectedStates = _states
@@ -73,6 +80,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
                             s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
                             extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
                 .ToHashSet();
+            if (state?.States != null)
+                SelectedStates = state.States.ToHashSet();
             _error = null;
         }
         catch (Exception ex)
@@ -89,6 +98,11 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             var items = await ApiService.GetStoriesAsync(_path, SelectedStates);
             _prompt = BuildPrompt(items, ConfigService.Config.DefinitionOfReady);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                Path = _path,
+                States = SelectedStates.ToArray()
+            });
             _error = null;
             await CopyPrompt();
         }
@@ -106,6 +120,21 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
+    }
+
+    private async Task Reset()
+    {
+        if (_backlogs.Length > 0)
+            _path = _backlogs[0];
+        var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+        SelectedStates = _states
+            .Where(s => s.Equals("New", StringComparison.OrdinalIgnoreCase) ||
+                        s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
+                        extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
+            .ToHashSet();
+        _prompt = null;
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
     }
 
     private Task OnStatesChanged(IEnumerable<string> values)
@@ -149,4 +178,9 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         return sb.ToString();
     }
 
+    private class PageState
+    {
+        public string Path { get; set; } = string.Empty;
+        public string[]? States { get; set; }
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -3,6 +3,7 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Story Validation</PageTitle>
 
@@ -67,6 +68,7 @@ else
             }
         </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load" Disabled="!_hasRules">Check</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -124,6 +126,7 @@ else if (_results != null)
     private bool _rulesExpanded;
     private List<ResultItem>? _results;
     private string? _error;
+    private const string StateKey = "validation";
 
     protected override async Task OnInitializedAsync()
     {
@@ -132,6 +135,12 @@ else if (_results != null)
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null)
+            {
+                if (!string.IsNullOrWhiteSpace(state.Path))
+                    _path = state.Path;
+            }
             _states = await ApiService.GetStatesAsync();
             var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
             SelectedStates = _states
@@ -139,6 +148,8 @@ else if (_results != null)
                             s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
                             extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
                 .ToHashSet();
+            if (state?.States != null)
+                SelectedStates = state.States.ToHashSet();
             SelectedTypes = _types.ToHashSet();
             _error = null;
         }
@@ -159,6 +170,12 @@ else if (_results != null)
         {
             var items = await ApiService.GetValidationItemsAsync(_path, SelectedStates, SelectedTypes);
             _results = Validate(items);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                Path = _path,
+                States = SelectedStates.ToArray(),
+                Types = SelectedTypes.ToArray()
+            });
             _error = null;
         }
         catch (Exception ex)
@@ -297,11 +314,33 @@ else if (_results != null)
         }
     }
 
+    private async Task Reset()
+    {
+        if (_backlogs.Length > 0)
+            _path = _backlogs[0];
+        var extras = ConfigService.Config.DefaultStates?.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries) ?? Array.Empty<string>();
+        SelectedStates = _states
+            .Where(s => s.Equals("New", StringComparison.OrdinalIgnoreCase) ||
+                        s.Equals("Active", StringComparison.OrdinalIgnoreCase) ||
+                        extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
+            .ToHashSet();
+        SelectedTypes = _types.ToHashSet();
+        _results = null;
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
+    }
+
     private class ResultItem
     {
         public WorkItemInfo Info { get; set; } = new();
         public List<string> Violations { get; set; } = [];
     }
 
+    private class PageState
+    {
+        public string Path { get; set; } = string.Empty;
+        public string[]? States { get; set; }
+        public string[]? Types { get; set; }
+    }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -1,6 +1,7 @@
 @page "/epics-features"
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
+@inject PageStateService StateService
 
 <PageTitle>DevOpsAssistant - Epics and Features</PageTitle>
 
@@ -23,6 +24,7 @@
             }
         </MudSelect>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load">Load</MudButton>
+        <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -84,6 +86,7 @@ else if (_roots != null)
     private List<WorkItemNode>? _roots;
     private string? _error;
     private bool _issuesOnly = true;
+    private const string StateKey = "work-items";
 
     private IEnumerable<WorkItemNode> DisplayRoots =>
         _roots == null
@@ -99,6 +102,14 @@ else if (_roots != null)
             _backlogs = await ApiService.GetBacklogsAsync();
             if (_backlogs.Length > 0)
                 _path = _backlogs[0];
+
+            var state = await StateService.LoadAsync<PageState>(StateKey);
+            if (state != null)
+            {
+                if (!string.IsNullOrWhiteSpace(state.Path))
+                    _path = state.Path;
+                _issuesOnly = state.IssuesOnly;
+            }
             _error = null;
         }
         catch (Exception ex)
@@ -114,6 +125,11 @@ else if (_roots != null)
         try
         {
             _roots = await ApiService.GetWorkItemHierarchyAsync(_path);
+            await StateService.SaveAsync(StateKey, new PageState
+            {
+                Path = _path,
+                IssuesOnly = _issuesOnly
+            });
             _error = null;
         }
         catch (Exception ex)
@@ -274,6 +290,22 @@ else if (_roots != null)
         }
 
         return false;
+    }
+
+    private async Task Reset()
+    {
+        if (_backlogs.Length > 0)
+            _path = _backlogs[0];
+        _issuesOnly = true;
+        _roots = null;
+        await StateService.ClearAsync(StateKey);
+        StateHasChanged();
+    }
+
+    private class PageState
+    {
+        public string Path { get; set; } = string.Empty;
+        public bool IssuesOnly { get; set; }
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddMudServices();
 builder.Services.AddBlazoredLocalStorage();
 builder.Services.AddScoped<DevOpsConfigService>();
+builder.Services.AddScoped<PageStateService>();
 builder.Services.AddScoped<DevOpsApiService>();
 builder.Services.AddScoped<VersionService>();
 builder.Services.AddScoped<DeploymentConfigService>();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PageStateService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PageStateService.cs
@@ -1,0 +1,28 @@
+using Blazored.LocalStorage;
+
+namespace DevOpsAssistant.Services;
+
+public class PageStateService
+{
+    private readonly ILocalStorageService _localStorage;
+
+    public PageStateService(ILocalStorageService localStorage)
+    {
+        _localStorage = localStorage;
+    }
+
+    public async Task SaveAsync<T>(string key, T state)
+    {
+        await _localStorage.SetItemAsync(key, state);
+    }
+
+    public async Task<T?> LoadAsync<T>(string key)
+    {
+        return await _localStorage.GetItemAsync<T>(key);
+    }
+
+    public async Task ClearAsync(string key)
+    {
+        await _localStorage.RemoveItemAsync(key);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PageStateService` for saving page-specific UI state
- persist field selections across user pages
- add Reset buttons to revert to defaults
- extend component test base to register the new service
- cover page state persistence with new unit tests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_68516423d93483289d52eb5d2c90c639