### PR TITLE
Ensure version footer displays

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -246,4 +246,18 @@ public class UiTests
         var row = await page.WaitForSelectorAsync("text=feature");
         Assert.NotNull(row);
     }
+
+    [Fact]
+    public async Task Footer_Displays_Version()
+    {
+        if (string.IsNullOrEmpty(_baseUrl))
+            return;
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+        var text = await page.TextContentAsync("footer");
+        Assert.Contains("Version", text);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/VersionService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/VersionService.cs
@@ -17,7 +17,7 @@ public class VersionService
     {
         try
         {
-            var text = await _httpClient.GetStringAsync("/version.txt");
+            var text = await _httpClient.GetStringAsync("version.txt");
             Version = text.Trim();
         }
         catch


### PR DESCRIPTION
## Summary
- fetch version file relative to base URL
- verify footer displays version in UI tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68530fbafa2c83289840309cdea4712a