### PR TITLE
Localize settings strings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
@@ -24,4 +24,7 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Token guardado</value>
   </data>
+  <data name="DarkMode" xml:space="preserve">
+    <value>Modo oscuro</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
@@ -8,7 +8,7 @@
     <DialogContent>
         <MudStack Spacing="2">
             <MudTextField @bind-Value="_token" Label='@L["PatToken"]' InputType="InputType.Password" />
-            <MudSwitch T="bool" @bind-Value="_darkMode" Color="Color.Primary" Label="Dark Mode"/>
+            <MudSwitch T="bool" @bind-Value="_darkMode" Color="Color.Primary" Label='@L["DarkMode"]'/>
         </MudStack>
     </DialogContent>
     <DialogActions>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
@@ -24,4 +24,7 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Token saved</value>
   </data>
+  <data name="DarkMode" xml:space="preserve">
+    <value>Dark Mode</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -30,6 +30,15 @@
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Tiene story points</value>
   </data>
+  <data name="GeneralTab" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="StoryQualityTab" xml:space="preserve">
+    <value>Calidad de Historia</value>
+  </data>
+  <data name="ValidationTab" xml:space="preserve">
+    <value>Reglas de Validación</value>
+  </data>
   <data name="Project" xml:space="preserve">
     <value>Proyecto de DevOps</value>
   </data>
@@ -74,5 +83,20 @@
   </data>
   <data name="MissingPat" xml:space="preserve">
     <value>Se requiere un token PAT o global.</value>
+  </data>
+  <data name="MainBranch" xml:space="preserve">
+    <value>Rama principal</value>
+  </data>
+  <data name="DefaultStates" xml:space="preserve">
+    <value>Estados predeterminados</value>
+  </data>
+  <data name="DarkMode" xml:space="preserve">
+    <value>Modo oscuro</value>
+  </data>
+  <data name="ReleaseNotesTreeView" xml:space="preserve">
+    <value>Vista en árbol de notas de lanzamiento</value>
+  </data>
+  <data name="DefinitionOfReady" xml:space="preserve">
+    <value>Definición de Terminado</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.razor
@@ -42,20 +42,20 @@
             }
         </MudStack>
         <MudTabs Class="mt-4">
-            <MudTabPanel Text="General">
+            <MudTabPanel Text='@L["GeneralTab"]'>
                 <MudStack Spacing="2">
                     <MudTextField @bind-Value="_model.Organization" Label="Organization"/>
                     <MudTextField @bind-Value="_model.Project" Label="Project"/>
                     <MudTextField @bind-Value="_model.PatToken" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token"/>
-                    <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
-                    <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
-                    <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
-                    <MudSwitch T="bool" @bind-Value="_model.ReleaseNotesTreeView" Color="Color.Primary" Label="Release Notes Tree View"/>
+                    <MudTextField @bind-Value="_model.MainBranch" Label='@L["MainBranch"]'/>
+                    <MudTextField @bind-Value="_model.DefaultStates" Label='@L["DefaultStates"]' HelperText="Comma separated"/>
+                    <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label='@L["DarkMode"]'/>
+                    <MudSwitch T="bool" @bind-Value="_model.ReleaseNotesTreeView" Color="Color.Primary" Label='@L["ReleaseNotesTreeView"]'/>
                 </MudStack>
             </MudTabPanel>
-            <MudTabPanel Text="Story Quality">
+            <MudTabPanel Text='@L["StoryQualityTab"]'>
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.DefinitionOfReady" Label="Definition of Ready" Lines="3"/>
+                    <MudTextField @bind-Value="_model.DefinitionOfReady" Label='@L["DefinitionOfReady"]' Lines="3"/>
                 </MudStack>
             </MudTabPanel>
             <MudTabPanel Text='@L["PromptsTab"]'>
@@ -66,7 +66,7 @@
                     <MudTextField @bind-Value="_model.PromptCharacterLimit" Label='@L["PromptLimit"]' InputType="InputType.Number" />
                 </MudStack>
             </MudTabPanel>
-            <MudTabPanel Text="Validation Rules">
+            <MudTabPanel Text='@L["ValidationTab"]'>
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.h6" Class="mt-2">Epic</MudText>
                     <MudSwitch T="bool" @bind-Value="_model.Rules.Epic.HasDescription" Color="Color.Primary" Label="Has description"/>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -30,6 +30,15 @@
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Has story points</value>
   </data>
+  <data name="GeneralTab" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="StoryQualityTab" xml:space="preserve">
+    <value>Story Quality</value>
+  </data>
+  <data name="ValidationTab" xml:space="preserve">
+    <value>Validation Rules</value>
+  </data>
   <data name="Project" xml:space="preserve">
     <value>DevOps Project</value>
   </data>
@@ -74,5 +83,20 @@
   </data>
   <data name="MissingPat" xml:space="preserve">
     <value>A PAT token or global token is required.</value>
+  </data>
+  <data name="MainBranch" xml:space="preserve">
+    <value>Main Branch</value>
+  </data>
+  <data name="DefaultStates" xml:space="preserve">
+    <value>Default States</value>
+  </data>
+  <data name="DarkMode" xml:space="preserve">
+    <value>Dark Mode</value>
+  </data>
+  <data name="ReleaseNotesTreeView" xml:space="preserve">
+    <value>Release Notes Tree View</value>
+  </data>
+  <data name="DefinitionOfReady" xml:space="preserve">
+    <value>Definition of Ready</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -15,20 +15,20 @@
         <MudText Typo="Typo.h5">@L["ProjectSettings"] @ProjectName</MudText>
         <MudTextField T="string" Value="_projectName" ValueChanged="OnNameChanged" Label='@L["ProjectName"]' Immediate="true" />
         <MudTabs Class="mt-4">
-            <MudTabPanel Text="General">
+            <MudTabPanel Text='@L["GeneralTab"]'>
                 <MudStack Spacing="2">
                     <MudTextField T="string" Value="_model.Organization" ValueChanged="OnOrgChanged" Label="DevOps Organization" Immediate="true"/>
                     <MudTextField T="string" Value="_model.Project" ValueChanged="OnProjectChanged" Label="DevOps Project" Immediate="true"/>
                     <MudTextField T="string" Value="_model.PatToken" ValueChanged="OnPatChanged" Label="PAT Token" InputType="InputType.Password" HelperText="Leave blank to use global token" Immediate="true"/>
-                    <MudTextField @bind-Value="_model.MainBranch" Label="Main Branch"/>
-                    <MudTextField @bind-Value="_model.DefaultStates" Label="Default States" HelperText="Comma separated"/>
-                    <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label="Dark Mode"/>
-                    <MudSwitch T="bool" @bind-Value="_model.ReleaseNotesTreeView" Color="Color.Primary" Label="Release Notes Tree View"/>
+                    <MudTextField @bind-Value="_model.MainBranch" Label='@L["MainBranch"]'/>
+                    <MudTextField @bind-Value="_model.DefaultStates" Label='@L["DefaultStates"]' HelperText="Comma separated"/>
+                    <MudSwitch T="bool" @bind-Value="_model.DarkMode" Color="Color.Primary" Label='@L["DarkMode"]'/>
+                    <MudSwitch T="bool" @bind-Value="_model.ReleaseNotesTreeView" Color="Color.Primary" Label='@L["ReleaseNotesTreeView"]'/>
                 </MudStack>
             </MudTabPanel>
-            <MudTabPanel Text="Story Quality">
+            <MudTabPanel Text='@L["StoryQualityTab"]'>
                 <MudStack Spacing="2">
-                    <MudTextField @bind-Value="_model.DefinitionOfReady" Label="Definition of Ready" Lines="3"/>
+                    <MudTextField @bind-Value="_model.DefinitionOfReady" Label='@L["DefinitionOfReady"]' Lines="3"/>
                 </MudStack>
             </MudTabPanel>
             <MudTabPanel Text='@L["PromptsTab"]'>
@@ -39,7 +39,7 @@
                     <MudTextField @bind-Value="_model.PromptCharacterLimit" Label='@L["PromptLimit"]' InputType="InputType.Number" />
                 </MudStack>
             </MudTabPanel>
-            <MudTabPanel Text="Validation Rules">
+            <MudTabPanel Text='@L["ValidationTab"]'>
                 <MudStack Spacing="1">
                     <MudText Typo="Typo.h6" Class="mt-2">Epic</MudText>
                     <MudSwitch T="bool" @bind-Value="_model.Rules.Epic.HasDescription" Color="Color.Primary" Label="Has description"/>


### PR DESCRIPTION
## Summary
- move various settings labels and tab names into resx files
- use localized text for dark mode and related fields

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68582bb2e13c83288f5685727cafa692