### PR TITLE
Fix build warnings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectsListPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectsListPageTests.cs
@@ -7,11 +7,11 @@ namespace DevOpsAssistant.Tests.Pages;
 public class ProjectsListPageTests : ComponentTestBase
 {
     [Fact]
-    public void ProjectsList_Shows_Projects()
+    public async Task ProjectsList_Shows_Projects()
     {
         var config = SetupServices();
-        config.AddProjectAsync("One").GetAwaiter().GetResult();
-        config.AddProjectAsync("Two").GetAwaiter().GetResult();
+        await config.AddProjectAsync("One");
+        await config.AddProjectAsync("Two");
 
         var cut = RenderComponent<ProjectsList>();
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -252,7 +252,7 @@
         var parameters = new DialogParameters { ["Message"] = $"{L["ConfirmDelete"].Value} {_projectName}?" };
         var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
         var result = await dialog.Result;
-        if (result.Canceled) return;
+        if (result?.Canceled != false) return;
         await ConfigService.RemoveProjectAsync(_projectName);
         _selected = ConfigService.CurrentProject.Name;
         _projectName = ConfigService.CurrentProject.Name;

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -1,4 +1,4 @@
-﻿@using DevOpsAssistant.Components
+@using DevOpsAssistant.Components
 @inherits LayoutComponentBase
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
@@ -19,7 +19,7 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer/>
-        <MudMenu Text='@L["Projects"]' Class="me-2">
+        <MudMenu Label='@L["Projects"]' Class="me-2">
             @foreach (var p in ConfigService.Projects)
             {
                 <MudMenuItem OnClick="() => ChangeProject(p.Name)">@p.Name</MudMenuItem>
@@ -102,7 +102,7 @@
         var parameters = new DialogParameters { ["Message"] = L["ChangeProjectWarning"].Value };
         var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
         var result = await dialog.Result;
-        if (result.Canceled)
+        if (result?.Canceled != false)
         {
             _selectedProject = ConfigService.CurrentProject.Name;
             StateHasChanged();


### PR DESCRIPTION
## Summary
- clean up nullability warnings in `SettingsDialog` and `MainLayout`
- modernize `ProjectsListPageTests` to use async/await
- swap MudMenu `Text` parameter for `Label`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `STAGING_URL=http://localhost dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --no-build --verbosity normal` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_6855c1b301a08328a94d34c186912836