### PR TITLE
Improve project management

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -184,4 +184,18 @@ public class DevOpsConfigServiceTests
         Assert.True(service.Config.Rules.Bug.HasStoryPoints);
         Assert.False(await storage.ContainKeyAsync("devops-projects"));
     }
+
+    [Fact]
+    public async Task RemoveProjectAsync_Removes_Project_And_Updates_Current()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("proj1");
+        await service.AddProjectAsync("proj2");
+
+        await service.RemoveProjectAsync("proj2");
+
+        Assert.DoesNotContain(service.Projects, p => p.Name == "proj2");
+        Assert.Equal("default", service.CurrentProject.Name);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
@@ -8,11 +8,15 @@ public class PageStateServiceTests
     public async Task Save_And_Load_State()
     {
         var storage = new FakeLocalStorageService();
-        var service = new PageStateService(storage);
+        var config = new DevOpsConfigService(storage);
+        var service = new PageStateService(storage, config);
         await service.SaveAsync("key", new TestState { Value = 1 });
         var loaded = await service.LoadAsync<TestState>("key");
         Assert.NotNull(loaded);
         Assert.Equal(1, loaded!.Value);
+
+        var stored = await storage.GetItemAsync<TestState>("default-key");
+        Assert.NotNull(stored);
     }
 
     private class TestState

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -19,9 +19,10 @@ public abstract class ComponentTestBase : TestContext
         Services.AddMudServices();
         Services.AddLocalization();
         JSInterop.Mode = JSRuntimeMode.Loose;
-        var config = new DevOpsConfigService(new FakeLocalStorageService());
+        var storage = new FakeLocalStorageService();
+        var config = new DevOpsConfigService(storage);
         Services.AddSingleton(config);
-        Services.AddSingleton(new PageStateService(new FakeLocalStorageService()));
+        Services.AddSingleton(new PageStateService(storage, config));
         if (includeApi)
         {
             var deployment = new DeploymentConfigService(new HttpClient());

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -42,4 +42,10 @@
   <data name="ImportFrom" xml:space="preserve">
     <value>Importar De</value>
   </data>
+  <data name="DeleteProject" xml:space="preserve">
+    <value>Eliminar Proyecto</value>
+  </data>
+  <data name="ConfirmDelete" xml:space="preserve">
+    <value>Eliminar proyecto</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,4 +1,5 @@
 @inject DevOpsConfigService ConfigService
+@inject IJSRuntime JS
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
 @using DevOpsAssistant.Services
@@ -6,29 +7,36 @@
 <MudDialog ContentClass="pa-4" ActionsClass="pa-4">
     <DialogContent>
         <MudStack Spacing="2">
-            <MudSelect T="string" Value="_projectName" ValueChanged="OnProjectChanged" Label='@L["Project"]' Immediate="true">
+            <MudSelect T="string" Value="_selected" ValueChanged="OnProjectChanged" Label='@L["Project"]' Immediate="true">
                 @foreach (var p in ConfigService.Projects)
                 {
                     <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
                 }
+                <MudSelectItem Value="@NewProjectValue">@L["NewProject"]</MudSelectItem>
             </MudSelect>
-            <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
-            <MudExpansionPanels>
-                <MudExpansionPanel Text='@L["NewProject"]'>
-                    <MudTextField @bind-Value="_newProjectName" Label='@L["ProjectName"]' />
-                    @if (ConfigService.Projects.Count > 0)
-                    {
-                        <MudSelect T="string" Label='@L["ImportFrom"]' @bind-Value="_importFrom">
-                            <MudSelectItem Value="@string.Empty">None</MudSelectItem>
-                            @foreach (var p in ConfigService.Projects)
-                            {
-                                <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
-                            }
-                        </MudSelect>
-                    }
-                    <MudButton OnClick="CreateProject" Color="Color.Primary" Class="mt-2">@L["NewProject"]</MudButton>
-                </MudExpansionPanel>
-            </MudExpansionPanels>
+            @if (_creating)
+            {
+                <MudTextField @bind-Value="_newProjectName" Label='@L["ProjectName"]' />
+                @if (ConfigService.Projects.Count > 0)
+                {
+                    <MudSelect T="string" Label='@L["ImportFrom"]' @bind-Value="_importFrom">
+                        <MudSelectItem Value="@string.Empty">None</MudSelectItem>
+                        @foreach (var p in ConfigService.Projects)
+                        {
+                            <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                }
+                <MudStack Row="true" Spacing="1" Class="mt-2">
+                    <MudButton OnClick="CreateProject" Color="Color.Primary" Disabled="_newProjectName.Trim().Length < 2">@L["NewProject"]</MudButton>
+                    <MudButton OnClick="CancelNewProject" Color="Color.Secondary">Cancel</MudButton>
+                </MudStack>
+            }
+            else
+            {
+                <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
+                <MudButton OnClick="DeleteProject" Color="Color.Error" Disabled="ConfigService.Projects.Count == 1" Class="mt-2">@L["DeleteProject"]</MudButton>
+            }
         </MudStack>
         <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
@@ -94,14 +102,18 @@
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
 
+    private const string NewProjectValue = "__new";
     private DevOpsConfig _model = new();
-    private string _projectName = "";
-    private string _newProjectName = "";
-    private string _importFrom = "";
+    private string _selected = string.Empty;
+    private string _projectName = string.Empty;
+    private string _newProjectName = string.Empty;
+    private string _importFrom = string.Empty;
+    private bool _creating;
 
     protected override async Task OnInitializedAsync()
     {
         await ConfigService.LoadAsync();
+        _selected = ConfigService.CurrentProject.Name;
         _projectName = ConfigService.CurrentProject.Name;
         var cfg = ConfigService.Config;
         _model = new DevOpsConfig
@@ -158,6 +170,16 @@
 
     private void OnProjectChanged(string name)
     {
+        _selected = name;
+        if (name == NewProjectValue)
+        {
+            _creating = true;
+            _newProjectName = string.Empty;
+            _importFrom = string.Empty;
+            return;
+        }
+
+        _creating = false;
         ConfigService.SelectProject(name);
         _projectName = ConfigService.CurrentProject.Name;
         var cfg = ConfigService.Config;
@@ -186,6 +208,42 @@
         await ConfigService.AddProjectAsync(_newProjectName, copy);
         _newProjectName = string.Empty;
         _importFrom = string.Empty;
+        _creating = false;
+        _selected = ConfigService.CurrentProject.Name;
+        _projectName = ConfigService.CurrentProject.Name;
+        var cfg = ConfigService.Config;
+        _model = new DevOpsConfig
+        {
+            Organization = cfg.Organization,
+            Project = cfg.Project,
+            PatToken = cfg.PatToken,
+            MainBranch = cfg.MainBranch,
+            DefaultStates = cfg.DefaultStates,
+            DarkMode = cfg.DarkMode,
+            ReleaseNotesTreeView = cfg.ReleaseNotesTreeView,
+            DefinitionOfReady = cfg.DefinitionOfReady,
+            StoryQualityPrompt = cfg.StoryQualityPrompt,
+            ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
+            RequirementsPrompt = cfg.RequirementsPrompt,
+            PromptCharacterLimit = cfg.PromptCharacterLimit,
+            Rules = cfg.Rules
+        };
+    }
+
+    private void CancelNewProject()
+    {
+        _creating = false;
+        _selected = ConfigService.CurrentProject.Name;
+        _newProjectName = string.Empty;
+        _importFrom = string.Empty;
+    }
+
+    private async Task DeleteProject()
+    {
+        var ok = await JS.InvokeAsync<bool>("confirm", $"{L["ConfirmDelete"]} {_projectName}?");
+        if (!ok) return;
+        await ConfigService.RemoveProjectAsync(_projectName);
+        _selected = ConfigService.CurrentProject.Name;
         _projectName = ConfigService.CurrentProject.Name;
         var cfg = ConfigService.Config;
         _model = new DevOpsConfig

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -42,4 +42,10 @@
   <data name="ImportFrom" xml:space="preserve">
     <value>Import From</value>
   </data>
+  <data name="DeleteProject" xml:space="preserve">
+    <value>Delete Project</value>
+  </data>
+  <data name="ConfirmDelete" xml:space="preserve">
+    <value>Delete project</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -70,6 +70,18 @@ public class DevOpsConfigService
         await SaveProjectsAsync();
     }
 
+    public async Task RemoveProjectAsync(string name)
+    {
+        var proj = Projects.FirstOrDefault(p => p.Name == name);
+        if (proj == null) return;
+        Projects.Remove(proj);
+        if (Projects.Count == 0)
+            Projects.Add(new DevOpsProject { Name = "default" });
+        if (CurrentProject.Name == name)
+            CurrentProject = Projects[0];
+        await SaveProjectsAsync();
+    }
+
     public void SelectProject(string name)
     {
         var proj = Projects.FirstOrDefault(p => p.Name == name);

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PageStateService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PageStateService.cs
@@ -5,24 +5,28 @@ namespace DevOpsAssistant.Services;
 public class PageStateService
 {
     private readonly ILocalStorageService _localStorage;
+    private readonly DevOpsConfigService _configService;
 
-    public PageStateService(ILocalStorageService localStorage)
+    public PageStateService(ILocalStorageService localStorage, DevOpsConfigService configService)
     {
         _localStorage = localStorage;
+        _configService = configService;
     }
 
     public async Task SaveAsync<T>(string key, T state)
     {
-        await _localStorage.SetItemAsync(key, state);
+        await _localStorage.SetItemAsync(GetKey(key), state);
     }
 
     public async Task<T?> LoadAsync<T>(string key)
     {
-        return await _localStorage.GetItemAsync<T>(key);
+        return await _localStorage.GetItemAsync<T>(GetKey(key));
     }
 
     public async Task ClearAsync(string key)
     {
-        await _localStorage.RemoveItemAsync(key);
+        await _localStorage.RemoveItemAsync(GetKey(key));
     }
+
+    private string GetKey(string key) => $"{_configService.CurrentProject.Name}-{key}";
 }


### PR DESCRIPTION
## Summary
- refine Settings dialog UI for managing projects
- prefix page state keys with current project name
- add ability to remove projects
- adjust tests for new behavior

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685429f5c0088328840aa8883a8e6976