### PR TITLE
Fix root redirect when no settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -38,7 +38,7 @@ public class MainLayoutTests : ComponentTestBase
         SetupServices();
 
         var cut = RenderComponent<MainLayout>();
-        var link = cut.Find($"a[href='/projects/default/settings']");
+        var link = cut.Find("a[href^='/projects/'][href$='/settings']");
 
         Assert.DoesNotContain("mud-nav-link-disabled", link.ClassName);
 
@@ -57,7 +57,7 @@ public class MainLayoutTests : ComponentTestBase
         var dialog = cut.WaitForElement("div.mud-dialog");
         dialog.GetElementsByTagName("button")[0].Click();
 
-        Assert.Equal("default", config.CurrentProject.Name);
+        Assert.Equal(string.Empty, config.CurrentProject.Name);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
@@ -2,6 +2,9 @@ using Bunit;
 using DevOpsAssistant.Pages;
 using DevOpsAssistant.Tests.Utils;
 using DevOpsAssistant.Services;
+using Microsoft.AspNetCore.Components;
+using Bunit.TestDoubles;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace DevOpsAssistant.Tests.Pages;
 
@@ -23,8 +26,9 @@ public class HomePageTests : ComponentTestBase
         var config = SetupServices();
         await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
 
+        var nav = Services.GetRequiredService<NavigationManager>() as FakeNavigationManager;
         var cut = RenderComponent<Home>();
 
-        Assert.Contains("NewProject", cut.Markup);
+        Assert.Equal("http://localhost/projects/new", nav!.Uri);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -11,6 +11,7 @@ public class DevOpsConfigServiceTests
     {
         var storage = new FakeLocalStorageService();
         var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("default");
         var config = new DevOpsConfig
         {
             Organization = " Org ",
@@ -198,7 +199,7 @@ public class DevOpsConfigServiceTests
         await service.RemoveProjectAsync("proj2");
 
         Assert.DoesNotContain(service.Projects, p => p.Name == "proj2");
-        Assert.Equal("default", service.CurrentProject.Name);
+        Assert.Equal("proj1", service.CurrentProject.Name);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PageStateServiceTests.cs
@@ -10,13 +10,14 @@ public class PageStateServiceTests
     {
         var storage = new FakeLocalStorageService();
         var config = new DevOpsConfigService(storage);
+        await config.AddProjectAsync("proj");
         var service = new PageStateService(storage, config);
         await service.SaveAsync("key", new TestState { Value = 1 });
         var loaded = await service.LoadAsync<TestState>("key");
         Assert.NotNull(loaded);
         Assert.Equal(1, loaded!.Value);
 
-        var stored = await storage.GetItemAsync<TestState>("default-key");
+        var stored = await storage.GetItemAsync<TestState>("proj-key");
         Assert.NotNull(stored);
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -38,7 +38,7 @@
             else
             {
                 <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
-                <MudButton OnClick="DeleteProject" Color="Color.Error" Disabled="ConfigService.Projects.Count == 1" Class="mt-2">@L["DeleteProject"]</MudButton>
+                <MudButton OnClick="DeleteProject" Color="Color.Error" Disabled="ConfigService.Projects.Count == 0" Class="mt-2">@L["DeleteProject"]</MudButton>
             }
         </MudStack>
         <MudTabs Class="mt-4">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -141,6 +141,13 @@
     private void EnsureSettingsIfNeeded()
     {
         var relative = NavigationManager.ToBaseRelativePath(NavigationManager.Uri);
+        if (!ConfigService.Projects.Any())
+        {
+            if (!relative.StartsWith("projects/new"))
+                NavigationManager.NavigateTo("/projects/new", replace: true);
+            return;
+        }
+
         if (IsProjectInvalid &&
             !relative.StartsWith("projects/new") &&
             !relative.EndsWith("/settings"))

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -16,9 +16,7 @@ public class DevOpsConfigService
     {
         _localStorage = localStorage;
 
-        var project = new DevOpsProject { Name = "default" };
-        Projects.Add(project);
-        CurrentProject = project;
+        CurrentProject = new DevOpsProject();
     }
 
     public List<DevOpsProject> Projects { get; private set; } = new();
@@ -114,8 +112,8 @@ public class DevOpsConfigService
         if (proj == null) return;
         Projects.Remove(proj);
         if (Projects.Count == 0)
-            Projects.Add(new DevOpsProject { Name = "default" });
-        if (CurrentProject.Name == name)
+            CurrentProject = new DevOpsProject();
+        else if (CurrentProject.Name == name)
             CurrentProject = Projects[0];
         await SaveProjectsAsync();
         OnProjectChanged();
@@ -194,8 +192,8 @@ public class DevOpsConfigService
 
     public async Task ClearAsync()
     {
-        Projects = new List<DevOpsProject> { new DevOpsProject { Name = "default" } };
-        CurrentProject = Projects[0];
+        Projects = new List<DevOpsProject>();
+        CurrentProject = new DevOpsProject();
         GlobalPatToken = string.Empty;
         GlobalDarkMode = false;
         await _localStorage.RemoveItemAsync(StorageKey);


### PR DESCRIPTION
## Summary
- redirect to new project page when no projects configured
- stop adding a default project on startup
- adjust delete project logic and related tests
- update unit tests for new behavior

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6857cc2aee9c832891465c03d916fd07