### PR TITLE
Fix localizer DI

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -74,7 +74,7 @@ public class DevOpsApiServiceTests
         return (string)method.Invoke(null, [area, states])!;
     }
 
-    private class TestLocalizer : IStringLocalizer
+    private class TestLocalizer : IStringLocalizer<DevOpsApiService>
     {
         private static readonly Dictionary<string, string> _data = new()
         {
@@ -101,7 +101,7 @@ public class DevOpsApiServiceTests
 
     private static DevOpsApiService CreateService(HttpClient client, DevOpsConfigService config)
     {
-        var localizer = new TestLocalizer();
+        IStringLocalizer<DevOpsApiService> localizer = new TestLocalizer();
         return new DevOpsApiService(client, config, new DeploymentConfigService(new HttpClient()), localizer);
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -13,7 +13,7 @@ public class DevOpsApiService
 {
     private const string ApiVersion = "7.0";
     private readonly DevOpsConfigService _configService;
-    private readonly IStringLocalizer _localizer;
+    private readonly IStringLocalizer<DevOpsApiService> _localizer;
 
     private readonly HttpClient _httpClient;
     private readonly DeploymentConfigService _deploymentConfig;
@@ -41,7 +41,7 @@ public class DevOpsApiService
 
     private string? StaticApiPath => _deploymentConfig.Config.StaticApiPath;
 
-    public DevOpsApiService(HttpClient httpClient, DevOpsConfigService configService, DeploymentConfigService deploymentConfig, IStringLocalizer localizer)
+    public DevOpsApiService(HttpClient httpClient, DevOpsConfigService configService, DeploymentConfigService deploymentConfig, IStringLocalizer<DevOpsApiService> localizer)
     {
         _httpClient = httpClient;
         _configService = configService;


### PR DESCRIPTION
## Summary
- use `IStringLocalizer<DevOpsApiService>` for DI
- update tests to use typed localizer

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_685191ce5c988328bebfe346bfbc4c21