### PR TITLE
Fix project selector confirm dialog

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -81,11 +81,12 @@ public class MainLayoutTests : ComponentTestBase
         await config.AddProjectAsync("One");
         await config.AddProjectAsync("Two");
         await config.SelectProjectAsync("One");
-        JSInterop.Setup<bool>("confirm", _ => true).SetResult(true);
-
         var cut = RenderComponent<MainLayout>();
         var method = typeof(MainLayout).GetMethod("ChangeProject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
-        await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, new object[] { "Two" })!);
+        var task = cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, new object[] { "Two" })!);
+        var dialog = cut.WaitForElement("div.mud-dialog");
+        dialog.GetElementsByTagName("button")[0].Click();
+        await task;
 
         Assert.Equal("Two", config.CurrentProject.Name);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.es.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Ok" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.razor
@@ -1,0 +1,21 @@
+@using Microsoft.Extensions.Localization
+@using MudBlazor
+@inject IStringLocalizer<ConfirmDialog> L
+
+<MudDialog>
+    <DialogContent>
+        <MudText>@Message</MudText>
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Confirm" Color="Color.Primary">@L["Ok"]</MudButton>
+        <MudButton OnClick="Cancel">@L["Cancel"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public string Message { get; set; } = string.Empty;
+
+    private void Confirm() => MudDialog.Close(DialogResult.Ok(true));
+    private void Cancel() => MudDialog.Cancel();
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ConfirmDialog.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -48,4 +48,7 @@
   <data name="ConfirmDelete" xml:space="preserve">
     <value>Eliminar proyecto</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,5 +1,5 @@
 @inject DevOpsConfigService ConfigService
-@inject IJSRuntime JS
+@inject IDialogService DialogService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
 @using System.Linq
@@ -249,8 +249,10 @@
 
     private async Task DeleteProject()
     {
-        var ok = await JS.InvokeAsync<bool>("confirm", $"{L["ConfirmDelete"]} {_projectName}?");
-        if (!ok) return;
+        var parameters = new DialogParameters { ["Message"] = $"{L["ConfirmDelete"].Value} {_projectName}?" };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result.Canceled) return;
         await ConfigService.RemoveProjectAsync(_projectName);
         _selected = ConfigService.CurrentProject.Name;
         _projectName = ConfigService.CurrentProject.Name;

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -48,4 +48,7 @@
   <data name="ConfirmDelete" xml:space="preserve">
     <value>Delete project</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -57,4 +57,7 @@
   <data name="ChangeProjectWarning" xml:space="preserve">
     <value>Cambiar de proyecto descartará el estado actual. ¿Continuar?</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -107,8 +107,10 @@
             return;
 
         _selectedProject = name;
-        var ok = await JS.InvokeAsync<bool>("confirm", L["ChangeProjectWarning"]);
-        if (!ok)
+        var parameters = new DialogParameters { ["Message"] = L["ChangeProjectWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result.Canceled)
         {
             _selectedProject = ConfigService.CurrentProject.Name;
             StateHasChanged();

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -57,4 +57,7 @@
   <data name="ChangeProjectWarning" xml:space="preserve">
     <value>Changing the project will clear the current page state. Continue?</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add reusable `ConfirmDialog` component
- show `ConfirmDialog` instead of browser confirm
- localize new dialog
- adjust tests for dialog workflow

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855afc94a4c8328be71eff175795d51