### PR TITLE
Improve layout and PAT token management

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.es.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PatToken" xml:space="preserve">
+    <value>Token PAT</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Guardar</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancelar</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.razor
@@ -1,0 +1,36 @@
+@inject DevOpsConfigService ConfigService
+@inject IDialogService DialogService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<PatTokenDialog> L
+
+<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
+    <DialogContent>
+        <MudTextField @bind-Value="_token" Label='@L["PatToken"]' InputType="InputType.Password" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Save" Color="Color.Primary">@L["Save"]</MudButton>
+        <MudButton OnClick="Cancel" Color="Color.Secondary">@L["Cancel"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    private string _token = string.Empty;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ConfigService.LoadAsync();
+        _token = ConfigService.GlobalPatToken;
+    }
+
+    private async Task Save()
+    {
+        await ConfigService.SaveGlobalPatAsync(_token);
+        MudDialog.Close(DialogResult.Ok(true));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.resx
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PatToken" xml:space="preserve">
+    <value>PAT Token</value>
+  </data>
+  <data name="Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -45,7 +45,7 @@
                 <MudStack Spacing="2">
                     <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
                     <MudTextField @bind-Value="_model.Project" Label="Project"/>
-                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password"/>
+                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
                     <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -36,6 +36,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
   </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>Token PAT</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Configuración</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -27,6 +27,7 @@
             <MudDivider />
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
         </MudMenu>
+        <MudIconButton Icon="@Icons.Material.Filled.VpnKey" OnClick="OpenPatDialog" title='@L["PatToken"]' class="me-2"/>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>
 
@@ -86,6 +87,11 @@
         StateHasChanged();
     }
 
+    private async Task OpenPatDialog()
+    {
+        await DialogService.ShowAsync<PatTokenDialog>(L["PatToken"]);
+    }
+
     private async Task ChangeProject(string name)
     {
         if (name == ConfigService.CurrentProject.Name)
@@ -127,6 +133,6 @@
     private bool IsConfigMissing =>
         string.IsNullOrWhiteSpace(ConfigService.Config.Organization) ||
         string.IsNullOrWhiteSpace(ConfigService.Config.Project) ||
-        string.IsNullOrWhiteSpace(ConfigService.Config.PatToken);
+        (string.IsNullOrWhiteSpace(ConfigService.Config.PatToken) && string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken));
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -36,6 +36,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
   </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>PAT Token</value>
+  </data>
   <data name="Settings" xml:space="preserve">
     <value>Settings</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SignOut" xml:space="preserve">
+    <value>Cerrar sesión</value>
+  </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>Token PAT</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -1,0 +1,52 @@
+@using DevOpsAssistant.Components
+@inherits LayoutComponentBase
+@inject IDialogService DialogService
+@inject DevOpsConfigService ConfigService
+@inject VersionService VersionService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<SimpleLayout> L
+
+<MudThemeProvider IsDarkMode="@ConfigService.Config.DarkMode"/>
+<MudDialogProvider/>
+<MudPopoverProvider/>
+
+<MudLayout>
+    <MudAppBar Color="Color.Primary" Elevation="1">
+        <MudText Typo="Typo.h6" Class="ms-2 me-4">
+            <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
+        </MudText>
+        <MudSpacer/>
+        <MudIconButton Icon="@Icons.Material.Filled.VpnKey" OnClick="OpenPatDialog" title='@L["PatToken"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
+    </MudAppBar>
+
+    <MudMainContent>
+        <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
+            @Body
+        </MudContainer>
+    </MudMainContent>
+    <footer>
+        <MudText Typo="Typo.caption" Align="Align.Center" Class="pa-2">
+            Version @VersionService.Version
+        </MudText>
+    </footer>
+</MudLayout>
+
+@code {
+    protected override async Task OnInitializedAsync()
+    {
+        await VersionService.LoadAsync();
+        await ConfigService.LoadAsync();
+    }
+
+    private async Task SignOut()
+    {
+        await ConfigService.ClearAsync();
+        StateHasChanged();
+    }
+
+    private async Task OpenPatDialog()
+    {
+        await DialogService.ShowAsync<PatTokenDialog>(L["PatToken"]);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SignOut" xml:space="preserve">
+    <value>Sign Out</value>
+  </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>PAT Token</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -44,8 +44,7 @@ else
         await ConfigService.LoadAsync();
         var anyConfigured = ConfigService.Projects.Any(p =>
             !string.IsNullOrWhiteSpace(p.Config.Organization) &&
-            !string.IsNullOrWhiteSpace(p.Config.Project) &&
-            !string.IsNullOrWhiteSpace(p.Config.PatToken));
+            !string.IsNullOrWhiteSpace(p.Config.Project));
 
         if (!anyConfigured)
         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -1,4 +1,5 @@
 @page "/projects/new"
+@layout SimpleLayout
 @using DevOpsAssistant.Services
 @using DevOpsAssistant.Components
 @inject DevOpsConfigService ConfigService

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -16,7 +16,7 @@
                 <MudStack Spacing="2">
                     <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
                     <MudTextField @bind-Value="_model.Project" Label="Project"/>
-                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password"/>
+                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
                 </MudStack>
             </MudTabPanel>
         </MudTabs>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
@@ -1,4 +1,5 @@
 @page "/projects"
+@layout SimpleLayout
 @using DevOpsAssistant.Services
 @inject DevOpsConfigService ConfigService
 @inject NavigationManager NavigationManager

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -52,7 +52,7 @@ public class DevOpsApiService
 
     private DevOpsConfig GetValidatedConfig()
     {
-        var config = _configService.Config;
+        var config = _configService.GetEffectiveConfig();
         if (string.IsNullOrWhiteSpace(config.Organization) ||
             string.IsNullOrWhiteSpace(config.Project) ||
             string.IsNullOrWhiteSpace(config.PatToken))

--- a/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
@@ -1,4 +1,4 @@
-﻿@using System.Net.Http
+@using System.Net.Http
 @using System.Net.Http.Json
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing


### PR DESCRIPTION
## Summary
- add a `SimpleLayout` without the project menu
- add `PatTokenDialog` for global PAT configuration
- support global PAT token in `DevOpsConfigService` and API service
- update project pages to use the new layout
- expose PAT dialog in the main layout

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685681abc1208328bbbfd42729846367