### PR TITLE
Fix newline handling in prompt splitting

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
@@ -31,4 +31,17 @@ public class PromptHelpersTests
         Assert.Single(result);
         Assert.Equal(text, result[0]);
     }
+
+    [Fact]
+    public void SplitPrompt_Normalizes_Windows_Newlines()
+    {
+        var text = "line1\r\nline2\r\nline3";
+
+        var limit = 16;
+        var result = PromptHelpers.SplitPrompt(text, limit);
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result, part => Assert.True(part.Length <= limit));
+        Assert.DoesNotContain('\r', string.Join(string.Empty, result));
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
@@ -4,10 +4,14 @@ namespace DevOpsAssistant.Services;
 
 public static class PromptHelpers
 {
+    private const char NewLine = '\n';
+
     public static IReadOnlyList<string> SplitPrompt(string text, int limit)
     {
         if (string.IsNullOrWhiteSpace(text) || limit <= 0 || text.Length <= limit)
             return new[] { text };
+
+        text = text.Replace("\r\n", "\n").Replace('\r', '\n');
 
         var adjustedLimit = limit;
         var parts = SplitInternal(text, adjustedLimit);
@@ -27,7 +31,7 @@ public static class PromptHelpers
 
         for (int i = 0; i < parts.Count; i++)
         {
-            parts[i] = $"[PART {i + 1}/{parts.Count}]\n" + parts[i];
+            parts[i] = $"[PART {i + 1}/{parts.Count}]" + NewLine + parts[i];
         }
         return parts;
     }
@@ -36,14 +40,14 @@ public static class PromptHelpers
     {
         var parts = new List<string>();
         var sb = new StringBuilder();
-        foreach (var line in text.Split('\n'))
+        foreach (var line in text.Split(NewLine))
         {
             if (sb.Length + line.Length + 1 > limit && sb.Length > 0)
             {
                 parts.Add(sb.ToString().TrimEnd());
                 sb.Clear();
             }
-            sb.AppendLine(line);
+            sb.Append(line).Append(NewLine);
         }
         if (sb.Length > 0)
             parts.Add(sb.ToString().TrimEnd());
@@ -53,6 +57,6 @@ public static class PromptHelpers
 
     private static int PrefixLength(int count)
     {
-        return $"[PART {count}/{count}]\n".Length;
+        return $"[PART {count}/{count}]".Length + 1; // +1 for newline
     }
 }


### PR DESCRIPTION
## Summary
- normalize CRLF to LF before splitting prompts
- use consistent newline logic when rebuilding parts
- test Windows newline handling

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_6852dc3222a883289bfe18e2dd7929f0