### PR TITLE
Fix MudCheckBox binding to silence analyzer

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -18,7 +18,7 @@
     <MudTextField @bind-Value="_patToken" Label="@TL["PatToken"]" InputType="InputType.Password" HelperText="Leave blank to use global token" Class="mt-2" />
     @if (string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken))
     {
-        <MudCheckBox T="bool" @bind-Checked="_useAsGlobal" Label="Use as global token" Class="mt-2" />
+        <MudCheckBox T="bool" @bind-Value="_useAsGlobal" Label="Use as global token" Class="mt-2" />
     }
     <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)" Class="mt-2">@L["Create"]</MudButton>
 </MudPaper>


### PR DESCRIPTION
## Summary
- fix MudCheckBox to use `@bind-Value`

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `npx playwright install --with-deps` *(fails: domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6856ff1071948328b32af96c95649dc9