### PR TITLE
Improve onboarding for projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ The application communicates with Azure DevOps using a Personal Access Token (PA
    the **Work Items (Read & write)**, **Wiki (Read)** and **Code (Read)** scopes.
 4. Create the token and copy the value.
 
-Run the site and click the settings icon in the top right corner. Enter your organization, project and PAT token, then save. You can also specify a comma separated list of additional default states which will be pre-selected on the story screens. Each AI feature has a field for a custom prompt, allowing you to tailor the generated instructions. These values are stored in your browser's local storage.
-When you're done, click the **Sign Out** button in the top bar to clear the saved settings.
+Run the site and you'll see a welcome screen if no configuration is found. Click **Open Settings** to create your first project. Enter your organization, project and PAT token, then save. You can add more projects using the dropdown at the top of the settings dialog. A comma separated list of default states can also be provided and each AI feature has a field for a custom prompt. These values are stored in your browser's local storage.
+When you're done, click the **Sign Out** button in the top bar to remove the saved projects and return to the welcome screen.
 
 ## Faking the DevOps API for tests
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -35,7 +35,7 @@ public class MainLayoutTests : ComponentTestBase
 
         var cut = RenderComponent<MainLayout>();
 
-        Assert.Contains("Configuration Required", cut.Markup);
+        Assert.Contains("Create Your First Project", cut.Markup);
         Assert.Contains("mud-nav-link-disabled", cut.Markup);
     }
 
@@ -47,7 +47,7 @@ public class MainLayoutTests : ComponentTestBase
 
         var cut = RenderComponent<MainLayout>();
 
-        Assert.DoesNotContain("Configuration Required", cut.Markup);
+        Assert.DoesNotContain("Create Your First Project", cut.Markup);
         Assert.DoesNotContain("mud-nav-link-disabled", cut.Markup);
     }
 
@@ -60,7 +60,7 @@ public class MainLayoutTests : ComponentTestBase
         var cut = RenderComponent<MainLayout>();
         cut.Find("button[title='Sign Out']").Click();
 
-        Assert.Contains("Configuration Required", cut.Markup);
+        Assert.Contains("Create Your First Project", cut.Markup);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Crea tu primer proyecto</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Bienvenido a DevOpsAssistant. Abre la configuración para especificar tu organización, proyecto y token PAT. Puedes administrar varios proyectos y cambiar entre ellos en cualquier momento.</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>Abrir Configuración</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.razor
@@ -1,16 +1,12 @@
+@using Microsoft.Extensions.Localization
 @inject IDialogService DialogService
+@inject IStringLocalizer<SplashScreen> L
 
 <MudPaper Class="pa-4" Style="max-width:500px;margin:auto;">
-    <MudText Typo="Typo.h4" Class="mb-2">Configuration Required</MudText>
-    <MudText>
-        To use DevOpsAssistant you need to configure your Azure DevOps organization,
-        project and a Personal Access Token. You can create a token in Azure DevOps
-        under <b>User settings &gt; Personal access tokens</b>. When creating the
-        token, enable the <b>Work Items (Read &amp; write)</b> and
-        <b>Wiki (Read)</b> scopes.
-    </MudText>
+    <MudText Typo="Typo.h4" Class="mb-2">@L["Heading"]</MudText>
+    <MudText>@L["Intro"]</MudText>
     <MudButton StartIcon="@Icons.Material.Filled.Settings" Color="Color.Primary" Class="mt-4" OnClick="OpenSettings">
-        Open Settings
+        @L["OpenSettings"]
     </MudButton>
 </MudPaper>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SplashScreen.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Heading" xml:space="preserve">
+    <value>Create Your First Project</value>
+  </data>
+  <data name="Intro" xml:space="preserve">
+    <value>Welcome to DevOpsAssistant! Open the settings dialog to configure your organization, project and PAT token. You can manage multiple projects and switch between them at any time.</value>
+  </data>
+  <data name="OpenSettings" xml:space="preserve">
+    <value>Open Settings</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización, proyecto, token PAT y otras opciones utilizadas por el sitio. También puede personalizar los prompts y las reglas de validación.</value>
+    <value>Configure su organización, proyecto y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your organization, project, PAT token and other options used by the site. You can also customize prompts and validation rules.</value>
+    <value>Configure your organization, project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- add localized SplashScreen component for onboarding
- mention project onboarding in README
- update help page text about projects
- revise layout tests for new onboarding message

## Testing
- `dotnet format --no-restore --verbosity minimal`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685459162b7c8328a6b5b1869a40c5d8