### PR TITLE
Add PAT token to new project screen

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/NewProjectPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/NewProjectPageTests.cs
@@ -12,5 +12,6 @@ public class NewProjectPageTests : ComponentTestBase
         SetupServices();
         var cut = RenderComponent<NewProject>();
         Assert.Contains("New Project", cut.Markup);
+        Assert.Contains("PAT Token", cut.Markup);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -39,6 +39,9 @@
   <data name="Organization" xml:space="preserve">
     <value>Organización</value>
   </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>Token PAT</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>Nuevo Proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -39,6 +39,9 @@
   <data name="Organization" xml:space="preserve">
     <value>Organization</value>
   </data>
+  <data name="PatToken" xml:space="preserve">
+    <value>PAT Token</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>New Project</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -6,6 +6,7 @@
 @inject NavigationManager NavigationManager
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
+@inject IStringLocalizer<PatTokenDialog> TL
 
 <PageTitle>DevOpsAssistant - New Project</PageTitle>
 
@@ -14,6 +15,7 @@
     <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
     <MudTextField @bind-Value="_organization" Label="Organization" Class="mt-2" />
     <MudTextField @bind-Value="_project" Label="Project" Class="mt-2" />
+    <MudTextField @bind-Value="_patToken" Label="@TL["PatToken"]" InputType="InputType.Password" HelperText="Leave blank to use global token" Class="mt-2" />
     <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)" Class="mt-2">@L["Create"]</MudButton>
 </MudPaper>
 
@@ -21,6 +23,7 @@
     private string _name = string.Empty;
     private string _organization = string.Empty;
     private string _project = string.Empty;
+    private string _patToken = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -33,7 +36,8 @@
         await ConfigService.SaveAsync(new DevOpsConfig
         {
             Organization = _organization,
-            Project = _project
+            Project = _project,
+            PatToken = _patToken
         });
         NavigationManager.NavigateTo($"/projects/{_name}", forceLoad: true);
     }


### PR DESCRIPTION
## Summary
- add PAT token field to new project page
- localize PAT token text
- expect PAT token label in new project tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `npx playwright install --with-deps` *(fails: Need to install the following packages)*

------
https://chatgpt.com/codex/tasks/task_e_685697f17ff083289158bd630b54d1fd