### PR TITLE
Fix build error due to null reference warning

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -59,6 +59,7 @@ public class MetricsPageTests : ComponentTestBase
         var list = (System.Collections.IList)periodsField.GetValue(metrics)!;
         Assert.True(list.Count > 0);
         var first = list[0];
+        Assert.NotNull(first);
         var start = (DateTime)first.GetType().GetProperty("Start")!.GetValue(first)!;
         var end = (DateTime)first.GetType().GetProperty("End")!.GetValue(first)!;
         Assert.Equal(13, (end - start).TotalDays);


### PR DESCRIPTION
## Summary
- fix nullable dereference in MetricsPageTests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity normal`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-restore -warnaserror /nologo`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -warnaserror /nologo`


------
https://chatgpt.com/codex/tasks/task_e_68586beb2bb48328bb74563bf5b9ef74