### PR TITLE
Improve Requirements planner notes

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -28,7 +28,7 @@
     <value>Copiar prompt inicial</value>
   </data>
   <data name="CopyPromptMessage" xml:space="preserve">
-    <value>Péguelo en su LLM para comenzar a recopilar requisitos.</value>
+    <value>Si necesita ayuda para recopilar los requisitos, copie este prompt inicial y péguelo en su LLM. Este paso es opcional.</value>
   </data>
   <data name="CopyToast" xml:space="preserve">
     <value>Copiado al portapapeles</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -17,11 +17,12 @@
 <PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
-    <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton> @L["CopyPromptMessage"]
+    @L["CopyPromptMessage"]
+    <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton>
 </MudAlert>
 
 <MudAlert Severity="Severity.Info" Class="mb-4">
-    Search a wiki page and generate a prompt to break requirements into Epics, Features and User Stories.
+    Select wiki pages or upload a requirements document to generate a prompt that breaks it into Epics, Features and User Stories.
     Paste the LLM response below to import items and create them in a backlog.
 </MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -28,7 +28,7 @@
     <value>Copy starter prompt</value>
   </data>
   <data name="CopyPromptMessage" xml:space="preserve">
-    <value>Paste it into your LLM to begin capturing requirements.</value>
+    <value>If you need help capturing requirements, paste this starter prompt into your LLM. This step is optional.</value>
   </data>
   <data name="CopyToast" xml:space="preserve">
     <value>Copied to clipboard</value>


### PR DESCRIPTION
## Summary
- update notes on Requirements planner page
- move Copy starter prompt button under explanatory text
- clarify optional use of the starter prompt in resource files

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685829924be48328a22e927f62a56660