### PR TITLE
Clarify DevOps fields in settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -31,13 +31,13 @@
     <value>Tiene story points</value>
   </data>
   <data name="Project" xml:space="preserve">
-    <value>Proyecto</value>
+    <value>Proyecto de DevOps</value>
   </data>
   <data name="ProjectName" xml:space="preserve">
     <value>Nombre del Proyecto</value>
   </data>
   <data name="Organization" xml:space="preserve">
-    <value>Organización</value>
+    <value>Organización de DevOps</value>
   </data>
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -31,13 +31,13 @@
     <value>Has story points</value>
   </data>
   <data name="Project" xml:space="preserve">
-    <value>Project</value>
+    <value>DevOps Project</value>
   </data>
   <data name="ProjectName" xml:space="preserve">
     <value>Project Name</value>
   </data>
   <data name="Organization" xml:space="preserve">
-    <value>Organization</value>
+    <value>DevOps Organization</value>
   </data>
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización, proyecto y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
+    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your organization, project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
+    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -13,8 +13,8 @@
 <MudPaper Class="p-4">
     <MudText Typo="Typo.h5" Class="mb-2">@L["NewProject"]</MudText>
     <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
-    <MudTextField @bind-Value="_organization" Label="Organization" Class="mt-2" />
-    <MudTextField @bind-Value="_project" Label="Project" Class="mt-2" />
+    <MudTextField @bind-Value="_organization" Label="DevOps Organization" Class="mt-2" />
+    <MudTextField @bind-Value="_project" Label="DevOps Project" Class="mt-2" />
     <MudTextField @bind-Value="_patToken" Label="@TL["PatToken"]" InputType="InputType.Password" HelperText="Leave blank to use global token" Class="mt-2" />
     <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)" Class="mt-2">@L["Create"]</MudButton>
 </MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -15,8 +15,8 @@
         <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
-                    <MudTextField @bind-Value="_model.Project" Label="Project"/>
+                    <MudTextField @bind-Value="_model.Organization" Label="DevOps Organization"/>
+                    <MudTextField @bind-Value="_model.Project" Label="DevOps Project"/>
                     <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>


### PR DESCRIPTION
## Summary
- clarify organization and project labels refer to DevOps
- update help text for DevOps configuration
- localize new DevOps terminology in Spanish

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `STAGING_URL=http://localhost dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --verbosity normal` *(fails: Playwright not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6856aefe5d988328ae55f2acf9f1bf8d