### PR TITLE
Update PAT token menu to global settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -39,6 +39,9 @@
   <data name="SignOutWarning" xml:space="preserve">
     <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
   </data>
+  <data name="GlobalSettings" xml:space="preserve">
+    <value>Configuración global</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -28,7 +28,7 @@
             <MudDivider />
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
         </MudMenu>
-        <MudIconButton Icon="@Icons.Material.Filled.VpnKey" OnClick="OpenOptionsDialog" title='@L["PatToken"]' class="me-2"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]' class="me-2"/>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>
 
@@ -104,7 +104,7 @@
 
     private async Task OpenOptionsDialog()
     {
-        await DialogService.ShowAsync<GlobalOptionsDialog>(L["PatToken"]);
+        await DialogService.ShowAsync<GlobalOptionsDialog>(L["GlobalSettings"]);
     }
 
     private async Task ChangeProject(string name)

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -39,6 +39,9 @@
   <data name="SignOutWarning" xml:space="preserve">
     <value>Signing out will remove all saved settings. Continue?</value>
   </data>
+  <data name="GlobalSettings" xml:space="preserve">
+    <value>Global Settings</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -18,6 +18,9 @@
   <data name="SignOutWarning" xml:space="preserve">
     <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
   </data>
+  <data name="GlobalSettings" xml:space="preserve">
+    <value>Configuración global</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -17,7 +17,7 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer/>
-        <MudIconButton Icon="@Icons.Material.Filled.VpnKey" OnClick="OpenOptionsDialog" title='@L["PatToken"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]'/>
         <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
     </MudAppBar>
 
@@ -53,6 +53,6 @@
 
     private async Task OpenOptionsDialog()
     {
-        await DialogService.ShowAsync<GlobalOptionsDialog>(L["PatToken"]);
+        await DialogService.ShowAsync<GlobalOptionsDialog>(L["GlobalSettings"]);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -18,6 +18,9 @@
   <data name="SignOutWarning" xml:space="preserve">
     <value>Signing out will remove all saved settings. Continue?</value>
   </data>
+  <data name="GlobalSettings" xml:space="preserve">
+    <value>Global Settings</value>
+  </data>
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>
   </data>


### PR DESCRIPTION
## Summary
- rename PAT token menu to 'Global Settings'
- switch to a Settings icon
- localize new menu text for English and Spanish

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685823e3eb30832893b6abe9e8ca6d27