### PR TITLE
Ensure sticky footer

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -4,6 +4,7 @@ using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
 using System.Threading.Tasks;
 using System.Linq;
+using System.IO;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
 using Bunit.TestDoubles;
@@ -71,6 +72,21 @@ public class MainLayoutTests : ComponentTestBase
         var cut = RenderComponent<MainLayout>();
 
         cut.WaitForAssertion(() => Assert.Contains("Version 1.0", cut.Markup));
+    }
+
+    [Fact]
+    public void Footer_Uses_Sticky_Flexbox_Css()
+    {
+        var cssPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,
+            "../../../../DevOpsAssistant/wwwroot/css/app.css"));
+        Assert.True(File.Exists(cssPath));
+        var css = File.ReadAllText(cssPath);
+
+        Assert.Contains("body {", css);
+        Assert.Contains("display: flex", css);
+        Assert.Contains("min-height: 100vh", css);
+        Assert.Contains(".app-footer {", css);
+        Assert.Contains("margin-top: auto", css);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- ensure layout CSS for sticky footer stays in place by testing for the rule in `app.css`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68590442a34c8328ba4a0498cda03082