### PR TITLE
Add user feedback toast messages

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.es.resx
@@ -21,4 +21,7 @@
   <data name="Cancel" xml:space="preserve">
     <value>Cancelar</value>
   </data>
+  <data name="SavedMessage" xml:space="preserve">
+    <value>Token guardado</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PatTokenDialog.razor
@@ -1,5 +1,6 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
+@inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<PatTokenDialog> L
 
@@ -26,6 +27,7 @@
     private async Task Save()
     {
         await ConfigService.SaveGlobalPatAsync(_token);
+        Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
         MudDialog.Close(DialogResult.Ok(true));
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -51,4 +51,7 @@
   <data name="Confirm" xml:space="preserve">
     <value>Confirmar</value>
   </data>
+  <data name="SavedMessage" xml:space="preserve">
+    <value>Configuración guardada</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -1,5 +1,6 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
+@inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
 @using System.Linq
@@ -169,6 +170,7 @@
         {
             await ConfigService.UpdateProjectAsync(_selected, _projectName, _model);
         }
+        Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
         MudDialog?.Close(DialogResult.Ok(true));
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -51,4 +51,7 @@
   <data name="Confirm" xml:space="preserve">
     <value>Confirm</value>
   </data>
+  <data name="SavedMessage" xml:space="preserve">
+    <value>Settings saved</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -11,6 +11,7 @@
 <MudThemeProvider IsDarkMode="@ConfigService.Config.DarkMode"/>
 <MudDialogProvider/>
 <MudPopoverProvider/>
+<MudSnackbarProvider/>
 
 <MudLayout>
     <MudAppBar Color="Color.Primary" Elevation="1">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -9,6 +9,7 @@
 <MudThemeProvider IsDarkMode="@ConfigService.Config.DarkMode"/>
 <MudDialogProvider/>
 <MudPopoverProvider/>
+<MudSnackbarProvider/>
 
 <MudLayout>
     <MudAppBar Color="Color.Primary" Elevation="1">

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -4,6 +4,7 @@
 @using DevOpsAssistant.Components
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
+@inject ISnackbar Snackbar
 
 <PageTitle>DevOpsAssistant - Settings</PageTitle>
 
@@ -40,5 +41,6 @@
     private async Task Save()
     {
         await ConfigService.SaveCurrentAsync(_projectName, _model);
+        Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
@@ -12,16 +12,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="PatToken" xml:space="preserve">
-    <value>PAT Token</value>
-  </data>
-  <data name="Save" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="SavedMessage" xml:space="preserve">
-    <value>Token saved</value>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copiado al portapapeles</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -10,6 +10,9 @@
 @inject IJSRuntime JS
 @inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
+@inject ISnackbar Snackbar
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<ReleaseNotes> L
 
 <PageTitle>DevOpsAssistant - Release Notes</PageTitle>
 
@@ -260,12 +263,16 @@ else if (_promptParts != null)
     private async Task CopyPrompt()
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
+        {
             await JS.InvokeVoidAsync("copyText", _prompt);
+            Snackbar.Add(L["CopyToast"].Value, Severity.Success);
+        }
     }
 
     private async Task CopyPart(string text)
     {
         await JS.InvokeVoidAsync("copyText", text);
+        Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
     private void PrevPart()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
@@ -12,16 +12,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="PatToken" xml:space="preserve">
-    <value>PAT Token</value>
-  </data>
-  <data name="Save" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="SavedMessage" xml:space="preserve">
-    <value>Token saved</value>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copied to clipboard</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -30,4 +30,7 @@
   <data name="CopyPromptMessage" xml:space="preserve">
     <value>Péguelo en su LLM para comenzar a recopilar requisitos.</value>
   </data>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copiado al portapapeles</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -10,6 +10,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<RequirementsPlanner> L
 
@@ -339,17 +340,22 @@ Define what success looks like — business or system-level outcomes.
     private async Task CopyPrompt()
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
+        {
             await JS.InvokeVoidAsync("copyText", _prompt);
+            Snackbar.Add(L["CopyToast"].Value, Severity.Success);
+        }
     }
 
     private async Task CopyInitialPrompt()
     {
         await JS.InvokeVoidAsync("copyText", InitialPrompt);
+        Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
     private async Task CopyPart(string text)
     {
         await JS.InvokeVoidAsync("copyText", text);
+        Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
     private void PrevPart()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -30,4 +30,7 @@
   <data name="CopyPromptMessage" xml:space="preserve">
     <value>Paste it into your LLM to begin capturing requirements.</value>
   </data>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copied to clipboard</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.es.resx
@@ -12,16 +12,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="PatToken" xml:space="preserve">
-    <value>PAT Token</value>
-  </data>
-  <data name="Save" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="SavedMessage" xml:space="preserve">
-    <value>Token saved</value>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copiado al portapapeles</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -8,6 +8,9 @@
 @inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@inject ISnackbar Snackbar
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<StoryReview> L
 
 <PageTitle>DevOpsAssistant - Story Quality</PageTitle>
 
@@ -129,12 +132,16 @@ else if (_promptParts != null)
     private async Task CopyPrompt()
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
+        {
             await JS.InvokeVoidAsync("copyText", _prompt);
+            Snackbar.Add(L["CopyToast"].Value, Severity.Success);
+        }
     }
 
     private async Task CopyPart(string text)
     {
         await JS.InvokeVoidAsync("copyText", text);
+        Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
     private void PrevPart()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.resx
@@ -12,16 +12,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="PatToken" xml:space="preserve">
-    <value>PAT Token</value>
-  </data>
-  <data name="Save" xml:space="preserve">
-    <value>Save</value>
-  </data>
-  <data name="Cancel" xml:space="preserve">
-    <value>Cancel</value>
-  </data>
-  <data name="SavedMessage" xml:space="preserve">
-    <value>Token saved</value>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copied to clipboard</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- enable snackbar provider
- add snackbar usage for copying text and saving settings
- add localized strings for the new toasts
- include small Razor updates

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6856885a821883288290cdbe6aa367d2