### PR TITLE
Add bug story points rule

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -23,7 +23,8 @@ public class SettingsDialogTests : ComponentTestBase
                 Bug = new BugRules
                 {
                     IncludeReproSteps = false,
-                    IncludeSystemInfo = false
+                    IncludeSystemInfo = false,
+                    HasStoryPoints = false
                 }
             }
         });
@@ -38,5 +39,6 @@ public class SettingsDialogTests : ComponentTestBase
         Assert.True(model.ReleaseNotesTreeView);
         Assert.False(model.Rules.Bug.IncludeReproSteps);
         Assert.False(model.Rules.Bug.IncludeSystemInfo);
+        Assert.False(model.Rules.Bug.HasStoryPoints);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -28,7 +28,8 @@ public class DevOpsConfigServiceTests
                 Bug = new BugRules
                 {
                     IncludeReproSteps = false,
-                    IncludeSystemInfo = false
+                    IncludeSystemInfo = false,
+                    HasStoryPoints = false
                 }
             }
         };
@@ -45,6 +46,7 @@ public class DevOpsConfigServiceTests
         Assert.True(stored.ReleaseNotesTreeView);
         Assert.False(stored.Rules.Bug.IncludeReproSteps);
         Assert.False(stored.Rules.Bug.IncludeSystemInfo);
+        Assert.False(stored.Rules.Bug.HasStoryPoints);
         Assert.Equal("DOR", stored.DefinitionOfReady);
         Assert.Equal("SQ", stored.StoryQualityPrompt);
         Assert.Equal("RN", stored.ReleaseNotesPrompt);
@@ -76,7 +78,8 @@ public class DevOpsConfigServiceTests
                 Bug = new BugRules
                 {
                     IncludeReproSteps = false,
-                    IncludeSystemInfo = false
+                    IncludeSystemInfo = false,
+                    HasStoryPoints = false
                 }
             }
         };
@@ -92,6 +95,8 @@ public class DevOpsConfigServiceTests
         Assert.True(service.Config.ReleaseNotesTreeView);
         Assert.False(service.Config.Rules.Bug.IncludeReproSteps);
         Assert.False(service.Config.Rules.Bug.IncludeSystemInfo);
+        Assert.False(service.Config.Rules.Bug.HasStoryPoints);
+        Assert.False(service.Config.Rules.Bug.HasStoryPoints);
         Assert.Equal("DOR", service.Config.DefinitionOfReady);
         Assert.Equal("SQ", service.Config.StoryQualityPrompt);
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
@@ -148,6 +153,7 @@ public class DevOpsConfigServiceTests
         Assert.False(service.Config.ReleaseNotesTreeView);
         Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
         Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
+        Assert.True(service.Config.Rules.Bug.HasStoryPoints);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.NotNull(service.Config.Rules);
     }
@@ -169,6 +175,7 @@ public class DevOpsConfigServiceTests
         Assert.False(service.Config.ReleaseNotesTreeView);
         Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
         Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
+        Assert.True(service.Config.Rules.Bug.HasStoryPoints);
         Assert.False(await storage.ContainKeyAsync("devops-config"));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -27,4 +27,7 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Límite de caracteres del prompt</value>
   </data>
+  <data name="BugHasStoryPoints" xml:space="preserve">
+    <value>Tiene story points</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -54,6 +54,7 @@
                     <MudText Typo="Typo.h6" Class="mt-2">Bug</MudText>
                     <MudSwitch T="bool" @bind-Value="_model.Rules.Bug.IncludeReproSteps" Color="Color.Primary" Label="Include Repro Steps"/>
                     <MudSwitch T="bool" @bind-Value="_model.Rules.Bug.IncludeSystemInfo" Color="Color.Primary" Label="Include System Info"/>
+                    <MudSwitch T="bool" @bind-Value="_model.Rules.Bug.HasStoryPoints" Color="Color.Primary" Label='@L["BugHasStoryPoints"]'/>
                 </MudStack>
             </MudTabPanel>
         </MudTabs>
@@ -106,7 +107,8 @@
                 Bug = new BugRules
                 {
                     IncludeReproSteps = cfg.Rules.Bug.IncludeReproSteps,
-                    IncludeSystemInfo = cfg.Rules.Bug.IncludeSystemInfo
+                    IncludeSystemInfo = cfg.Rules.Bug.IncludeSystemInfo,
+                    HasStoryPoints = cfg.Rules.Bug.HasStoryPoints
                 }
             }
         };

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -27,4 +27,7 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Prompt Character Limit</value>
   </data>
+  <data name="BugHasStoryPoints" xml:space="preserve">
+    <value>Has story points</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización, proyecto, token PAT y otras opciones utilizadas por el sitio. También puede personalizar los prompts para cada función de IA.</value>
+    <value>Configure su organización, proyecto, token PAT y otras opciones utilizadas por el sitio. También puede personalizar los prompts y las reglas de validación.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your organization, project, PAT token and other options used by the site. You can also customize prompts for each AI feature.</value>
+    <value>Configure your organization, project, PAT token and other options used by the site. You can also customize prompts and validation rules.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BugStoryPointsRule" xml:space="preserve">
+    <value>Los bugs deben tener story points</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -5,6 +5,8 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
 @inject PageStateService StateService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Validation> L
 
 <PageTitle>DevOpsAssistant - Story Validation</PageTitle>
 
@@ -223,6 +225,7 @@ else if (_results != null)
             {
                 if (rules.Bug.IncludeReproSteps && !item.HasReproSteps) v.Add("Missing repro steps");
                 if (rules.Bug.IncludeSystemInfo && !item.HasSystemInfo) v.Add("Missing system info");
+                if (rules.Bug.HasStoryPoints && !item.HasStoryPoints) v.Add("Missing story points");
             }
 
             if (v.Count > 0)
@@ -263,6 +266,7 @@ else if (_results != null)
         if (r.Story.HasAssignee) list.Add("Stories must have an assignee");
         if (r.Bug.IncludeReproSteps) list.Add("Bugs must have repro steps");
         if (r.Bug.IncludeSystemInfo) list.Add("Bugs must have system info");
+        if (r.Bug.HasStoryPoints) list.Add(L["BugStoryPointsRule"]);
         _activeRules = list.ToArray();
         _hasRules = _activeRules.Length > 0;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="BugStoryPointsRule" xml:space="preserve">
+    <value>Bugs must have story points</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
@@ -4,4 +4,5 @@ public class BugRules
 {
     public bool IncludeReproSteps { get; set; } = true;
     public bool IncludeSystemInfo { get; set; } = true;
+    public bool HasStoryPoints { get; set; } = true;
 }


### PR DESCRIPTION
## Summary
- require story points for bugs via validation rules
- save and load the new rule in settings
- update help text on settings instructions
- keep tests and localization current

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6853da1ffb188328ae2cab55b9313330