### PR TITLE
Add project name validation

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -220,6 +220,47 @@ public class DevOpsConfigServiceTests
     }
 
     [Fact]
+    public async Task AddProjectAsync_Returns_False_For_Duplicate()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+
+        await service.AddProjectAsync("proj");
+        var result = await service.AddProjectAsync("proj");
+
+        Assert.False(result);
+        Assert.Single(service.Projects);
+    }
+
+    [Fact]
+    public async Task SaveCurrentAsync_Returns_False_When_NewName_Exists()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("one");
+        await service.AddProjectAsync("two");
+        await service.SelectProjectAsync("one");
+
+        var result = await service.SaveCurrentAsync("two", new DevOpsConfig());
+
+        Assert.False(result);
+        Assert.Equal("one", service.CurrentProject.Name);
+    }
+
+    [Fact]
+    public async Task UpdateProjectAsync_Returns_False_When_NewName_Exists()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("one");
+        await service.AddProjectAsync("two");
+
+        var result = await service.UpdateProjectAsync("two", "one", new DevOpsConfig());
+
+        Assert.False(result);
+    }
+
+    [Fact]
     public async Task SaveGlobalDarkModeAsync_Persists_Value()
     {
         var storage = new FakeLocalStorageService();

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -60,4 +60,19 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Configuración guardada</value>
   </data>
+  <data name="DuplicateName" xml:space="preserve">
+    <value>Ya existe un proyecto con ese nombre.</value>
+  </data>
+  <data name="MissingName" xml:space="preserve">
+    <value>Se requiere el nombre del proyecto.</value>
+  </data>
+  <data name="MissingOrganization" xml:space="preserve">
+    <value>Se requiere la organización.</value>
+  </data>
+  <data name="MissingProject" xml:space="preserve">
+    <value>Se requiere el proyecto.</value>
+  </data>
+  <data name="MissingPat" xml:space="preserve">
+    <value>Se requiere un token PAT o global.</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -162,13 +162,19 @@
 
     private async Task Save()
     {
+        bool result;
         if (_selected == ConfigService.CurrentProject.Name)
         {
-            await ConfigService.SaveCurrentAsync(_projectName, _model);
+            result = await ConfigService.SaveCurrentAsync(_projectName, _model);
         }
         else
         {
-            await ConfigService.UpdateProjectAsync(_selected, _projectName, _model);
+            result = await ConfigService.UpdateProjectAsync(_selected, _projectName, _model);
+        }
+        if (!result)
+        {
+            Snackbar.Add(L["DuplicateName"].Value, Severity.Error);
+            return;
         }
         Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
         MudDialog?.Close(DialogResult.Ok(true));
@@ -216,7 +222,12 @@
     private async Task CreateProject()
     {
         DevOpsProject? copy = ConfigService.Projects.FirstOrDefault(p => p.Name == _importFrom);
-        await ConfigService.AddProjectAsync(_newProjectName, copy);
+        var added = await ConfigService.AddProjectAsync(_newProjectName, copy);
+        if (!added)
+        {
+            Snackbar.Add(L["DuplicateName"].Value, Severity.Error);
+            return;
+        }
         _newProjectName = string.Empty;
         _importFrom = string.Empty;
         _creating = false;

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -60,4 +60,19 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Settings saved</value>
   </data>
+  <data name="DuplicateName" xml:space="preserve">
+    <value>A project with that name already exists.</value>
+  </data>
+  <data name="MissingName" xml:space="preserve">
+    <value>Project name is required.</value>
+  </data>
+  <data name="MissingOrganization" xml:space="preserve">
+    <value>Organization is required.</value>
+  </data>
+  <data name="MissingProject" xml:space="preserve">
+    <value>Project is required.</value>
+  </data>
+  <data name="MissingPat" xml:space="preserve">
+    <value>A PAT token or global token is required.</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -13,15 +13,24 @@
 <MudPaper Class="p-4">
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@L["NewProject"]</MudText>
-        <MudTextField @bind-Value="_name" Label='@L["ProjectName"]' />
-        <MudTextField @bind-Value="_organization" Label="DevOps Organization" />
-        <MudTextField @bind-Value="_project" Label="DevOps Project" />
-        <MudTextField @bind-Value="_patToken" Label="@TL["PatToken"]" InputType="InputType.Password" HelperText="Leave blank to use global token" />
+        <MudTextField T="string" Value="_name" ValueChanged="OnNameChanged" Label='@L["ProjectName"]' Immediate="true" />
+        <MudTextField T="string" Value="_organization" ValueChanged="OnOrgChanged" Label="DevOps Organization" Immediate="true" />
+        <MudTextField T="string" Value="_project" ValueChanged="OnProjectChanged" Label="DevOps Project" Immediate="true" />
+        <MudTextField T="string" Value="_patToken" ValueChanged="OnPatChanged" Label="@TL["PatToken"]" InputType="InputType.Password" HelperText="Leave blank to use global token" Immediate="true" />
         @if (string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken))
         {
             <MudCheckBox T="bool" @bind-Value="_useAsGlobal" Label="Use as global token" />
         }
-        <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="_name.Trim().Length < 2 || string.IsNullOrWhiteSpace(_organization) || string.IsNullOrWhiteSpace(_project)">@L["Create"]</MudButton>
+        @if (_errors.Count > 0)
+        {
+            <MudAlert Severity="Severity.Error">
+                @foreach (var e in _errors)
+                {
+                    <div>@e</div>
+                }
+            </MudAlert>
+        }
+        <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanCreate">@L["Create"]</MudButton>
     </MudStack>
 </MudPaper>
 
@@ -31,17 +40,74 @@
     private string _project = string.Empty;
     private string _patToken = string.Empty;
     private bool _useAsGlobal;
+    private List<string> _errors = new();
+
+    private bool CanCreate => _errors.Count == 0;
 
     protected override async Task OnInitializedAsync()
     {
         await ConfigService.LoadAsync();
         if (string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken))
             _useAsGlobal = true;
+        Validate();
     }
+
+    private Task OnNameChanged(string value)
+    {
+        _name = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnOrgChanged(string value)
+    {
+        _organization = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnProjectChanged(string value)
+    {
+        _project = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnPatChanged(string value)
+    {
+        _patToken = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private void Validate()
+    {
+        _errors.Clear();
+        if (string.IsNullOrWhiteSpace(_name))
+            _errors.Add(L["MissingName"]);
+        else if (ConfigService.Projects.Any(p => p.Name.Equals(_name, StringComparison.OrdinalIgnoreCase)))
+            _errors.Add(L["DuplicateName"]);
+        if (string.IsNullOrWhiteSpace(_organization))
+            _errors.Add(L["MissingOrganization"]);
+        if (string.IsNullOrWhiteSpace(_project))
+            _errors.Add(L["MissingProject"]);
+        if (string.IsNullOrWhiteSpace(_patToken) && string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken))
+            _errors.Add(L["MissingPat"]);
+    }
+
 
     private async Task Create()
     {
-        await ConfigService.AddProjectAsync(_name);
+        Validate();
+        if (!CanCreate)
+            return;
+
+        var added = await ConfigService.AddProjectAsync(_name);
+        if (!added)
+        {
+            _errors = new List<string> { L["DuplicateName"] };
+            return;
+        }
         await ConfigService.SaveAsync(new DevOpsConfig
         {
             Organization = _organization,

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -13,13 +13,13 @@
 <MudPaper Class="p-4">
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@L["ProjectSettings"] @ProjectName</MudText>
-        <MudTextField @bind-Value="_projectName" Label='@L["ProjectName"]' />
+        <MudTextField T="string" Value="_projectName" ValueChanged="OnNameChanged" Label='@L["ProjectName"]' Immediate="true" />
         <MudTabs Class="mt-4">
             <MudTabPanel Text="General">
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.Organization" Label="DevOps Organization"/>
-                    <MudTextField @bind-Value="_model.Project" Label="DevOps Project"/>
-                    <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
+                    <MudTextField T="string" Value="_model.Organization" ValueChanged="OnOrgChanged" Label="DevOps Organization" Immediate="true"/>
+                    <MudTextField T="string" Value="_model.Project" ValueChanged="OnProjectChanged" Label="DevOps Project" Immediate="true"/>
+                    <MudTextField T="string" Value="_model.PatToken" ValueChanged="OnPatChanged" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token" Immediate="true"/>
                     <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
                     <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
                     <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
@@ -68,8 +68,17 @@
                 </MudStack>
             </MudTabPanel>
         </MudTabs>
+        @if (_errors.Count > 0)
+        {
+            <MudAlert Severity="Severity.Error" Class="mb-2">
+                @foreach (var e in _errors)
+                {
+                    <div>@e</div>
+                }
+            </MudAlert>
+        }
         <MudStack Row="true" Spacing="1" Class="mt-2">
-            <MudButton OnClick="Save" Color="Color.Primary">Save</MudButton>
+            <MudButton OnClick="Save" Color="Color.Primary" Disabled="!CanSave">Save</MudButton>
             <MudButton OnClick="Delete" Color="Color.Error">@L["DeleteProject"]</MudButton>
         </MudStack>
     </MudStack>
@@ -79,6 +88,9 @@
     [Parameter] public string ProjectName { get; set; } = string.Empty;
     private string _projectName = string.Empty;
     private DevOpsConfig _model = new();
+    private List<string> _errors = new();
+
+    private bool CanSave => _errors.Count == 0;
 
     protected override async Task OnParametersSetAsync()
     {
@@ -124,11 +136,21 @@
                 }
             }
         };
+        Validate();
     }
 
     private async Task Save()
     {
-        await ConfigService.SaveCurrentAsync(_projectName, _model);
+        Validate();
+        if (!CanSave)
+            return;
+
+        var saved = await ConfigService.SaveCurrentAsync(_projectName, _model);
+        if (!saved)
+        {
+            _errors = new List<string> { L["DuplicateName"] };
+            return;
+        }
         Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
     }
 
@@ -143,5 +165,49 @@
             NavigationManager.NavigateTo("/projects", true);
         else
             NavigationManager.NavigateTo("/projects/new", true);
+    }
+
+    private Task OnNameChanged(string value)
+    {
+        _projectName = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnOrgChanged(string value)
+    {
+        _model.Organization = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnProjectChanged(string value)
+    {
+        _model.Project = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private Task OnPatChanged(string value)
+    {
+        _model.PatToken = value;
+        Validate();
+        return Task.CompletedTask;
+    }
+
+    private void Validate()
+    {
+        _errors.Clear();
+        if (string.IsNullOrWhiteSpace(_projectName))
+            _errors.Add(L["MissingName"]);
+        else if (!_projectName.Equals(ConfigService.CurrentProject.Name, StringComparison.OrdinalIgnoreCase) &&
+                 ConfigService.Projects.Any(p => p.Name.Equals(_projectName, StringComparison.OrdinalIgnoreCase)))
+            _errors.Add(L["DuplicateName"]);
+        if (string.IsNullOrWhiteSpace(_model.Organization))
+            _errors.Add(L["MissingOrganization"]);
+        if (string.IsNullOrWhiteSpace(_model.Project))
+            _errors.Add(L["MissingProject"]);
+        if (string.IsNullOrWhiteSpace(_model.PatToken) && string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken))
+            _errors.Add(L["MissingPat"]);
     }
 }


### PR DESCRIPTION
## Summary
- prevent duplicate project names in DevOpsConfigService
- show validation errors on New Project page
- show validation errors on Project Settings page
- surface duplicate name errors in Settings dialog
- expand unit tests for config service

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6858278c17a08328896211d249f0d714