### PR TITLE
Enforce config setup flow

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -102,6 +102,6 @@ public class MainLayoutTests : ComponentTestBase
         dialog.GetElementsByTagName("button")[0].Click();
         await task;
 
-        Assert.EndsWith("/", nav.Uri);
+        Assert.Equal("http://localhost/projects/Two/settings", nav.Uri);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -36,6 +36,9 @@
   <data name="ProjectName" xml:space="preserve">
     <value>Nombre del Proyecto</value>
   </data>
+  <data name="Organization" xml:space="preserve">
+    <value>Organización</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>Nuevo Proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -36,6 +36,9 @@
   <data name="ProjectName" xml:space="preserve">
     <value>Project Name</value>
   </data>
+  <data name="Organization" xml:space="preserve">
+    <value>Organization</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>New Project</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -67,6 +67,11 @@
     private bool _drawerOpen = true;
     private string _selectedProject = string.Empty;
 
+    protected override void OnAfterRender(bool firstRender)
+    {
+        EnsureSettingsIfNeeded();
+    }
+
     protected override async Task OnInitializedAsync()
     {
         await VersionService.LoadAsync();
@@ -111,6 +116,7 @@
         await ConfigService.SelectProjectAsync(name);
         _selectedProject = ConfigService.CurrentProject.Name;
         StateHasChanged();
+        EnsureSettingsIfNeeded();
 
         var relative = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
         if (relative.StartsWith("projects/"))
@@ -127,6 +133,17 @@
         else
         {
             NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+        }
+    }
+
+    private void EnsureSettingsIfNeeded()
+    {
+        var relative = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        if (IsConfigMissing &&
+            !relative.StartsWith("projects/new") &&
+            !relative.EndsWith("/settings"))
+        {
+            NavigationManager.NavigateTo($"/projects/{_selectedProject}/settings", true);
         }
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -42,11 +42,9 @@ else
     protected override async Task OnParametersSetAsync()
     {
         await ConfigService.LoadAsync();
-        var anyConfigured = ConfigService.Projects.Any(p =>
-            !string.IsNullOrWhiteSpace(p.Config.Organization) &&
-            !string.IsNullOrWhiteSpace(p.Config.Project));
+        var anyProjects = ConfigService.Projects.Any();
 
-        if (!anyConfigured)
+        if (!anyProjects)
         {
             NavigationManager.NavigateTo("/projects/new", true);
             return;

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -12,11 +12,15 @@
 <MudPaper Class="p-4">
     <MudText Typo="Typo.h5" Class="mb-2">@L["NewProject"]</MudText>
     <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
-    <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2" Class="mt-2">@L["Create"]</MudButton>
+    <MudTextField @bind-Value="_organization" Label="Organization" Class="mt-2" />
+    <MudTextField @bind-Value="_project" Label="Project" Class="mt-2" />
+    <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)" Class="mt-2">@L["Create"]</MudButton>
 </MudPaper>
 
 @code {
     private string _name = string.Empty;
+    private string _organization = string.Empty;
+    private string _project = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -26,6 +30,11 @@
     private async Task Create()
     {
         await ConfigService.AddProjectAsync(_name);
+        await ConfigService.SaveAsync(new DevOpsConfig
+        {
+            Organization = _organization,
+            Project = _project
+        });
         NavigationManager.NavigateTo($"/projects/{_name}", forceLoad: true);
     }
 }


### PR DESCRIPTION
## Summary
- show new project page only if no projects exist
- redirect to project settings when config missing
- ask for organization & project when creating a project
- localize Organization label
- update navigation change test for new behaviour

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685688efdaf08328a5bdbe8e6cadaf89