### PR TITLE
Improve project switch behavior

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -126,14 +126,10 @@
             if (segments.Length > 1 && segments[1] != "new")
             {
                 segments[1] = name;
-                NavigationManager.NavigateTo($"/{string.Join('/', segments)}", forceLoad: true);
+                NavigationManager.NavigateTo($"/{string.Join('/', segments)}", replace: true);
                 return;
             }
-            NavigationManager.NavigateTo("/", forceLoad: true);
-        }
-        else
-        {
-            NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+            NavigationManager.NavigateTo("/", replace: true);
         }
     }
 
@@ -144,7 +140,7 @@
             !relative.StartsWith("projects/new") &&
             !relative.EndsWith("/settings"))
         {
-            NavigationManager.NavigateTo($"/projects/{_selectedProject}/settings", true);
+            NavigationManager.NavigateTo($"/projects/{_selectedProject}/settings", replace: true);
         }
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
@@ -3,10 +3,10 @@
 @using DevOpsAssistant.Services.Models
 @using DevOpsAssistant.Utils
 @inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<BranchHealth> L
+@inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Branch Health</PageTitle>
 
@@ -186,5 +186,10 @@ else if (_branches != null)
     {
         public string RepoId { get; set; } = string.Empty;
         public string BaseBranch { get; set; } = string.Empty;
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -8,6 +8,7 @@
 @inject PageStateService StateService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Metrics> L
+@inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Metrics</PageTitle>
 
@@ -239,5 +240,10 @@ else if (_periods.Any())
         public AggregateMode Mode { get; set; }
         public VelocityMode VelocityMode { get; set; }
         public DateTime? StartDate { get; set; }
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -8,8 +8,8 @@
 @using MudBlazor
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
-@inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
+@inherits ProjectComponentBase
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<ReleaseNotes> L
@@ -401,6 +401,11 @@ else if (_promptParts != null)
 
         sb.AppendLine(json);
         return sb.ToString();
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -7,9 +7,9 @@
 @using DevOpsAssistant.Utils
 @using Microsoft.AspNetCore.Components.Forms
 @inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@inherits ProjectComponentBase
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<RequirementsPlanner> L
@@ -636,5 +636,10 @@ Define what success looks like — business or system-level outcomes.
     {
         public string Backlog { get; set; } = string.Empty;
         public string WikiId { get; set; } = string.Empty;
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -5,12 +5,12 @@
 @using DevOpsAssistant.Services.Models
 @using DevOpsAssistant.Utils
 @inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
 @inject IJSRuntime JS
 @inject PageStateService StateService
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<StoryReview> L
+@inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Story Quality</PageTitle>
 
@@ -302,5 +302,10 @@ else if (_promptParts != null)
     {
         public string Path { get; set; } = string.Empty;
         public string[]? States { get; set; }
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -2,10 +2,10 @@
 @using System
 @using DevOpsAssistant.Services.Models
 @inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Validation> L
+@inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Story Validation</PageTitle>
 
@@ -350,6 +350,11 @@ else if (_results != null)
         public string Path { get; set; } = string.Empty;
         public string[]? States { get; set; }
         public string[]? Types { get; set; }
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -1,8 +1,8 @@
 @page "/epics-features"
 @using DevOpsAssistant.Services.Models
 @inject DevOpsApiService ApiService
-@inject DevOpsConfigService ConfigService
 @inject PageStateService StateService
+@inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Epics and Features</PageTitle>
 
@@ -307,6 +307,11 @@ else if (_roots != null)
     {
         public string Path { get; set; } = string.Empty;
         public bool IssuesOnly { get; set; }
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -9,6 +9,8 @@ public class DevOpsConfigService
     private const string GlobalPatKey = "devops-pat";
     private readonly ILocalStorageService _localStorage;
 
+    public event Action? ProjectChanged;
+
     public DevOpsConfigService(ILocalStorageService localStorage)
     {
         _localStorage = localStorage;
@@ -94,6 +96,7 @@ public class DevOpsConfigService
         Projects.Add(Normalize(project));
         CurrentProject = project;
         await SaveProjectsAsync();
+        OnProjectChanged();
     }
 
     public async Task RemoveProjectAsync(string name)
@@ -106,6 +109,7 @@ public class DevOpsConfigService
         if (CurrentProject.Name == name)
             CurrentProject = Projects[0];
         await SaveProjectsAsync();
+        OnProjectChanged();
     }
 
     public async Task SelectProjectAsync(string name)
@@ -116,6 +120,12 @@ public class DevOpsConfigService
         Projects.Insert(0, proj);
         CurrentProject = proj;
         await SaveProjectsAsync();
+        OnProjectChanged();
+    }
+
+    private void OnProjectChanged()
+    {
+        ProjectChanged?.Invoke();
     }
 
     private static DevOpsConfig Normalize(DevOpsConfig config)
@@ -181,6 +191,7 @@ public class DevOpsConfigService
         await _localStorage.RemoveItemAsync(StorageKey);
         await _localStorage.RemoveItemAsync(LegacyStorageKey);
         await _localStorage.RemoveItemAsync(GlobalPatKey);
+        OnProjectChanged();
     }
 
     private async Task SaveProjectsAsync()

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/ProjectComponentBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/ProjectComponentBase.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using DevOpsAssistant.Services;
+
+namespace DevOpsAssistant.Utils;
+
+public abstract class ProjectComponentBase : ComponentBase, IDisposable
+{
+    [Inject]
+    protected DevOpsConfigService ConfigService { get; set; } = default!;
+
+    protected override void OnInitialized()
+    {
+        ConfigService.ProjectChanged += HandleProjectChanged;
+    }
+
+    protected virtual Task OnProjectChangedAsync() => Task.CompletedTask;
+
+    private void HandleProjectChanged()
+    {
+        _ = InvokeAsync(async () =>
+        {
+            await OnProjectChangedAsync();
+            StateHasChanged();
+        });
+    }
+
+    public void Dispose()
+    {
+        ConfigService.ProjectChanged -= HandleProjectChanged;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
@@ -10,3 +10,4 @@
 @using DevOpsAssistant.Layout
 @using DevOpsAssistant.Services
 @using MudBlazor
+@using DevOpsAssistant.Utils


### PR DESCRIPTION
## Summary
- trigger page refresh via new `ProjectComponentBase`
- raise change events from `DevOpsConfigService`
- update `_Imports` and pages to use the new base
- avoid full page reloads in `MainLayout`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6856a7614f248328b305a3b74c8bad78