### PR TITLE
Fix validation state persistence

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ValidationPageTests.cs
@@ -5,6 +5,10 @@ using DevOpsAssistant.Tests.Utils;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Net;
+using System.Net.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace DevOpsAssistant.Tests.Pages;
 
@@ -66,6 +70,56 @@ public class ValidationPageTests : ComponentTestBase
 
         cut.Find("button.rules-toggle").Click();
         cut.WaitForAssertion(() => Assert.True((bool)expandedField.GetValue(cut.Instance)!));
+    }
+
+    [Fact]
+    public async Task OnInitialized_Loads_Types_From_State()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig
+        {
+            Organization = "Org",
+            Project = "Proj",
+            PatToken = "token"
+        });
+
+        var handler = new FakeHttpMessageHandler(req =>
+        {
+            if (req.RequestUri!.AbsoluteUri.Contains("classificationnodes"))
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"path\":\"Area\"}") };
+            if (req.RequestUri!.AbsoluteUri.Contains("states"))
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"value\":[{\"name\":\"New\"}]}") };
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+        });
+        var client = new HttpClient(handler);
+        Services.AddSingleton(new DeploymentConfigService(new HttpClient()));
+        Services.AddSingleton<DevOpsApiService>(sp => new DevOpsApiService(
+            client,
+            config,
+            sp.GetRequiredService<DeploymentConfigService>(),
+            sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
+
+        var stateService = Services.GetRequiredService<PageStateService>();
+        await stateService.SaveAsync("validation", new TestState
+        {
+            Path = "Area",
+            States = new[] { "New" },
+            Types = new[] { "Bug" }
+        });
+
+        var cut = RenderWithProvider<Validation>();
+
+        var prop = typeof(Validation).GetProperty("SelectedTypes", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var set = (HashSet<string>)prop.GetValue(cut.Instance)!;
+        Assert.Single(set);
+        Assert.Contains("Bug", set);
+    }
+
+    private class TestState
+    {
+        public string Path { get; set; } = string.Empty;
+        public string[]? States { get; set; }
+        public string[]? Types { get; set; }
     }
 
     private class TestPage : Validation

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -156,6 +156,8 @@ else if (_results != null)
             if (state?.States != null)
                 SelectedStates = state.States.ToHashSet();
             SelectedTypes = _types.ToHashSet();
+            if (state?.Types != null)
+                SelectedTypes = state.Types.ToHashSet();
             _error = null;
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- restore selected work item types on page init
- test state loading on Validation page

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6851c291f5f88328989a5331b1dc88f2