### PR TITLE
Add PAT docs link and back button

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -69,6 +69,9 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Configuración guardada</value>
   </data>
+  <data name="Back" xml:space="preserve">
+    <value>Volver</value>
+  </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>Ya existe un proyecto con ese nombre.</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -69,6 +69,9 @@
   <data name="SavedMessage" xml:space="preserve">
     <value>Settings saved</value>
   </data>
+  <data name="Back" xml:space="preserve">
+    <value>Back</value>
+  </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>A project with that name already exists.</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación.</value>
+    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token (vea https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate). El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules.</value>
+    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token (see https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate). The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -13,6 +13,9 @@
 <MudPaper Class="p-4">
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@L["NewProject"]</MudText>
+        <MudText Typo="Typo.body2" Class="mb-2">
+            For help finding these values see the <MudLink Href="/help">help page</MudLink>.
+        </MudText>
         <MudTextField T="string" Value="_name" ValueChanged="OnNameChanged" Label='@L["ProjectName"]' Immediate="true" />
         <MudTextField T="string" Value="_organization" ValueChanged="OnOrgChanged" Label="DevOps Organization" Immediate="true" />
         <MudTextField T="string" Value="_project" ValueChanged="OnProjectChanged" Label="DevOps Project" Immediate="true" />
@@ -30,7 +33,13 @@
                 }
             </MudAlert>
         }
-        <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanCreate">@L["Create"]</MudButton>
+        <MudStack Row="true" Spacing="1">
+            @if (ConfigService.Projects.Any())
+            {
+                <MudButton OnClick="Back" Color="Color.Secondary" Variant="Variant.Text">@L["Back"]</MudButton>
+            }
+            <MudButton OnClick="Create" Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanCreate">@L["Create"]</MudButton>
+        </MudStack>
     </MudStack>
 </MudPaper>
 
@@ -119,5 +128,10 @@
             await ConfigService.SaveGlobalPatAsync(_patToken);
         }
         NavigationManager.NavigateTo($"/projects/{_name}", forceLoad: true);
+    }
+
+    private void Back()
+    {
+        NavigationManager.NavigateTo("/projects");
     }
 }


### PR DESCRIPTION
## Summary
- document how to get a PAT and where to find org/project values
- link to the help page from the new project form
- show a Back button on the new project form when projects exist

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68582e5ede608328b6d96f67399acb26