### PR TITLE
Fix prompt split for long lines

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/PromptHelpersTests.cs
@@ -44,4 +44,16 @@ public class PromptHelpersTests
         Assert.All(result, part => Assert.True(part.Length <= limit));
         Assert.DoesNotContain('\r', string.Join(string.Empty, result));
     }
+
+    [Fact]
+    public void SplitPrompt_Splits_Long_Lines()
+    {
+        var text = new string('a', 50);
+
+        var limit = 20;
+        var result = PromptHelpers.SplitPrompt(text, limit);
+
+        Assert.True(result.Count > 1);
+        Assert.All(result, part => Assert.True(part.Length <= limit));
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
@@ -1,5 +1,3 @@
-using System.Text;
-
 namespace DevOpsAssistant.Services;
 
 public static class PromptHelpers
@@ -39,18 +37,20 @@ public static class PromptHelpers
     private static List<string> SplitInternal(string text, int limit)
     {
         var parts = new List<string>();
-        var sb = new StringBuilder();
-        foreach (var line in text.Split(NewLine))
+        var remaining = text.Trim();
+
+        while (remaining.Length > limit)
         {
-            if (sb.Length + line.Length + 1 > limit && sb.Length > 0)
-            {
-                parts.Add(sb.ToString().TrimEnd());
-                sb.Clear();
-            }
-            sb.Append(line).Append(NewLine);
+            var splitPos = remaining.LastIndexOfAny(new[] { ' ', '\n' }, limit);
+            if (splitPos <= 0)
+                splitPos = limit;
+
+            parts.Add(remaining.Substring(0, splitPos).TrimEnd());
+            remaining = remaining.Substring(splitPos).TrimStart();
         }
-        if (sb.Length > 0)
-            parts.Add(sb.ToString().TrimEnd());
+
+        if (remaining.Length > 0)
+            parts.Add(remaining);
 
         return parts;
     }


### PR DESCRIPTION
## Summary
- improve prompt splitting so long lines also respect the limit
- cover long-line case with new unit test

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6852e62481bc8328a6eeac18e1e635fb