### PR TITLE
Clarify devops org/project text

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -44,8 +44,8 @@
         <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
-                    <MudTextField @bind-Value="_model.Project" Label="Project"/>
+                    <MudTextField @bind-Value="_model.Organization" Label="DevOps Organization"/>
+                    <MudTextField @bind-Value="_model.Project" Label="DevOps Project"/>
                     <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización, proyecto y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
+    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your organization, project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
+    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -12,8 +12,8 @@
 <MudPaper Class="p-4">
     <MudText Typo="Typo.h5" Class="mb-2">@L["NewProject"]</MudText>
     <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
-    <MudTextField @bind-Value="_organization" Label="Organization" Class="mt-2" />
-    <MudTextField @bind-Value="_project" Label="Project" Class="mt-2" />
+    <MudTextField @bind-Value="_organization" Label="DevOps Organization" Class="mt-2" />
+    <MudTextField @bind-Value="_project" Label="DevOps Project" Class="mt-2" />
     <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)" Class="mt-2">@L["Create"]</MudButton>
 </MudPaper>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -15,8 +15,8 @@
         <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
-                    <MudTextField @bind-Value="_model.Project" Label="Project"/>
+                    <MudTextField @bind-Value="_model.Organization" Label="DevOps Organization"/>
+                    <MudTextField @bind-Value="_model.Project" Label="DevOps Project"/>
                     <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>


### PR DESCRIPTION
## Summary
- clarify labels for DevOps organization and DevOps project
- update help content in English and Spanish

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `STAGING_URL=http://localhost dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --verbosity normal` *(fails: Restore canceled)*

------
https://chatgpt.com/codex/tasks/task_e_685690ec2fb4832897ebcb0b07f41f93