### PR TITLE
Add multi-project settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -37,23 +37,26 @@ public class DevOpsConfigServiceTests
         await service.SaveAsync(config);
 
         Assert.Equal("Org", service.Config.Organization);
-        var stored = await storage.GetItemAsync<DevOpsConfig>("devops-config");
+        var stored = await storage.GetItemAsync<List<DevOpsProject>>("devops-projects");
         Assert.NotNull(stored);
-        Assert.Equal("Org", stored.Organization);
-        Assert.Equal("Proj", stored.Project);
-        Assert.Equal("Token", stored.PatToken);
-        Assert.True(stored.DarkMode);
-        Assert.True(stored.ReleaseNotesTreeView);
-        Assert.False(stored.Rules.Bug.IncludeReproSteps);
-        Assert.False(stored.Rules.Bug.IncludeSystemInfo);
-        Assert.False(stored.Rules.Bug.HasStoryPoints);
-        Assert.Equal("DOR", stored.DefinitionOfReady);
-        Assert.Equal("SQ", stored.StoryQualityPrompt);
-        Assert.Equal("RN", stored.ReleaseNotesPrompt);
-        Assert.Equal("RP", stored.RequirementsPrompt);
-        Assert.Equal("Resolved", stored.DefaultStates);
-        Assert.Equal("main", stored.MainBranch);
-        Assert.True(stored.Rules.Epic.HasDescription);
+        var p = Assert.Single(stored!);
+        Assert.Equal("default", p.Name);
+        var storedCfg = p.Config;
+        Assert.Equal("Org", storedCfg.Organization);
+        Assert.Equal("Proj", storedCfg.Project);
+        Assert.Equal("Token", storedCfg.PatToken);
+        Assert.True(storedCfg.DarkMode);
+        Assert.True(storedCfg.ReleaseNotesTreeView);
+        Assert.False(storedCfg.Rules.Bug.IncludeReproSteps);
+        Assert.False(storedCfg.Rules.Bug.IncludeSystemInfo);
+        Assert.False(storedCfg.Rules.Bug.HasStoryPoints);
+        Assert.Equal("DOR", storedCfg.DefinitionOfReady);
+        Assert.Equal("SQ", storedCfg.StoryQualityPrompt);
+        Assert.Equal("RN", storedCfg.ReleaseNotesPrompt);
+        Assert.Equal("RP", storedCfg.RequirementsPrompt);
+        Assert.Equal("Resolved", storedCfg.DefaultStates);
+        Assert.Equal("main", storedCfg.MainBranch);
+        Assert.True(storedCfg.Rules.Epic.HasDescription);
     }
 
     [Fact]
@@ -83,7 +86,8 @@ public class DevOpsConfigServiceTests
                 }
             }
         };
-        await storage.SetItemAsync("devops-config", stored);
+        var project = new DevOpsProject { Name = "proj", Config = stored };
+        await storage.SetItemAsync("devops-projects", new List<DevOpsProject> { project });
         var service = new DevOpsConfigService(storage);
 
         await service.LoadAsync();
@@ -103,6 +107,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("RP", service.Config.RequirementsPrompt);
         Assert.Equal("Active", service.Config.DefaultStates);
         Assert.True(service.Config.Rules.Epic.HasDescription);
+        Assert.Equal("proj", service.CurrentProject.Name);
     }
 
     [Fact]
@@ -136,6 +141,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
         Assert.Equal("Active", service.Config.DefaultStates);
+        Assert.Equal("default", service.CurrentProject.Name);
     }
 
     [Fact]
@@ -176,6 +182,6 @@ public class DevOpsConfigServiceTests
         Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
         Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
         Assert.True(service.Config.Rules.Bug.HasStoryPoints);
-        Assert.False(await storage.ContainKeyAsync("devops-config"));
+        Assert.False(await storage.ContainKeyAsync("devops-projects"));
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -30,4 +30,16 @@
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Tiene story points</value>
   </data>
+  <data name="Project" xml:space="preserve">
+    <value>Proyecto</value>
+  </data>
+  <data name="ProjectName" xml:space="preserve">
+    <value>Nombre del Proyecto</value>
+  </data>
+  <data name="NewProject" xml:space="preserve">
+    <value>Nuevo Proyecto</value>
+  </data>
+  <data name="ImportFrom" xml:space="preserve">
+    <value>Importar De</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,10 +1,36 @@
 @inject DevOpsConfigService ConfigService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
+@using DevOpsAssistant.Services
 
 <MudDialog ContentClass="pa-4" ActionsClass="pa-4">
     <DialogContent>
-        <MudTabs>
+        <MudStack Spacing="2">
+            <MudSelect T="string" Value="_projectName" ValueChanged="OnProjectChanged" ValueExpression="@(() => _projectName)" Label='@L["Project"]' Immediate="true">
+                @foreach (var p in ConfigService.Projects)
+                {
+                    <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
+                }
+            </MudSelect>
+            <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
+            <MudExpansionPanels>
+                <MudExpansionPanel Text='@L["NewProject"]' ExpandIcon="@Icons.Material.Filled.Add">
+                    <MudTextField @bind-Value="_newProjectName" Label='@L["ProjectName"]' />
+                    @if (ConfigService.Projects.Count > 0)
+                    {
+                        <MudSelect T="string" Label='@L["ImportFrom"]' @bind-Value="_importFrom">
+                            <MudSelectItem Value="@string.Empty">None</MudSelectItem>
+                            @foreach (var p in ConfigService.Projects)
+                            {
+                                <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
+                            }
+                        </MudSelect>
+                    }
+                    <MudButton OnClick="CreateProject" Color="Color.Primary" Class="mt-2">@L["NewProject"]</MudButton>
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        </MudStack>
+        <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
                     <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
@@ -69,10 +95,14 @@
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
 
     private DevOpsConfig _model = new();
+    private string _projectName = "";
+    private string _newProjectName = "";
+    private string _importFrom = "";
 
     protected override async Task OnInitializedAsync()
     {
         await ConfigService.LoadAsync();
+        _projectName = ConfigService.CurrentProject.Name;
         var cfg = ConfigService.Config;
         _model = new DevOpsConfig
         {
@@ -117,13 +147,63 @@
 
     private async Task Save()
     {
-        await ConfigService.SaveAsync(_model);
+        await ConfigService.SaveCurrentAsync(_projectName, _model);
         MudDialog.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()
     {
         MudDialog.Cancel();
+    }
+
+    private void OnProjectChanged(string name)
+    {
+        ConfigService.SelectProject(name);
+        _projectName = ConfigService.CurrentProject.Name;
+        var cfg = ConfigService.Config;
+        _model = new DevOpsConfig
+        {
+            Organization = cfg.Organization,
+            Project = cfg.Project,
+            PatToken = cfg.PatToken,
+            MainBranch = cfg.MainBranch,
+            DefaultStates = cfg.DefaultStates,
+            DarkMode = cfg.DarkMode,
+            ReleaseNotesTreeView = cfg.ReleaseNotesTreeView,
+            DefinitionOfReady = cfg.DefinitionOfReady,
+            StoryQualityPrompt = cfg.StoryQualityPrompt,
+            ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
+            RequirementsPrompt = cfg.RequirementsPrompt,
+            PromptCharacterLimit = cfg.PromptCharacterLimit,
+            Rules = cfg.Rules
+        };
+        StateHasChanged();
+    }
+
+    private async Task CreateProject()
+    {
+        DevOpsProject? copy = ConfigService.Projects.FirstOrDefault(p => p.Name == _importFrom);
+        await ConfigService.AddProjectAsync(_newProjectName, copy);
+        _newProjectName = string.Empty;
+        _importFrom = string.Empty;
+        _projectName = ConfigService.CurrentProject.Name;
+        var cfg = ConfigService.Config;
+        _model = new DevOpsConfig
+        {
+            Organization = cfg.Organization,
+            Project = cfg.Project,
+            PatToken = cfg.PatToken,
+            MainBranch = cfg.MainBranch,
+            DefaultStates = cfg.DefaultStates,
+            DarkMode = cfg.DarkMode,
+            ReleaseNotesTreeView = cfg.ReleaseNotesTreeView,
+            DefinitionOfReady = cfg.DefinitionOfReady,
+            StoryQualityPrompt = cfg.StoryQualityPrompt,
+            ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
+            RequirementsPrompt = cfg.RequirementsPrompt,
+            PromptCharacterLimit = cfg.PromptCharacterLimit,
+            Rules = cfg.Rules
+        };
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -30,4 +30,16 @@
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Has story points</value>
   </data>
+  <data name="Project" xml:space="preserve">
+    <value>Project</value>
+  </data>
+  <data name="ProjectName" xml:space="preserve">
+    <value>Project Name</value>
+  </data>
+  <data name="NewProject" xml:space="preserve">
+    <value>New Project</value>
+  </data>
+  <data name="ImportFrom" xml:space="preserve">
+    <value>Import From</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -4,28 +4,76 @@ namespace DevOpsAssistant.Services;
 
 public class DevOpsConfigService
 {
-    private const string StorageKey = "devops-config";
+    private const string LegacyStorageKey = "devops-config";
+    private const string StorageKey = "devops-projects";
     private readonly ILocalStorageService _localStorage;
 
     public DevOpsConfigService(ILocalStorageService localStorage)
     {
         _localStorage = localStorage;
+
+        var project = new DevOpsProject { Name = "default" };
+        Projects.Add(project);
+        CurrentProject = project;
     }
 
-    public DevOpsConfig Config { get; private set; } = new();
+    public List<DevOpsProject> Projects { get; private set; } = new();
+    public DevOpsProject CurrentProject { get; private set; } = new();
+
+    public DevOpsConfig Config => CurrentProject.Config;
 
     public async Task LoadAsync()
     {
-        var config = await _localStorage.GetItemAsync<DevOpsConfig>(StorageKey);
-        if (config != null) Config = Normalize(config);
+        var projects = await _localStorage.GetItemAsync<List<DevOpsProject>>(StorageKey);
+        if (projects != null && projects.Count > 0)
+        {
+            Projects = projects.Select(Normalize).ToList();
+            CurrentProject = Projects[0];
+            return;
+        }
+
+        var legacy = await _localStorage.GetItemAsync<DevOpsConfig>(LegacyStorageKey);
+        if (legacy != null)
+        {
+            var project = new DevOpsProject { Name = "default", Config = Normalize(legacy) };
+            Projects = new List<DevOpsProject> { project };
+            CurrentProject = project;
+            await SaveProjectsAsync();
+            await _localStorage.RemoveItemAsync(LegacyStorageKey);
+        }
     }
 
     public async Task SaveAsync(DevOpsConfig config)
     {
         var normalized = Normalize(config);
 
-        Config = normalized;
-        await _localStorage.SetItemAsync(StorageKey, normalized);
+        CurrentProject.Config = normalized;
+        await SaveProjectsAsync();
+    }
+
+    public async Task SaveCurrentAsync(string name, DevOpsConfig config)
+    {
+        CurrentProject.Name = name.Trim();
+        CurrentProject.Config = Normalize(config);
+        await SaveProjectsAsync();
+    }
+
+    public async Task AddProjectAsync(string name, DevOpsProject? source = null)
+    {
+        var project = new DevOpsProject
+        {
+            Name = name.Trim(),
+            Config = source != null ? Clone(source.Config) : new DevOpsConfig()
+        };
+        Projects.Add(Normalize(project));
+        CurrentProject = project;
+        await SaveProjectsAsync();
+    }
+
+    public void SelectProject(string name)
+    {
+        var proj = Projects.FirstOrDefault(p => p.Name == name);
+        if (proj != null) CurrentProject = proj;
     }
 
     private static DevOpsConfig Normalize(DevOpsConfig config)
@@ -48,9 +96,43 @@ public class DevOpsConfigService
         };
     }
 
+    private static DevOpsProject Normalize(DevOpsProject project)
+    {
+        project.Name = project.Name.Trim();
+        project.Config = Normalize(project.Config);
+        return project;
+    }
+
+    private static DevOpsConfig Clone(DevOpsConfig cfg)
+    {
+        return new DevOpsConfig
+        {
+            Organization = cfg.Organization,
+            Project = cfg.Project,
+            PatToken = cfg.PatToken,
+            MainBranch = cfg.MainBranch,
+            DarkMode = cfg.DarkMode,
+            ReleaseNotesTreeView = cfg.ReleaseNotesTreeView,
+            DefaultStates = cfg.DefaultStates,
+            DefinitionOfReady = cfg.DefinitionOfReady,
+            StoryQualityPrompt = cfg.StoryQualityPrompt,
+            ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
+            RequirementsPrompt = cfg.RequirementsPrompt,
+            PromptCharacterLimit = cfg.PromptCharacterLimit,
+            Rules = cfg.Rules
+        };
+    }
+
     public async Task ClearAsync()
     {
-        Config = new DevOpsConfig();
+        Projects = new List<DevOpsProject> { new DevOpsProject { Name = "default" } };
+        CurrentProject = Projects[0];
         await _localStorage.RemoveItemAsync(StorageKey);
+        await _localStorage.RemoveItemAsync(LegacyStorageKey);
+    }
+
+    private async Task SaveProjectsAsync()
+    {
+        await _localStorage.SetItemAsync(StorageKey, Projects);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsProject.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsProject.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services;
+
+public class DevOpsProject
+{
+    public string Name { get; set; } = string.Empty;
+    public DevOpsConfig Config { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- support multiple DevOps projects and migrate old settings
- store projects in `devops-projects` local storage entry
- allow selecting and creating projects in the Settings dialog
- update tests for new project model

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -v minimal`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68541b87d9fc83288145d8514b33fe24