### PR TITLE
Add markdown upload support

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
@@ -1,0 +1,20 @@
+using System.IO;
+using System.Text;
+using DevOpsAssistant.Services;
+using Xunit;
+
+namespace DevOpsAssistant.Tests.Utils;
+
+public class DocumentHelpersTests
+{
+    [Fact]
+    public void ExtractText_Returns_Content_For_Markdown()
+    {
+        var text = "# Heading\nContent";
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
+
+        var result = DocumentHelpers.ExtractText(stream, "test.md");
+
+        Assert.Equal(text, result);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -29,7 +29,7 @@
             </MudTooltip>
             @if (_useDocument)
             {
-                <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx" />
+                <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx,.md" />
             }
             else if (_wikiItems != null)
             {

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/DocumentHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/DocumentHelpers.cs
@@ -16,6 +16,7 @@ public static class DocumentHelpers
             ".pdf" => ExtractPdf(stream),
             ".docx" => ExtractDocx(stream),
             ".pptx" => ExtractPptx(stream),
+            ".md" => ExtractMarkdown(stream),
             _ => string.Empty
         };
     }
@@ -45,5 +46,11 @@ public static class DocumentHelpers
         return string.Join("\n", doc.PresentationPart!.SlideParts.SelectMany(
             s => s.Slide.Descendants<DocumentFormat.OpenXml.Drawing.Text>())
             .Select(t => t.Text));
+    }
+
+    private static string ExtractMarkdown(Stream stream)
+    {
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
     }
 }


### PR DESCRIPTION
## Summary
- enable Markdown extraction in `DocumentHelpers`
- allow `.md` uploads in the Requirements Planner page
- test Markdown extraction

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore -v minimal`
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_6853e5e3c9a48328bcb94b8718cdf021