### PR TITLE
Add help page and tooltips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ The following guidelines apply to the entire repository and inform how Codex sho
 - Run `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror` to ensure there are no Roslyn warnings.
 - If these commands fail because the environment lacks `dotnet`, note this in the PR's testing section.
 - Ensure all user-facing strings come from localization resources. Add new `.resx` entries when introducing UI text.
+- Keep `src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor` and its `.resx` files current with instructions for each page whenever features change.
 
 ## Commit guidelines
 

--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -47,6 +47,7 @@ public class UiTests
     [InlineData("/story-review", "reviewing user stories")]
     [InlineData("/validation", "validate work items")]
     [InlineData("/epics-features", "epics and features")]
+    [InlineData("/help", "Help & Instructions")]
     public async Task Page_Loads_With_Expected_Content(string path, string text)
     {
         if (string.IsNullOrEmpty(_baseUrl))
@@ -68,6 +69,7 @@ public class UiTests
     [InlineData("Metrics", "Metrics")]
     [InlineData("Requirement Planner", "Requirement Planner")]
     [InlineData("Branch Health", "Branch Health")]
+    [InlineData("Help", "Help & Instructions")]
     public async Task Nav_Menu_Navigates_To_Correct_Page(string linkText, string heading)
     {
         if (string.IsNullOrEmpty(_baseUrl))

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -48,4 +48,7 @@
   <data name="BranchHealth" xml:space="preserve">
     <value>Estado de Ramas</value>
   </data>
+  <data name="Help" xml:space="preserve">
+    <value>Ayuda</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -35,6 +35,7 @@
                 <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">@L["Metrics"]</MudNavLink>
                 <MudNavLink Href="branch-health" Icon="@Icons.Material.Filled.Source" Disabled="@IsConfigMissing">@L["BranchHealth"]</MudNavLink>
             </MudNavGroup>
+            <MudNavLink Href="help" Icon="@Icons.Material.Filled.Help">@L["Help"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -48,4 +48,7 @@
   <data name="BranchHealth" xml:space="preserve">
     <value>Branch Health</value>
   </data>
+  <data name="Help" xml:space="preserve">
+    <value>Help</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BaseBranchTooltip" xml:space="preserve">
+    <value>Comparar con esta rama para ver la diferencia</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
@@ -3,6 +3,8 @@
 @inject DevOpsApiService ApiService
 @inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<BranchHealth> L
 
 <PageTitle>DevOpsAssistant - Branch Health</PageTitle>
 
@@ -23,7 +25,9 @@
                 <MudSelectItem Value="@r">@r.Name</MudSelectItem>
             }
         </MudSelect>
-        <MudAutocomplete T="string" Label="Base Branch" @bind-Value="_baseBranch" SearchFunc="SearchBranches" Disabled="_repo == null" />
+        <MudTooltip Text='@L["BaseBranchTooltip"]'>
+            <MudAutocomplete T="string" Label="Base Branch" @bind-Value="_baseBranch" SearchFunc="SearchBranches" Disabled="_repo == null" />
+        </MudTooltip>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_repo == null" OnClick="Load">Load</MudButton>
         <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
     </MudStack>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BaseBranchTooltip" xml:space="preserve">
+    <value>Compare against this branch for ahead/behind counts</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Ayuda e instrucciones</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Esta página describe cómo usar cada sección de DevOpsAssistant.</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Cargue un backlog para visualizar épicas y características. Los estados sugeridos aparecen cuando los padres difieren de sus hijos y se pueden actualizar.</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Seleccione un backlog y estados y luego verifique los elementos de trabajo con sus reglas. Las violaciones pueden etiquetarse para seguimiento.</value>
+  </data>
+  <data name="Quality" xml:space="preserve">
+    <value>Genere un prompt para revisar historias con los principios INVEST usando su Definición de Ready.</value>
+  </data>
+  <data name="RequirementsPlanner" xml:space="preserve">
+    <value>Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos.</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Muestre gráficos de rendimiento, tiempo de entrega y tiempo de ciclo para el backlog elegido.</value>
+  </data>
+  <data name="BranchHealth" xml:space="preserve">
+    <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configure su organización, proyecto, token PAT y otras opciones utilizadas por el sitio.</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
@@ -1,0 +1,41 @@
+@page "/help"
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Help> L
+
+<PageTitle>DevOpsAssistant - Help</PageTitle>
+
+<MudText Typo="Typo.h4" Class="mb-4">@L["Heading"]</MudText>
+<MudText Typo="Typo.body1" Class="mb-4">@L["Intro"]</MudText>
+
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
+    <MudText Typo="Typo.body2">@L["Epics"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Story Validation</MudText>
+    <MudText Typo="Typo.body2">@L["Validation"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Story Quality</MudText>
+    <MudText Typo="Typo.body2">@L["Quality"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Requirement Planner</MudText>
+    <MudText Typo="Typo.body2">@L["RequirementsPlanner"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Release Notes</MudText>
+    <MudText Typo="Typo.body2">@L["ReleaseNotes"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Metrics</MudText>
+    <MudText Typo="Typo.body2">@L["Metrics"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Branch Health</MudText>
+    <MudText Typo="Typo.body2">@L["BranchHealth"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Settings</MudText>
+    <MudText Typo="Typo.body2">@L["Settings"]</MudText>
+</MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Help &amp; Instructions</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>This page describes how to use each section of DevOpsAssistant.</value>
+  </data>
+  <data name="Epics" xml:space="preserve">
+    <value>Load a backlog to visualize Epics and Features. Suggested states appear when parents differ from their children and can be updated.</value>
+  </data>
+  <data name="Validation" xml:space="preserve">
+    <value>Select a backlog and states then check work items against your rules. Violations can be tagged for follow up.</value>
+  </data>
+  <data name="Quality" xml:space="preserve">
+    <value>Generate a prompt to review stories for INVEST compliance using your Definition of Ready.</value>
+  </data>
+  <data name="RequirementsPlanner" xml:space="preserve">
+    <value>Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items.</value>
+  </data>
+  <data name="ReleaseNotes" xml:space="preserve">
+    <value>Select stories and build a prompt that summarizes them for release notes.</value>
+  </data>
+  <data name="Metrics" xml:space="preserve">
+    <value>Display throughput, lead time and cycle time charts for the chosen backlog.</value>
+  </data>
+  <data name="BranchHealth" xml:space="preserve">
+    <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
+  </data>
+  <data name="Settings" xml:space="preserve">
+    <value>Configure your organization, project, PAT token and other options used by the site.</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="VelocityTooltip" xml:space="preserve">
+    <value>Elija qué campo usar para el cálculo de velocidad</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -4,6 +4,8 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Metrics> L
 
 <PageTitle>DevOpsAssistant - Metrics</PageTitle>
 
@@ -30,10 +32,12 @@
             <MudSelectItem Value="AggregateMode.Month">Month</MudSelectItem>
         </MudSelect>
         <MudDatePicker @bind-Date="_startDate" Label="Start Date" />
-        <MudSelect T="VelocityMode" @bind-Value="_velocityMode" Label="Velocity By">
-            <MudSelectItem Value="VelocityMode.StoryPoints">Story Points</MudSelectItem>
-            <MudSelectItem Value="VelocityMode.OriginalEstimate">Original Estimate</MudSelectItem>
-        </MudSelect>
+        <MudTooltip Text='@L["VelocityTooltip"]'>
+            <MudSelect T="VelocityMode" @bind-Value="_velocityMode" Label="Velocity By">
+                <MudSelectItem Value="VelocityMode.StoryPoints">Story Points</MudSelectItem>
+                <MudSelectItem Value="VelocityMode.OriginalEstimate">Original Estimate</MudSelectItem>
+            </MudSelect>
+        </MudTooltip>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load">Load</MudButton>
         <MudButton Variant="Variant.Outlined" OnClick="ExportCsv">Export CSV</MudButton>
         <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="VelocityTooltip" xml:space="preserve">
+    <value>Choose which field to use for velocity calculations</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="UseDocumentTooltip" xml:space="preserve">
+    <value>Cargue un documento en lugar de seleccionar páginas wiki</value>
+  </data>
+  <data name="StoriesOnlyTooltip" xml:space="preserve">
+    <value>Ignorar épicas y características y crear solo historias</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -7,6 +7,8 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<RequirementsPlanner> L
 
 <PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
@@ -22,7 +24,9 @@
 <MudStepper @ref="_stepper" Class="mb-4" ActionContent="@(_ => (RenderFragment)(builder => { }) )">
     <MudStep Title="Select Requirements">
         <MudStack Spacing="2">
-            <MudSwitch T="bool" @bind-Value="_useDocument" Color="Color.Primary" Label="Use Document" />
+            <MudTooltip Text='@L["UseDocumentTooltip"]'>
+                <MudSwitch T="bool" @bind-Value="_useDocument" Color="Color.Primary" Label="Use Document" />
+            </MudTooltip>
             @if (_useDocument)
             {
                 <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx" />
@@ -35,7 +39,9 @@
                     </ItemTemplate>
                 </MudTreeView>
             }
-            <MudSwitch T="bool" @bind-Value="_storiesOnly" Color="Color.Primary" Label="Stories Only" />
+            <MudTooltip Text='@L["StoriesOnlyTooltip"]'>
+                <MudSwitch T="bool" @bind-Value="_storiesOnly" Color="Color.Primary" Label="Stories Only" />
+            </MudTooltip>
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@GenerateDisabled" OnClick="Generate">Generate Prompt</MudButton>
             <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
         </MudStack>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="UseDocumentTooltip" xml:space="preserve">
+    <value>Upload a document instead of selecting wiki pages</value>
+  </data>
+  <data name="StoriesOnlyTooltip" xml:space="preserve">
+    <value>Ignore Epics and Features and create User Stories only</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- create Help page describing each section
- link to Help from the nav menu
- add tooltips for complex fields
- keep help docs updated in AGENTS instructions
- cover Help page in UI tests

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68518a9a983c8328ae54c9260489e019