### PR TITLE
Add project selection pages

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/NewProjectPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/NewProjectPageTests.cs
@@ -1,0 +1,16 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class NewProjectPageTests : ComponentTestBase
+{
+    [Fact]
+    public void NewProject_Renders()
+    {
+        SetupServices();
+        var cut = RenderComponent<NewProject>();
+        Assert.Contains("New Project", cut.Markup);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectsListPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectsListPageTests.cs
@@ -1,0 +1,21 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class ProjectsListPageTests : ComponentTestBase
+{
+    [Fact]
+    public void ProjectsList_Shows_Projects()
+    {
+        var config = SetupServices();
+        config.AddProjectAsync("One").GetAwaiter().GetResult();
+        config.AddProjectAsync("Two").GetAwaiter().GetResult();
+
+        var cut = RenderComponent<ProjectsList>();
+
+        Assert.Contains("One", cut.Markup);
+        Assert.Contains("Two", cut.Markup);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -19,13 +19,14 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer/>
-        <MudSelect T="string" Class="me-2" Style="width:150px" Label='@L["Project"]' Value="_selectedProject" ValueChanged="ChangeProject" Dense="true" Immediate="true">
+        <MudMenu Text='@L["Projects"]' Class="me-2">
             @foreach (var p in ConfigService.Projects)
             {
-                <MudSelectItem Value="@p.Name">@p.Name</MudSelectItem>
+                <MudMenuItem OnClick="() => ChangeProject(p.Name)">@p.Name</MudMenuItem>
             }
-        </MudSelect>
-        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenSettings" title='@L["Settings"]'/>
+            <MudDivider />
+            <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
+        </MudMenu>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>
 
@@ -43,6 +44,7 @@
                 <MudNavLink Href="metrics" Icon="@Icons.Material.Filled.Insights" Disabled="@IsConfigMissing">@L["Metrics"]</MudNavLink>
                 <MudNavLink Href="branch-health" Icon="@Icons.Material.Filled.Source" Disabled="@IsConfigMissing">@L["BranchHealth"]</MudNavLink>
             </MudNavGroup>
+            <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings" Disabled="@IsConfigMissing">@L["Settings"]</MudNavLink>
             <MudNavLink Href="help" Icon="@Icons.Material.Filled.Help">@L["Help"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
@@ -84,16 +86,6 @@
         _drawerOpen = !_drawerOpen;
     }
 
-    private async Task OpenSettings()
-    {
-        var dialog = await DialogService.ShowAsync<SettingsDialog>("Settings");
-        var result = await dialog.Result;
-        if (result != null && !result.Canceled)
-        {
-            _selectedProject = ConfigService.CurrentProject.Name;
-            StateHasChanged();
-        }
-    }
 
     private async Task SignOut()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -1,6 +1,9 @@
 @page "/"
+@page "/projects/{ProjectName}"
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Home> L
+@inject DevOpsAssistant.Services.DevOpsConfigService ConfigService
+@inject NavigationManager NavigationManager
 
 <PageTitle>DevOpsAssistant - Home</PageTitle>
 
@@ -23,3 +26,17 @@
         </MudPaper>
     </MudItem>
 </MudGrid>
+
+@code {
+    [Parameter] public string? ProjectName { get; set; }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ConfigService.LoadAsync();
+        if (!string.IsNullOrWhiteSpace(ProjectName) && ConfigService.CurrentProject.Name != ProjectName)
+        {
+            await ConfigService.SelectProjectAsync(ProjectName);
+            NavigationManager.NavigateTo(NavigationManager.Uri.Replace($"/projects/{ProjectName}", "/"), forceLoad: true);
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -1,0 +1,30 @@
+@page "/projects/new"
+@using DevOpsAssistant.Services
+@using DevOpsAssistant.Components
+@inject DevOpsConfigService ConfigService
+@inject NavigationManager NavigationManager
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SettingsDialog> L
+
+<PageTitle>DevOpsAssistant - New Project</PageTitle>
+
+<MudPaper Class="p-4">
+    <MudText Typo="Typo.h5" Class="mb-2">@L["NewProject"]</MudText>
+    <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
+    <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2" Class="mt-2">@L["Create"]</MudButton>
+</MudPaper>
+
+@code {
+    private string _name = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ConfigService.LoadAsync();
+    }
+
+    private async Task Create()
+    {
+        await ConfigService.AddProjectAsync(_name);
+        NavigationManager.NavigateTo($"/projects/{_name}", forceLoad: true);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -1,0 +1,44 @@
+@page "/projects/{ProjectName}/settings"
+@inject DevOpsConfigService ConfigService
+@using DevOpsAssistant.Services.Models
+@using DevOpsAssistant.Components
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SettingsDialog> L
+
+<PageTitle>DevOpsAssistant - Settings</PageTitle>
+
+<MudPaper Class="p-4">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h5">@L["ProjectSettings"] @ProjectName</MudText>
+        <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
+        <MudTabs Class="mt-4">
+            <MudTabPanel Text="General">
+                <MudStack Spacing="2">
+                    <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
+                    <MudTextField @bind-Value="_model.Project" Label="Project"/>
+                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password"/>
+                </MudStack>
+            </MudTabPanel>
+        </MudTabs>
+        <MudButton OnClick="Save" Color="Color.Primary" Class="mt-2">Save</MudButton>
+    </MudStack>
+</MudPaper>
+
+@code {
+    [Parameter] public string ProjectName { get; set; } = string.Empty;
+    private string _projectName = string.Empty;
+    private DevOpsConfig _model = new();
+
+    protected override async Task OnParametersSetAsync()
+    {
+        await ConfigService.LoadAsync();
+        await ConfigService.SelectProjectAsync(ProjectName);
+        _projectName = ConfigService.CurrentProject.Name;
+        _model = ConfigService.Config;
+    }
+
+    private async Task Save()
+    {
+        await ConfigService.SaveCurrentAsync(_projectName, _model);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
@@ -1,0 +1,31 @@
+@page "/projects"
+@using DevOpsAssistant.Services
+@inject DevOpsConfigService ConfigService
+@inject NavigationManager NavigationManager
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Home> L
+
+<PageTitle>DevOpsAssistant - Projects</PageTitle>
+
+<MudPaper Class="p-4">
+    <MudText Typo="Typo.h5" Class="mb-2">@L["Project"]</MudText>
+    <MudList T="string">
+        @foreach (var p in ConfigService.Projects)
+        {
+            <MudListItem T="string" Style="cursor:pointer" OnClick="() => OpenProject(p.Name)">@p.Name</MudListItem>
+        }
+    </MudList>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/projects/new" Class="mt-2">@L["NewProject"]</MudButton>
+</MudPaper>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        await ConfigService.LoadAsync();
+    }
+
+    private void OpenProject(string name)
+    {
+        NavigationManager.NavigateTo($"/projects/{name}");
+    }
+}


### PR DESCRIPTION
## Summary
- add project list route and new project onboarding
- move settings to dedicated page
- update main layout with Projects menu
- support project route in home page
- test new project pages

## Testing
- `dotnet format --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855b961cc688328ada34b1ce3e67722