### PR TITLE
Refine requirements planner HTML guidance

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -28,7 +28,7 @@
     <value>Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready. Los prompts largos se dividen en partes y puede cambiar entre ellas con las flechas.</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos. Las descripciones y criterios pueden usar HTML. Active Vista previa HTML tras importar para verificar el marcado.</value>
+    <value>Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos. Utilice HTML en las descripciones y criterios cuando ayude a formatear listas u otra estructura; no agregue etiquetas innecesarias. Active Vista previa HTML tras importar para verificar el marcado.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento. Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -28,7 +28,7 @@
     <value>Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready. Long prompts are split into parts and you can switch between them using the arrows.</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items. Descriptions and acceptance criteria may use HTML. Toggle Preview HTML after importing to verify markup.</value>
+    <value>Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items. Use HTML in descriptions and acceptance criteria when it helps with lists or other formatting—don't add tags just for the sake of it. Toggle Preview HTML after importing to verify markup.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Select stories and build a prompt that summarizes them for release notes. Prompts can be copied or downloaded, splitting into parts with arrows to navigate.</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -85,8 +85,11 @@
                         <MudText Typo="Typo.subtitle2">Story</MudText>
                         @if (_previewHtml)
                         {
+                            <MudText Typo="Typo.subtitle2">Description</MudText>
                             <div class="mb-2" style="border:1px solid #ccc;padding:4px;">@((MarkupString)story.Description)</div>
+                            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
                             <div class="mb-2" style="border:1px solid #ccc;padding:4px;">@((MarkupString)story.AcceptanceCriteria)</div>
+                            <MudText Typo="Typo.subtitle2">Tags</MudText>
                             <div class="mb-2">@string.Join(", ", story.Tags)</div>
                         }
                         else
@@ -121,8 +124,11 @@
                                         <MudText Typo="Typo.subtitle2">Story</MudText>
                                         @if (_previewHtml)
                                         {
+                                            <MudText Typo="Typo.subtitle2">Description</MudText>
                                             <div class="mb-2" style="border:1px solid #ccc;padding:4px;">@((MarkupString)story.Description)</div>
+                                            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
                                             <div class="mb-2" style="border:1px solid #ccc;padding:4px;">@((MarkupString)story.AcceptanceCriteria)</div>
+                                            <MudText Typo="Typo.subtitle2">Tags</MudText>
                                             <div class="mb-2">@string.Join(", ", story.Tags)</div>
                                         }
                                         else
@@ -450,7 +456,7 @@
             sb.AppendLine("- A clear, user-centric title and description");
             sb.AppendLine("- Acceptance criteria in Gherkin-style format");
             sb.AppendLine("- A \"tags\" array for engineering triage (e.g., [\"frontend\", \"backend\", \"integration\", \"performance\", \"security\", \"accessibility\", \"needs-design\"])");
-            sb.AppendLine("Descriptions and acceptance criteria can include HTML formatting where appropriate.");
+            sb.AppendLine("Use HTML formatting in descriptions and acceptance criteria only when it improves readability, such as for bulleted lists. Avoid unnecessary tags like wrapping everything in <p> elements.");
 
             if (storiesOnly)
             {


### PR DESCRIPTION
## Summary
- clarify HTML guidelines for requirements planner
- show field headings when previewing imported HTML
- update Help documentation for new behavior

## Testing
- `dotnet test --verbosity minimal`
- `dotnet format --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6854178ddd50832894c095da7c8b56f6