### PR TITLE
Add localization enforcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ The following guidelines apply to the entire repository and inform how Codex sho
 - Run `dotnet restore` and then `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln` to verify the solution builds and tests succeed.
 - Run `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror` to ensure there are no Roslyn warnings.
 - If these commands fail because the environment lacks `dotnet`, note this in the PR's testing section.
+- Ensure all user-facing strings come from localization resources. Add new `.resx` entries when introducing UI text.
 
 ## Commit guidelines
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -8,6 +8,7 @@ using DevOpsAssistant.Pages;
 using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace DevOpsAssistant.Tests.Pages;
 
@@ -74,7 +75,11 @@ public class ReleaseNotesPageTests : ComponentTestBase
         });
         var client = new HttpClient(handler);
         Services.AddSingleton(new DeploymentConfigService(new HttpClient()));
-        Services.AddSingleton(sp => new DevOpsApiService(client, config, sp.GetRequiredService<DeploymentConfigService>()));
+        Services.AddSingleton(sp => new DevOpsApiService(
+            client,
+            config,
+            sp.GetRequiredService<DeploymentConfigService>(),
+            sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var page = RenderWithProvider<TestPage>();
         var setField = typeof(ReleaseNotes).GetField("_selectedItems", BindingFlags.NonPublic | BindingFlags.Instance)!;

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -6,6 +6,7 @@ using DevOpsAssistant.Tests;
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 using MudBlazor;
 using MudBlazor.Services;
 
@@ -25,7 +26,11 @@ public abstract class ComponentTestBase : TestContext
         {
             var deployment = new DeploymentConfigService(new HttpClient());
             Services.AddSingleton(deployment);
-            Services.AddSingleton(sp => new DevOpsApiService(new HttpClient(), config, deployment));
+            Services.AddSingleton(sp => new DevOpsApiService(
+                new HttpClient(),
+                config,
+                deployment,
+                sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
         }
         var client = new HttpClient(new FakeHttpMessageHandler(_ =>
             new HttpResponseMessage(HttpStatusCode.OK)

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ConfigIncomplete" xml:space="preserve">
+    <value>DevOps configuration is incomplete.</value>
+  </data>
+  <data name="InvalidRequest" xml:space="preserve">
+    <value>Invalid request. Please verify your parameters.</value>
+  </data>
+  <data name="Unauthorized" xml:space="preserve">
+    <value>Authentication failed. Please verify your PAT token.</value>
+  </data>
+  <data name="Forbidden" xml:space="preserve">
+    <value>Access denied. Please check your PAT permissions.</value>
+  </data>
+  <data name="NotFound" xml:space="preserve">
+    <value>The requested project was not found.</value>
+  </data>
+  <data name="Conflict" xml:space="preserve">
+    <value>The item was updated elsewhere. Refresh and try again.</value>
+  </data>
+  <data name="TooManyRequests" xml:space="preserve">
+    <value>Rate limit exceeded. Please wait and retry.</value>
+  </data>
+  <data name="ServiceUnavailable" xml:space="preserve">
+    <value>Azure DevOps service is unavailable. Please try again later.</value>
+  </data>
+  <data name="GenericFailure" xml:space="preserve">
+    <value>Request failed with status code {0} ({1})</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- move DevOpsApiService error messages to resx resources
- inject localizer into DevOpsApiService
- use test localizer in unit tests
- document localization requirement in AGENTS instructions

## Testing
- `dotnet format --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6851803f7c388328ba14189beb209adf