### PR TITLE
Add production environment approval

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -67,6 +67,7 @@ jobs:
 
   deploy_production:
     runs-on: ubuntu-latest
+    environment: production
     needs: ui_tests
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ artifact.
 When changes are merged into the `main` branch, the deployment workflow first
 publishes the site to a staging environment. Playwright UI tests verify that
 each page loads correctly before the same build is promoted to production.
+The production deployment runs in the `production` environment so GitHub can
+require approval from designated reviewers before the job executes.
 During pull requests the CI workflow only runs the unit tests.
 
 ### Azure Static Web Apps


### PR DESCRIPTION
## Summary
- require production job to run in the `production` environment
- document that production deployments require approval

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6858f3387a1083289830ab69cb807f0a