### PR TITLE
Enhance footer and help link

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -78,4 +78,7 @@
   <data name="Confirm" xml:space="preserve">
     <value>Confirmar</value>
   </data>
+  <data name="FooterCopyright" xml:space="preserve">
+    <value>&#169; {0} TommCarrr industries</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -59,12 +59,17 @@
         <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
             @Body
         </MudContainer>
+        <footer class="app-footer">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2">
+                <MudText Typo="Typo.caption" Align="Align.Center">
+                    Version @VersionService.Version
+                </MudText>
+                <MudText Typo="Typo.caption" Align="Align.Center">
+                    @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+                </MudText>
+            </MudContainer>
+        </footer>
     </MudMainContent>
-    <footer class="app-footer">
-        <MudText Typo="Typo.caption" Align="Align.Center">
-            Version @VersionService.Version
-        </MudText>
-    </footer>
 </MudLayout>
 
 @code {

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -78,4 +78,7 @@
   <data name="Confirm" xml:space="preserve">
     <value>Confirm</value>
   </data>
+  <data name="FooterCopyright" xml:space="preserve">
+    <value>&#169; {0} TommCarrr industries</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -33,4 +33,7 @@
   <data name="PatToken" xml:space="preserve">
     <value>Token PAT</value>
   </data>
+  <data name="FooterCopyright" xml:space="preserve">
+    <value>&#169; {0} TommCarrr industries</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -29,12 +29,17 @@
         <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
             @Body
         </MudContainer>
+        <footer class="app-footer">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2">
+                <MudText Typo="Typo.caption" Align="Align.Center">
+                    Version @VersionService.Version
+                </MudText>
+                <MudText Typo="Typo.caption" Align="Align.Center">
+                    @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+                </MudText>
+            </MudContainer>
+        </footer>
     </MudMainContent>
-    <footer class="app-footer">
-        <MudText Typo="Typo.caption" Align="Align.Center">
-            Version @VersionService.Version
-        </MudText>
-    </footer>
 </MudLayout>
 
 @code {

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -33,4 +33,7 @@
   <data name="PatToken" xml:space="preserve">
     <value>PAT Token</value>
   </data>
+  <data name="FooterCopyright" xml:space="preserve">
+    <value>&#169; {0} TommCarrr industries</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -40,6 +40,6 @@
     <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token (vea https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate). El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.</value>
+    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token. Consulte {0} para ver las instrucciones. El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
@@ -37,5 +37,8 @@
 </MudPaper>
 <MudPaper Class="pa-4 mb-4">
     <MudText Typo="Typo.h6">Settings</MudText>
-    <MudText Typo="Typo.body2">@L["Settings"]</MudText>
+    <MudText Typo="Typo.body2">
+        @((MarkupString)string.Format(L["Settings"],
+            "<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>this guide</a>"))
+    </MudText>
 </MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -40,6 +40,6 @@
     <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token (see https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate). The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.</value>
+    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token. See {0} for instructions. The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -159,10 +159,10 @@ html, body { height: 100%; }
 #app { min-height: 100vh; display: flex; flex-direction: column; }
 .app-footer {
     margin-top: auto;
-    background-color: var(--mud-palette-background, #f5f5f5);
+    background-color: var(--mud-palette-surface, #fff);
     border-top: 1px solid var(--mud-palette-lines, #e0e0e0);
     color: var(--mud-palette-text-primary, #000);
-    padding: 0.5rem 0;
+    padding: 1rem 0;
     z-index: 1;
     position: relative;
 }


### PR DESCRIPTION
## Summary
- convert PAT link in Help page into clickable markup
- move footer inside `MudMainContent`
- style footer with MudBlazor surface color and extra padding
- add copyright line via resources
- make footer year dynamic using `System.DateTime.Now.Year`

## Testing
- `./dotnet-install.sh --channel 9.0`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68585cda7a448328b086ab29197bc929