### PR TITLE
Fix project selector

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -106,10 +106,12 @@
         if (name == ConfigService.CurrentProject.Name)
             return;
 
+        _selectedProject = name;
         var ok = await JS.InvokeAsync<bool>("confirm", L["ChangeProjectWarning"]);
         if (!ok)
         {
             _selectedProject = ConfigService.CurrentProject.Name;
+            StateHasChanged();
             return;
         }
 


### PR DESCRIPTION
## Summary
- ensure MainLayout updates `_selectedProject` before the confirmation dialog
- restore original selection when user cancels

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6855830a39288328b1318f17a7287595