### PR TITLE
Improve footer layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -60,12 +60,12 @@
             @Body
         </MudContainer>
         <footer class="app-footer">
-            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2">
-                <MudText Typo="Typo.caption" Align="Align.Center">
-                    Version @VersionService.Version
-                </MudText>
-                <MudText Typo="Typo.caption" Align="Align.Center">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
+                <MudText Typo="Typo.body2" Align="Align.Left">
                     @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+                </MudText>
+                <MudText Typo="Typo.caption" Align="Align.Right">
+                    Version @VersionService.Version
                 </MudText>
             </MudContainer>
         </footer>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -30,12 +30,12 @@
             @Body
         </MudContainer>
         <footer class="app-footer">
-            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2">
-                <MudText Typo="Typo.caption" Align="Align.Center">
-                    Version @VersionService.Version
-                </MudText>
-                <MudText Typo="Typo.caption" Align="Align.Center">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
+                <MudText Typo="Typo.body2" Align="Align.Left">
                     @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+                </MudText>
+                <MudText Typo="Typo.caption" Align="Align.Right">
+                    Version @VersionService.Version
                 </MudText>
             </MudContainer>
         </footer>

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -154,9 +154,27 @@ code {
     color: var(--mud-palette-text-secondary, #6c757d);
 }
 
+.footer-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
 /* layout */
-html, body { height: 100%; }
-#app { min-height: 100vh; display: flex; flex-direction: column; }
+html, body {
+    height: 100%;
+    margin: 0;
+}
+body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+#app {
+    flex: 1 0 auto;
+    display: flex;
+    flex-direction: column;
+}
 .app-footer {
     margin-top: auto;
     background-color: var(--mud-palette-surface, #fff);


### PR DESCRIPTION
## Summary
- keep footer at viewport bottom when content is short
- line up footer items horizontally and enlarge copyright text

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68587976dcdc8328b39fad77e4dd0189