### PR TITLE
Fix project selector

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -41,4 +41,22 @@ public class SettingsDialogTests : ComponentTestBase
         Assert.False(model.Rules.Bug.IncludeSystemInfo);
         Assert.False(model.Rules.Bug.HasStoryPoints);
     }
+
+    [Fact]
+    public async Task Save_Does_Not_Change_Current_Project()
+    {
+        var config = SetupServices();
+        await config.AddProjectAsync("One");
+        await config.AddProjectAsync("Two");
+        await config.SelectProjectAsync("One");
+
+        var cut = RenderComponent<SettingsDialog>();
+        var change = typeof(SettingsDialog).GetMethod("OnProjectChanged", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await cut.InvokeAsync(() => (Task)change.Invoke(cut.Instance, new object[] { "Two" })!);
+
+        var save = typeof(SettingsDialog).GetMethod("Save", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await cut.InvokeAsync(() => (Task)save.Invoke(cut.Instance, null)!);
+
+        Assert.Equal("One", config.CurrentProject.Name);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/SettingsDialogTests.cs
@@ -52,7 +52,7 @@ public class SettingsDialogTests : ComponentTestBase
 
         var cut = RenderComponent<SettingsDialog>();
         var change = typeof(SettingsDialog).GetMethod("OnProjectChanged", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        await cut.InvokeAsync(() => (Task)change.Invoke(cut.Instance, new object[] { "Two" })!);
+        await cut.InvokeAsync(() => change.Invoke(cut.Instance, new object[] { "Two" }));
 
         var save = typeof(SettingsDialog).GetMethod("Save", BindingFlags.NonPublic | BindingFlags.Instance)!;
         await cut.InvokeAsync(() => (Task)save.Invoke(cut.Instance, null)!);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -1,4 +1,5 @@
 using DevOpsAssistant.Services;
+using System.Linq;
 
 namespace DevOpsAssistant.Tests;
 
@@ -197,5 +198,22 @@ public class DevOpsConfigServiceTests
 
         Assert.DoesNotContain(service.Projects, p => p.Name == "proj2");
         Assert.Equal("default", service.CurrentProject.Name);
+    }
+
+    [Fact]
+    public async Task UpdateProjectAsync_Updates_Project_Without_Changing_Current()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("one");
+        await service.AddProjectAsync("two");
+        await service.SelectProjectAsync("one");
+
+        var cfg = new DevOpsConfig { Organization = "Org" };
+        await service.UpdateProjectAsync("two", "two", cfg);
+
+        Assert.Equal("one", service.CurrentProject.Name);
+        var other = service.Projects.First(p => p.Name == "two");
+        Assert.Equal("Org", other.Config.Organization);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -176,7 +176,7 @@
         MudDialog.Cancel();
     }
 
-    private async Task OnProjectChanged(string name)
+    private void OnProjectChanged(string name)
     {
         _selected = name;
         if (name == NewProjectValue)

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -168,7 +168,7 @@
         {
             await ConfigService.UpdateProjectAsync(_selected, _projectName, _model);
         }
-        MudDialog.Close(DialogResult.Ok(true));
+        MudDialog?.Close(DialogResult.Ok(true));
     }
 
     private void Cancel()

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -2,6 +2,7 @@
 @inject IJSRuntime JS
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
+@using System.Linq
 @using DevOpsAssistant.Services
 
 <MudDialog ContentClass="pa-4" ActionsClass="pa-4">
@@ -159,7 +160,14 @@
 
     private async Task Save()
     {
-        await ConfigService.SaveCurrentAsync(_projectName, _model);
+        if (_selected == ConfigService.CurrentProject.Name)
+        {
+            await ConfigService.SaveCurrentAsync(_projectName, _model);
+        }
+        else
+        {
+            await ConfigService.UpdateProjectAsync(_selected, _projectName, _model);
+        }
         MudDialog.Close(DialogResult.Ok(true));
     }
 
@@ -180,9 +188,9 @@
         }
 
         _creating = false;
-        await ConfigService.SelectProjectAsync(name);
-        _projectName = ConfigService.CurrentProject.Name;
-        var cfg = ConfigService.Config;
+        var proj = ConfigService.Projects.First(p => p.Name == name);
+        _projectName = proj.Name;
+        var cfg = proj.Config;
         _model = new DevOpsConfig
         {
             Organization = cfg.Organization,

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -18,13 +18,13 @@
         <MudText Typo="Typo.h6" Class="ms-2 me-4">
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
-        <MudSelect T="string" Class="me-4" Label='@L["Project"]' Value="_selectedProject" ValueChanged="ChangeProject" Dense="true">
+        <MudSpacer/>
+        <MudSelect T="string" Class="me-2" Style="width:150px" Label='@L["Project"]' Value="_selectedProject" ValueChanged="ChangeProject" Dense="true" Immediate="true">
             @foreach (var p in ConfigService.Projects)
             {
                 <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
             }
         </MudSelect>
-        <MudSpacer/>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" title='@L["Settings"]'/>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -58,6 +58,15 @@ public class DevOpsConfigService
         await SaveProjectsAsync();
     }
 
+    public async Task UpdateProjectAsync(string existingName, string newName, DevOpsConfig config)
+    {
+        var proj = Projects.FirstOrDefault(p => p.Name == existingName);
+        if (proj == null) return;
+        proj.Name = newName.Trim();
+        proj.Config = Normalize(config);
+        await SaveProjectsAsync();
+    }
+
     public async Task AddProjectAsync(string name, DevOpsProject? source = null)
     {
         var project = new DevOpsProject


### PR DESCRIPTION
## Summary
- adjust MainLayout to move project selector to the right side
- keep current project when saving settings for another project
- expose `UpdateProjectAsync` for editing non-current projects
- test project updates and ensure settings saves don't change project

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`
- `STAGING_URL=http://localhost dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --no-build --verbosity minimal` *(fails: argument invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68556d608da88328a3b39f00bfb5e589