### PR TITLE
Add delete option and navigation fixes

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -67,9 +67,12 @@
 
     private bool _drawerOpen = true;
     private string _selectedProject = string.Empty;
+    private bool _initialized;
 
     protected override void OnAfterRender(bool firstRender)
     {
+        if (!_initialized)
+            return;
         EnsureSettingsIfNeeded();
     }
 
@@ -78,6 +81,7 @@
         await VersionService.LoadAsync();
         await ConfigService.LoadAsync();
         _selectedProject = ConfigService.CurrentProject.Name;
+        _initialized = true;
         StateHasChanged();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -8,36 +8,28 @@
 
 <PageTitle>DevOpsAssistant - Home</PageTitle>
 
-@if (_showProjects)
-{
-    <ProjectsList />
-}
-else
-{
-    <MudGrid>
-        <MudItem xs="12">
-            <MudText Typo="Typo.h4" Class="mb-2">@L["Welcome"]</MudText>
-        </MudItem>
-        <MudItem xs="12">
-            <MudPaper Class="pa-4">
-                <MudText Typo="Typo.body1">
-                    @L["Description"]
-                </MudText>
-                <MudList T="string" Dense="true" Class="ms-4 mt-2">
-                    <MudListItem T="string">@L["Epics"]</MudListItem>
-                    <MudListItem T="string">@L["Validation"]</MudListItem>
-                    <MudListItem T="string">@L["ReleaseNotes"]</MudListItem>
-                    <MudListItem T="string">@L["Quality"]</MudListItem>
-                    <MudListItem T="string">@L["Metrics"]</MudListItem>
-                </MudList>
-            </MudPaper>
-        </MudItem>
-    </MudGrid>
-}
+<MudGrid>
+    <MudItem xs="12">
+        <MudText Typo="Typo.h4" Class="mb-2">@L["Welcome"]</MudText>
+    </MudItem>
+    <MudItem xs="12">
+        <MudPaper Class="pa-4">
+            <MudText Typo="Typo.body1">
+                @L["Description"]
+            </MudText>
+            <MudList T="string" Dense="true" Class="ms-4 mt-2">
+                <MudListItem T="string">@L["Epics"]</MudListItem>
+                <MudListItem T="string">@L["Validation"]</MudListItem>
+                <MudListItem T="string">@L["ReleaseNotes"]</MudListItem>
+                <MudListItem T="string">@L["Quality"]</MudListItem>
+                <MudListItem T="string">@L["Metrics"]</MudListItem>
+            </MudList>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
 
 @code {
     [Parameter] public string? ProjectName { get; set; }
-    private bool _showProjects;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -50,11 +42,16 @@ else
             return;
         }
 
-        if (!string.IsNullOrWhiteSpace(ProjectName) && ConfigService.CurrentProject.Name != ProjectName)
+        if (string.IsNullOrWhiteSpace(ProjectName))
+        {
+            NavigationManager.NavigateTo("/projects", true);
+            return;
+        }
+
+        if (ConfigService.CurrentProject.Name != ProjectName)
         {
             await ConfigService.SelectProjectAsync(ProjectName);
             NavigationManager.NavigateTo(NavigationManager.Uri.Replace($"/projects/{ProjectName}", "/"), forceLoad: true);
         }
-        _showProjects = string.IsNullOrWhiteSpace(ProjectName);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -5,6 +5,8 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
 @inject ISnackbar Snackbar
+@inject IDialogService DialogService
+@inject NavigationManager NavigationManager
 
 <PageTitle>DevOpsAssistant - Settings</PageTitle>
 
@@ -66,7 +68,10 @@
                 </MudStack>
             </MudTabPanel>
         </MudTabs>
-        <MudButton OnClick="Save" Color="Color.Primary" Class="mt-2">Save</MudButton>
+        <MudStack Row="true" Spacing="1" Class="mt-2">
+            <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
+            <MudButton OnClick="Delete" Color="Color.Error">@L["DeleteProject"]</MudButton>
+        </MudStack>
     </MudStack>
 </MudPaper>
 
@@ -125,5 +130,18 @@
     {
         await ConfigService.SaveCurrentAsync(_projectName, _model);
         Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
+    }
+
+    private async Task Delete()
+    {
+        var parameters = new DialogParameters { ["Message"] = $"{L["ConfirmDelete"].Value} {_projectName}?" };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+        await ConfigService.RemoveProjectAsync(_projectName);
+        if (ConfigService.Projects.Any())
+            NavigationManager.NavigateTo("/projects", true);
+        else
+            NavigationManager.NavigateTo("/projects/new", true);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -159,9 +159,12 @@ html, body { height: 100%; }
 #app { min-height: 100vh; display: flex; flex-direction: column; }
 .app-footer {
     margin-top: auto;
-    background-color: var(--mud-palette-background-grey, #f5f5f5);
+    background-color: var(--mud-palette-background, #f5f5f5);
     border-top: 1px solid var(--mud-palette-lines, #e0e0e0);
+    color: var(--mud-palette-text-primary, #000);
     padding: 0.5rem 0;
+    z-index: 1;
+    position: relative;
 }
 
 /* High contrast mode for users requesting extra contrast */


### PR DESCRIPTION
## Summary
- add delete action to project settings
- redirect to project list when no project selected
- prevent early navigation before config loads
- improve footer styling for dark mode

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_68581eb083e08328b5da02321ebef17d