### PR TITLE
Add project dropdown

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -2,6 +2,7 @@ using Bunit;
 using DevOpsAssistant.Layout;
 using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
+using System.Threading.Tasks;
 
 namespace DevOpsAssistant.Tests.Layout;
 
@@ -71,5 +72,20 @@ public class MainLayoutTests : ComponentTestBase
         var cut = RenderComponent<MainLayout>();
 
         cut.WaitForAssertion(() => Assert.Contains("Version 1.0", cut.Markup));
+    }
+
+    [Fact]
+    public async Task Project_Select_Changes_Current_Project()
+    {
+        var config = SetupServices();
+        await config.AddProjectAsync("One");
+        await config.AddProjectAsync("Two");
+        config.SelectProject("One");
+
+        var cut = RenderComponent<MainLayout>();
+        var method = typeof(MainLayout).GetMethod("ChangeProject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        await (Task)method.Invoke(cut.Instance, new object[] { "Two" })!;
+
+        Assert.Equal("Two", config.CurrentProject.Name);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -80,11 +80,12 @@ public class MainLayoutTests : ComponentTestBase
         var config = SetupServices();
         await config.AddProjectAsync("One");
         await config.AddProjectAsync("Two");
-        config.SelectProject("One");
+        await config.SelectProjectAsync("One");
+        JSInterop.Setup<bool>("confirm", _ => true).SetResult(true);
 
         var cut = RenderComponent<MainLayout>();
         var method = typeof(MainLayout).GetMethod("ChangeProject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        await (Task)method.Invoke(cut.Instance, new object[] { "Two" })!;
+        await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, new object[] { "Two" })!);
 
         Assert.Equal("Two", config.CurrentProject.Name);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -168,7 +168,7 @@
         MudDialog.Cancel();
     }
 
-    private void OnProjectChanged(string name)
+    private async Task OnProjectChanged(string name)
     {
         _selected = name;
         if (name == NewProjectValue)
@@ -180,7 +180,7 @@
         }
 
         _creating = false;
-        ConfigService.SelectProject(name);
+        await ConfigService.SelectProjectAsync(name);
         _projectName = ConfigService.CurrentProject.Name;
         var cfg = ConfigService.Config;
         _model = new DevOpsConfig

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -51,4 +51,10 @@
   <data name="Help" xml:space="preserve">
     <value>Ayuda</value>
   </data>
+  <data name="Project" xml:space="preserve">
+    <value>Proyecto</value>
+  </data>
+  <data name="ChangeProjectWarning" xml:space="preserve">
+    <value>Cambiar de proyecto descartará el estado actual. ¿Continuar?</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -113,7 +113,7 @@
             return;
         }
 
-        ConfigService.SelectProject(name);
+        await ConfigService.SelectProjectAsync(name);
         _selectedProject = ConfigService.CurrentProject.Name;
         StateHasChanged();
         NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -3,6 +3,8 @@
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
 @inject VersionService VersionService
+@inject NavigationManager NavigationManager
+@inject IJSRuntime JS
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<MainLayout> L
 
@@ -16,6 +18,12 @@
         <MudText Typo="Typo.h6" Class="ms-2 me-4">
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
+        <MudSelect T="string" Class="me-4" Label='@L["Project"]' Value="_selectedProject" ValueChanged="ChangeProject" Dense="true">
+            @foreach (var p in ConfigService.Projects)
+            {
+                <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
+            }
+        </MudSelect>
         <MudSpacer/>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" title='@L["Settings"]'/>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
@@ -61,11 +69,13 @@
 @code {
 
     private bool _drawerOpen = true;
+    private string _selectedProject = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
         await VersionService.LoadAsync();
         await ConfigService.LoadAsync();
+        _selectedProject = ConfigService.CurrentProject.Name;
         StateHasChanged();
     }
 
@@ -80,6 +90,7 @@
         var result = await dialog.Result;
         if (result != null && !result.Canceled)
         {
+            _selectedProject = ConfigService.CurrentProject.Name;
             StateHasChanged();
         }
     }
@@ -88,6 +99,24 @@
     {
         await ConfigService.ClearAsync();
         StateHasChanged();
+    }
+
+    private async Task ChangeProject(string name)
+    {
+        if (name == ConfigService.CurrentProject.Name)
+            return;
+
+        var ok = await JS.InvokeAsync<bool>("confirm", L["ChangeProjectWarning"]);
+        if (!ok)
+        {
+            _selectedProject = ConfigService.CurrentProject.Name;
+            return;
+        }
+
+        ConfigService.SelectProject(name);
+        _selectedProject = ConfigService.CurrentProject.Name;
+        StateHasChanged();
+        NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
     }
 
     private bool IsConfigMissing =>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -51,4 +51,10 @@
   <data name="Help" xml:space="preserve">
     <value>Help</value>
   </data>
+  <data name="Project" xml:space="preserve">
+    <value>Project</value>
+  </data>
+  <data name="ChangeProjectWarning" xml:space="preserve">
+    <value>Changing the project will clear the current page state. Continue?</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -82,10 +82,14 @@ public class DevOpsConfigService
         await SaveProjectsAsync();
     }
 
-    public void SelectProject(string name)
+    public async Task SelectProjectAsync(string name)
     {
         var proj = Projects.FirstOrDefault(p => p.Name == name);
-        if (proj != null) CurrentProject = proj;
+        if (proj == null) return;
+        Projects.Remove(proj);
+        Projects.Insert(0, proj);
+        CurrentProject = proj;
+        await SaveProjectsAsync();
     }
 
     private static DevOpsConfig Normalize(DevOpsConfig config)


### PR DESCRIPTION
## Summary
- add project selector to main toolbar
- reload layout when project changes
- show warning when changing project
- cover project selection logic in tests

## Testing
- `dotnet test DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj` *(fails: Determining projects to restore)*

------
https://chatgpt.com/codex/tasks/task_e_685519e58df08328bb2745317a822314