### PR TITLE
Add sign-out confirmation dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The application communicates with Azure DevOps using a Personal Access Token (PA
 4. Create the token and copy the value.
 
 Run the site and you'll see a project selection screen if any projects are configured or be taken to the **New Project** page otherwise. Use the settings page from the project menu to configure each project. A comma separated list of default states can also be provided and each AI feature has a field for a custom prompt. These values are stored in your browser's local storage.
-When you're done, click the **Sign Out** button in the top bar to remove the saved projects and return to the project selection screen.
+When you're done, click the **Sign Out** button in the top bar. A warning dialog confirms that all saved settings will be removed before returning to the project selection screen.
 
 ## Faking the DevOps API for tests
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -54,6 +54,8 @@ public class MainLayoutTests : ComponentTestBase
 
         var cut = RenderComponent<MainLayout>();
         cut.Find("button[title='Sign Out']").Click();
+        var dialog = cut.WaitForElement("div.mud-dialog");
+        dialog.GetElementsByTagName("button")[0].Click();
 
         Assert.Equal("default", config.CurrentProject.Name);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -119,6 +119,7 @@ public class UiTests
         await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
         await page.ReloadAsync();
         await page.GetByTitle("Sign Out").ClickAsync();
+        await page.GetByText("OK").ClickAsync();
         var json = await page.EvaluateAsync<string>("() => localStorage.getItem('devops-config')");
         Assert.True(string.IsNullOrEmpty(json));
         var splash = await page.QuerySelectorAsync("text=Open Settings");

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -36,6 +36,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
   </data>
+  <data name="SignOutWarning" xml:space="preserve">
+    <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -89,6 +89,11 @@
 
     private async Task SignOut()
     {
+        var parameters = new DialogParameters { ["Message"] = L["SignOutWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+
         await ConfigService.ClearAsync();
         StateHasChanged();
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -36,6 +36,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
   </data>
+  <data name="SignOutWarning" xml:space="preserve">
+    <value>Signing out will remove all saved settings. Continue?</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -15,6 +15,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
   </data>
+  <data name="SignOutWarning" xml:space="preserve">
+    <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -42,6 +42,11 @@
 
     private async Task SignOut()
     {
+        var parameters = new DialogParameters { ["Message"] = L["SignOutWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+
         await ConfigService.ClearAsync();
         StateHasChanged();
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -15,6 +15,9 @@
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
   </data>
+  <data name="SignOutWarning" xml:space="preserve">
+    <value>Signing out will remove all saved settings. Continue?</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>
   </data>


### PR DESCRIPTION
## Summary
- warn when signing out that settings will be removed using ConfirmDialog
- update unit and UI tests for new dialog
- clarify README sign out behavior
- localize new warning message

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6856f7247f248328ac54d05fdcea3297