### PR TITLE
Add help icon to app bar and expand logout options

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -3,6 +3,7 @@ using DevOpsAssistant.Layout;
 using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
 using System.Threading.Tasks;
+using System.Linq;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
 using Bunit.TestDoubles;
@@ -53,9 +54,11 @@ public class MainLayoutTests : ComponentTestBase
         await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
 
         var cut = RenderComponent<MainLayout>();
-        cut.Find("button[title='Sign Out']").Click();
+        var method = typeof(MainLayout).GetMethod("SignOut", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var task = cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, null)!);
         var dialog = cut.WaitForElement("div.mud-dialog");
         dialog.GetElementsByTagName("button")[0].Click();
+        await task;
 
         Assert.Equal(string.Empty, config.CurrentProject.Name);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -119,6 +119,7 @@ public class UiTests
         await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
         await page.ReloadAsync();
         await page.GetByTitle("Sign Out").ClickAsync();
+        await page.GetByText("Remove All Settings").ClickAsync();
         await page.GetByText("OK").ClickAsync();
         var json = await page.EvaluateAsync<string>("() => localStorage.getItem('devops-config')");
         Assert.True(string.IsNullOrEmpty(json));

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -36,7 +36,16 @@
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
   </data>
-  <data name="SignOutWarning" xml:space="preserve">
+  <data name="RemovePat" xml:space="preserve">
+    <value>Eliminar token PAT</value>
+  </data>
+  <data name="RemoveAll" xml:space="preserve">
+    <value>Eliminar toda la configuración</value>
+  </data>
+  <data name="RemovePatWarning" xml:space="preserve">
+    <value>Esto eliminará el token PAT global. ¿Continuar?</value>
+  </data>
+  <data name="RemoveAllWarning" xml:space="preserve">
     <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
   </data>
   <data name="GlobalSettings" xml:space="preserve">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -29,7 +29,11 @@
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
         </MudMenu>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]' class="me-2"/>
-        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" Href="/help" title='@L["Help"]' class="me-2"/>
+        <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
+            <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
+            <MudMenuItem OnClick="SignOut">@L["RemoveAll"]</MudMenuItem>
+        </MudMenu>
     </MudAppBar>
 
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
@@ -47,7 +51,6 @@
                 <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
             </MudNavGroup>
             <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
-            <MudNavLink Href="help" Icon="@Icons.Material.Filled.Help">@L["Help"]</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 
@@ -93,12 +96,23 @@
 
     private async Task SignOut()
     {
-        var parameters = new DialogParameters { ["Message"] = L["SignOutWarning"].Value };
+        var parameters = new DialogParameters { ["Message"] = L["RemoveAllWarning"].Value };
         var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
         var result = await dialog.Result;
         if (result?.Canceled != false) return;
 
         await ConfigService.ClearAsync();
+        StateHasChanged();
+    }
+
+    private async Task RemovePat()
+    {
+        var parameters = new DialogParameters { ["Message"] = L["RemovePatWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+
+        await ConfigService.RemoveGlobalPatAsync();
         StateHasChanged();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -36,7 +36,16 @@
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
   </data>
-  <data name="SignOutWarning" xml:space="preserve">
+  <data name="RemovePat" xml:space="preserve">
+    <value>Remove PAT Token</value>
+  </data>
+  <data name="RemoveAll" xml:space="preserve">
+    <value>Remove All Settings</value>
+  </data>
+  <data name="RemovePatWarning" xml:space="preserve">
+    <value>This will delete the global PAT token. Continue?</value>
+  </data>
+  <data name="RemoveAllWarning" xml:space="preserve">
     <value>Signing out will remove all saved settings. Continue?</value>
   </data>
   <data name="GlobalSettings" xml:space="preserve">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -15,7 +15,16 @@
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
   </data>
-  <data name="SignOutWarning" xml:space="preserve">
+  <data name="RemovePat" xml:space="preserve">
+    <value>Eliminar token PAT</value>
+  </data>
+  <data name="RemoveAll" xml:space="preserve">
+    <value>Eliminar toda la configuración</value>
+  </data>
+  <data name="RemovePatWarning" xml:space="preserve">
+    <value>Esto eliminará el token PAT global. ¿Continuar?</value>
+  </data>
+  <data name="RemoveAllWarning" xml:space="preserve">
     <value>Cerrar sesión eliminará toda la configuración guardada. ¿Continuar?</value>
   </data>
   <data name="GlobalSettings" xml:space="preserve">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -18,7 +18,11 @@
         </MudText>
         <MudSpacer/>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]'/>
-        <MudIconButton Icon="@Icons.Material.Filled.Logout" OnClick="SignOut" title='@L["SignOut"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" Href="/help" title='@L["Help"]' class="mx-2"/>
+        <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
+            <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
+            <MudMenuItem OnClick="SignOut">@L["RemoveAll"]</MudMenuItem>
+        </MudMenu>
     </MudAppBar>
 
     <MudMainContent>
@@ -42,12 +46,23 @@
 
     private async Task SignOut()
     {
-        var parameters = new DialogParameters { ["Message"] = L["SignOutWarning"].Value };
+        var parameters = new DialogParameters { ["Message"] = L["RemoveAllWarning"].Value };
         var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
         var result = await dialog.Result;
         if (result?.Canceled != false) return;
 
         await ConfigService.ClearAsync();
+        StateHasChanged();
+    }
+
+    private async Task RemovePat()
+    {
+        var parameters = new DialogParameters { ["Message"] = L["RemovePatWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+
+        await ConfigService.RemoveGlobalPatAsync();
         StateHasChanged();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -15,7 +15,16 @@
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
   </data>
-  <data name="SignOutWarning" xml:space="preserve">
+  <data name="RemovePat" xml:space="preserve">
+    <value>Remove PAT Token</value>
+  </data>
+  <data name="RemoveAll" xml:space="preserve">
+    <value>Remove All Settings</value>
+  </data>
+  <data name="RemovePatWarning" xml:space="preserve">
+    <value>This will delete the global PAT token. Continue?</value>
+  </data>
+  <data name="RemoveAllWarning" xml:space="preserve">
     <value>Signing out will remove all saved settings. Continue?</value>
   </data>
   <data name="GlobalSettings" xml:space="preserve">

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -203,6 +203,12 @@ public class DevOpsConfigService
         OnProjectChanged();
     }
 
+    public async Task RemoveGlobalPatAsync()
+    {
+        GlobalPatToken = string.Empty;
+        await _localStorage.RemoveItemAsync(GlobalPatKey);
+    }
+
     private async Task SaveProjectsAsync()
     {
         await _localStorage.SetItemAsync(StorageKey, Projects);


### PR DESCRIPTION
## Summary
- move Help link to the AppBar in both layouts
- offer menu options for clearing the PAT or all settings
- support PAT removal in config service
- adjust unit and UI tests for new logout behavior

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685828c28f3083289069192c56bf11c4