### PR TITLE
Handle project validity changes

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -272,4 +272,43 @@ public class DevOpsConfigServiceTests
         var stored = await storage.GetItemAsync<bool?>("devops-dark");
         Assert.True(stored);
     }
+
+    [Fact]
+    public async Task SaveCurrentAsync_Raises_Event_When_Validity_Changes()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("one");
+        bool raised = false;
+        service.ProjectChanged += () => raised = true;
+
+        await service.SaveCurrentAsync("one", new DevOpsConfig
+        {
+            Organization = "Org",
+            Project = "Proj",
+            PatToken = "token"
+        });
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public async Task SaveCurrentAsync_Does_Not_Raise_Event_When_Validity_Unchanged()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+        await service.AddProjectAsync("one");
+        await service.SaveCurrentAsync("one", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        bool raised = false;
+        service.ProjectChanged += () => raised = true;
+
+        await service.SaveCurrentAsync("one", new DevOpsConfig
+        {
+            Organization = "Org2",
+            Project = "Proj2",
+            PatToken = "token2"
+        });
+
+        Assert.False(raised);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @using DevOpsAssistant.Components
 @inherits LayoutComponentBase
+@implements IDisposable
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
 @inject VersionService VersionService
@@ -71,6 +72,17 @@
     private bool _drawerOpen = true;
     private string _selectedProject = string.Empty;
     private bool _initialized;
+    
+    private void HandleProjectChanged()
+    {
+        _selectedProject = ConfigService.CurrentProject.Name;
+        InvokeAsync(StateHasChanged);
+    }
+
+    protected override void OnInitialized()
+    {
+        ConfigService.ProjectChanged += HandleProjectChanged;
+    }
 
     protected override void OnAfterRender(bool firstRender)
     {
@@ -175,5 +187,10 @@
     }
 
     private bool IsProjectInvalid => !ConfigService.IsCurrentProjectValid;
+
+    public void Dispose()
+    {
+        ConfigService.ProjectChanged -= HandleProjectChanged;
+    }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -67,6 +67,7 @@ public class DevOpsConfigService
 
     public async Task<bool> SaveCurrentAsync(string name, DevOpsConfig config)
     {
+        var wasValid = IsCurrentProjectValid;
         name = name.Trim();
         if (!CurrentProject.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
             Projects.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
@@ -75,6 +76,8 @@ public class DevOpsConfigService
         CurrentProject.Name = name;
         CurrentProject.Config = Normalize(config);
         await SaveProjectsAsync();
+        if (wasValid != IsCurrentProjectValid)
+            OnProjectChanged();
         return true;
     }
 


### PR DESCRIPTION
## Summary
- update `SaveCurrentAsync` to fire ProjectChanged when validity changes
- refresh navigation menu when projects change
- test DevOpsConfigService events

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68582d9aab548328a2e0035b54aff95c