### PR TITLE
Add prompt length controls

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -31,6 +31,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
         var page = RenderWithProvider<TestPage>();
         var field = typeof(ReleaseNotes).GetField("_prompt", BindingFlags.NonPublic | BindingFlags.Instance)!;
         field.SetValue(page.Instance, "text");
+        var partsField = typeof(ReleaseNotes).GetField("_promptParts", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        partsField.SetValue(page.Instance, new List<string> { "text" });
         page.Render();
 
         Assert.Contains("Copy", page.Markup);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
@@ -1,0 +1,29 @@
+using DevOpsAssistant.Services;
+
+namespace DevOpsAssistant.Tests.Utils;
+
+public class PromptHelpersTests
+{
+    [Fact]
+    public void SplitPrompt_Respects_Limit()
+    {
+        var text = "line1\nline2\nline3";
+
+        var result = PromptHelpers.SplitPrompt(text, 10);
+
+        Assert.Equal(3, result.Count);
+        Assert.StartsWith("[PART 1/3]", result[0]);
+        Assert.StartsWith("[PART 2/3]", result[1]);
+    }
+
+    [Fact]
+    public void SplitPrompt_Returns_Original_When_Limit_Zero()
+    {
+        var text = "test";
+
+        var result = PromptHelpers.SplitPrompt(text, 0);
+
+        Assert.Single(result);
+        Assert.Equal(text, result[0]);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -24,4 +24,7 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Prompt de Requerimientos</value>
   </data>
+  <data name="PromptLimit" xml:space="preserve">
+    <value>Límite de caracteres del prompt</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -26,6 +26,7 @@
                     <MudTextField @bind-Value="_model.StoryQualityPrompt" Label='@L["StoryQualityPrompt"]' Lines="3"/>
                     <MudTextField @bind-Value="_model.ReleaseNotesPrompt" Label='@L["ReleaseNotesPrompt"]' Lines="3"/>
                     <MudTextField @bind-Value="_model.RequirementsPrompt" Label='@L["RequirementsPrompt"]' Lines="3"/>
+                    <MudTextField @bind-Value="_model.PromptCharacterLimit" Label='@L["PromptLimit"]' InputType="InputType.Number" />
                 </MudStack>
             </MudTabPanel>
             <MudTabPanel Text="Validation Rules">
@@ -85,6 +86,7 @@
             StoryQualityPrompt = cfg.StoryQualityPrompt,
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
+            PromptCharacterLimit = cfg.PromptCharacterLimit,
             Rules = new ValidationRules
             {
                 Epic = new EpicRules { HasDescription = cfg.Rules.Epic.HasDescription },

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -24,4 +24,7 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Requirements Prompt</value>
   </data>
+  <data name="PromptLimit" xml:space="preserve">
+    <value>Prompt Character Limit</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -25,13 +25,13 @@
     <value>Seleccione un backlog y estados y luego verifique los elementos de trabajo con sus reglas. Las violaciones pueden etiquetarse para seguimiento.</value>
   </data>
   <data name="Quality" xml:space="preserve">
-    <value>Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready.</value>
+    <value>Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready. Los prompts largos se dividen en partes y puede cambiar entre ellas con las flechas.</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
     <value>Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.</value>
+    <value>Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento. Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Muestre gráficos de rendimiento, tiempo de entrega y tiempo de ciclo para el backlog elegido.</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -25,13 +25,13 @@
     <value>Select a backlog and states then check work items against your rules. Violations can be tagged for follow up.</value>
   </data>
   <data name="Quality" xml:space="preserve">
-    <value>Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready.</value>
+    <value>Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready. Long prompts are split into parts and you can switch between them using the arrows.</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
     <value>Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>Select stories and build a prompt that summarizes them for release notes.</value>
+    <value>Select stories and build a prompt that summarizes them for release notes. Prompts can be copied or downloaded, splitting into parts with arrows to navigate.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Display throughput, lead time and cycle time charts for the chosen backlog.</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -89,20 +89,34 @@
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
 }
-else if (!string.IsNullOrWhiteSpace(_prompt))
+else if (_promptParts != null)
 {
     <MudPaper Class="pa-2">
         <MudStack Spacing="2">
+            <MudButton Variant="Variant.Text"
+                       StartIcon="@Icons.Material.Filled.Download"
+                       OnClick="DownloadPrompt">
+                Download
+            </MudButton>
             <MudTextField T="string"
-                          Text="@_prompt"
+                          Text="@_promptParts[_partIndex]"
                           Lines="10"
                           ReadOnly="true"
-                          Class="w-100"/>
-            <MudButton Variant="Variant.Text"
-                       StartIcon="@Icons.Material.Filled.ContentCopy"
-                       OnClick="CopyPrompt">
-                Copy
-            </MudButton>
+                          Class="w-100" />
+            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft"
+                               Disabled="_partIndex == 0"
+                               OnClick="PrevPart" />
+                <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronRight"
+                               Disabled="_partIndex == _promptParts.Count - 1"
+                               OnClick="NextPart" />
+                <MudButton Variant="Variant.Text"
+                           StartIcon="@Icons.Material.Filled.ContentCopy"
+                           OnClick="() => CopyPart(_promptParts[_partIndex])">
+                    Copy
+                </MudButton>
+            </MudStack>
         </MudStack>
     </MudPaper>
 }
@@ -112,6 +126,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     private WorkItemInfo? _searchValue;
     private bool _loading;
     private string? _prompt;
+    private List<string>? _promptParts;
+    private int _partIndex;
     private string? _error;
     private string _path = string.Empty;
     private string[] _backlogs = [];
@@ -212,6 +228,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             var ids = _selectedItems.Select(s => s.Id);
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
             _prompt = BuildPrompt(details, ConfigService.Config);
+            _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
+            _partIndex = 0;
             _error = null;
             await CopyPrompt();
         }
@@ -243,6 +261,29 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
     }
 
+    private async Task CopyPart(string text)
+    {
+        await JS.InvokeVoidAsync("copyText", text);
+    }
+
+    private void PrevPart()
+    {
+        if (_partIndex > 0)
+            _partIndex--;
+    }
+
+    private void NextPart()
+    {
+        if (_promptParts != null && _partIndex < _promptParts.Count - 1)
+            _partIndex++;
+    }
+
+    private async Task DownloadPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
+    }
+
     private async Task Reset()
     {
         if (ConfigService.Config.ReleaseNotesTreeView && _backlogs.Length > 0)
@@ -251,6 +292,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         _treeItems = null;
         _selectedNodes = null;
         _prompt = null;
+        _promptParts = null;
+        _partIndex = 0;
         await StateService.ClearAsync(StateKey);
         StateHasChanged();
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -51,8 +51,17 @@
     </MudStep>
     <MudStep Title="Import Response" Disabled="@string.IsNullOrWhiteSpace(_prompt)">
         <MudStack Spacing="2">
-            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100" />
-            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">Copy</MudButton>
+            @if (_promptParts != null)
+            {
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
+                <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" Class="w-100" />
+                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                    <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="_partIndex == 0" OnClick="PrevPart" />
+                    <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                    <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="_partIndex == _promptParts.Count - 1" OnClick="NextPart" />
+                    <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">Copy</MudButton>
+                </MudStack>
+            }
             <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="LLM Response" Class="w-100" />
             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">Import</MudButton>
         </MudStack>
@@ -135,6 +144,8 @@
     private bool _useDocument;
     private string _wikiId = string.Empty;
     private string _prompt = string.Empty;
+    private List<string>? _promptParts;
+    private int _partIndex;
     private string _responseText = string.Empty;
     private bool _loading;
     private string? _error;
@@ -213,6 +224,8 @@
                 }
             }
             _prompt = BuildPrompt(pages, _storiesOnly, _clarify, ConfigService.Config);
+            _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
+            _partIndex = 0;
             await StateService.SaveAsync(StateKey, new PageState
             {
                 Backlog = _backlog,
@@ -238,6 +251,29 @@
             await JS.InvokeVoidAsync("copyText", _prompt);
     }
 
+    private async Task CopyPart(string text)
+    {
+        await JS.InvokeVoidAsync("copyText", text);
+    }
+
+    private void PrevPart()
+    {
+        if (_partIndex > 0)
+            _partIndex--;
+    }
+
+    private void NextPart()
+    {
+        if (_promptParts != null && _partIndex < _promptParts.Count - 1)
+            _partIndex++;
+    }
+
+    private async Task DownloadPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
+    }
+
     private Task OnFileSelected(InputFileChangeEventArgs e)
     {
         _file = e.File;
@@ -250,6 +286,8 @@
         _file = null;
         _useDocument = false;
         _prompt = string.Empty;
+        _promptParts = null;
+        _partIndex = 0;
         _responseText = string.Empty;
         _plan = null;
         _storiesOnly = false;

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -40,14 +40,18 @@
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
 }
-else if (!string.IsNullOrWhiteSpace(_prompt))
+else if (_promptParts != null)
 {
     <MudPaper Class="pa-2">
         <MudStack Spacing="2">
-            <MudTextField T="string" Text="@_prompt" Lines="10" ReadOnly="true" Class="w-100"/>
-            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="CopyPrompt">
-                Copy
-            </MudButton>
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
+            <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" Class="w-100" />
+            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="_partIndex == 0" OnClick="PrevPart" />
+                <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="_partIndex == _promptParts.Count - 1" OnClick="NextPart" />
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">Copy</MudButton>
+            </MudStack>
         </MudStack>
     </MudPaper>
 }
@@ -59,6 +63,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
     private HashSet<string> SelectedStates { get; set; } = new();
     private bool _loading;
     private string? _prompt;
+    private List<string>? _promptParts;
+    private int _partIndex;
     private string? _error;
     private const string StateKey = "story-review";
 
@@ -98,6 +104,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
         {
             var items = await ApiService.GetStoriesAsync(_path, SelectedStates);
             _prompt = BuildPrompt(items, ConfigService.Config);
+            _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
+            _partIndex = 0;
             await StateService.SaveAsync(StateKey, new PageState
             {
                 Path = _path,
@@ -122,6 +130,29 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("copyText", _prompt);
     }
 
+    private async Task CopyPart(string text)
+    {
+        await JS.InvokeVoidAsync("copyText", text);
+    }
+
+    private void PrevPart()
+    {
+        if (_partIndex > 0)
+            _partIndex--;
+    }
+
+    private void NextPart()
+    {
+        if (_promptParts != null && _partIndex < _promptParts.Count - 1)
+            _partIndex++;
+    }
+
+    private async Task DownloadPrompt()
+    {
+        if (!string.IsNullOrWhiteSpace(_prompt))
+            await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
+    }
+
     private async Task Reset()
     {
         if (_backlogs.Length > 0)
@@ -133,6 +164,8 @@ else if (!string.IsNullOrWhiteSpace(_prompt))
                         extras.Any(e => s.Equals(e, StringComparison.OrdinalIgnoreCase)))
             .ToHashSet();
         _prompt = null;
+        _promptParts = null;
+        _partIndex = 0;
         await StateService.ClearAsync(StateKey);
         StateHasChanged();
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -13,5 +13,6 @@ public class DevOpsConfig
     public string StoryQualityPrompt { get; set; } = string.Empty;
     public string ReleaseNotesPrompt { get; set; } = string.Empty;
     public string RequirementsPrompt { get; set; } = string.Empty;
+    public int PromptCharacterLimit { get; set; }
     public ValidationRules Rules { get; set; } = new();
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -43,6 +43,7 @@ public class DevOpsConfigService
             StoryQualityPrompt = config.StoryQualityPrompt.Trim(),
             ReleaseNotesPrompt = config.ReleaseNotesPrompt.Trim(),
             RequirementsPrompt = config.RequirementsPrompt.Trim(),
+            PromptCharacterLimit = config.PromptCharacterLimit,
             Rules = config.Rules
         };
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
@@ -1,0 +1,32 @@
+using System.Text;
+
+namespace DevOpsAssistant.Services;
+
+public static class PromptHelpers
+{
+    public static IReadOnlyList<string> SplitPrompt(string text, int limit)
+    {
+        if (string.IsNullOrWhiteSpace(text) || limit <= 0 || text.Length <= limit)
+            return new[] { text };
+
+        var parts = new List<string>();
+        var sb = new StringBuilder();
+        foreach (var line in text.Split('\n'))
+        {
+            if (sb.Length + line.Length + 1 > limit && sb.Length > 0)
+            {
+                parts.Add(sb.ToString().TrimEnd());
+                sb.Clear();
+            }
+            sb.AppendLine(line);
+        }
+        if (sb.Length > 0)
+            parts.Add(sb.ToString().TrimEnd());
+
+        for (int i = 0; i < parts.Count; i++)
+        {
+            parts[i] = $"[PART {i + 1}/{parts.Count}]\n" + parts[i];
+        }
+        return parts;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -12,6 +12,16 @@ window.downloadCsv = function (filename, text) {
     URL.revokeObjectURL(url);
 };
 
+window.downloadText = function (filename, text) {
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+};
+
 window.blazorCulture = {
     get: function () {
         return localStorage['BlazorCulture'];


### PR DESCRIPTION
## Summary
- introduce PromptCharacterLimit option
- split generated prompts when limit is exceeded
- allow downloading prompt as text file
- update settings UI and help docs
- test new PromptHelpers
- move download button above prompt, display single prompt textbox with prev/next arrows

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`


------
https://chatgpt.com/codex/tasks/task_e_6852c11aaca08328a1bd26d9114d1318