### PR TITLE
Add manual staging deploy workflow

### DIFF
--- a/.github/workflows/manual-staging.yml
+++ b/.github/workflows/manual-staging.yml
@@ -1,0 +1,73 @@
+name: Manual Staging Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
+        default: main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: false
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.branch }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Restore
+        run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
+      - name: Build
+        run: dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror
+      - name: Test
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.sln -c Release --no-build --no-restore --verbosity normal
+      - name: Set version
+        run: echo "1.0.${{ github.run_number }}" > src/DevOpsAssistant/DevOpsAssistant/wwwroot/version.txt
+      - name: Deploy to Staging
+        id: staging
+        uses: Azure/static-web-apps-deploy@v1
+        env:
+          INCLUDE_MOCK_DATA: 'true'
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_STAGING }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "src/DevOpsAssistant/DevOpsAssistant"
+          output_location: "wwwroot"
+      - name: Export URL
+        run: echo "STAGING_URL=${{ steps.staging.outputs.static_web_app_url }}" >> $GITHUB_ENV
+
+  ui_tests:
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+      - name: Cache NuGet packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+      - name: Restore
+        run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run UI tests
+        run: dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj --no-restore --verbosity normal
+        env:
+          STAGING_URL: ${{ env.STAGING_URL }}
+


### PR DESCRIPTION
## Summary
- add workflow_dispatch for manually deploying a branch to staging

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `npx playwright install --with-deps` *(fails: Domain forbidden)*
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.UiTests/DevOpsAssistant.UiTests.csproj` *(fails: Playwright unable to launch browser)*

------
https://chatgpt.com/codex/tasks/task_e_68570308520c8328a5dd5cddabf9e9ea