### PR TITLE
Ensure footer stays at bottom

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -55,9 +55,11 @@
     </MudDrawer>
 
     <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
-            @Body
-        </MudContainer>
+        <div class="main-content">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
+                @Body
+            </MudContainer>
+        </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
                 <MudText Typo="Typo.body2" Align="Align.Left">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -26,9 +26,11 @@
     </MudAppBar>
 
     <MudMainContent>
-        <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
-            @Body
-        </MudContainer>
+        <div class="main-content">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4 mt-4">
+                @Body
+            </MudContainer>
+        </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
                 <MudText Typo="Typo.body2" Align="Align.Left">

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -179,6 +179,9 @@ body {
     display: flex;
     flex-direction: column;
 }
+.main-content {
+    flex: 1;
+}
 .app-footer {
     margin-top: auto;
     background-color: var(--mud-palette-surface, #fff);


### PR DESCRIPTION
## Summary
- make footer sticky by wrapping page content in `main-content`
- support new wrapper in CSS for all layouts

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68591c5cd92083288965c55a870b5095