### PR TITLE
Add flexbox styles to layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -89,6 +89,8 @@ public class MainLayoutTests : ComponentTestBase
         Assert.Contains("margin-top: auto", css);
         Assert.Contains(".mud-main-content", css);
         Assert.Contains("flex-direction: column", css);
+        Assert.Contains(".mud-layout", css);
+        Assert.Contains("flex: 1", css);
     }
 
     [Fact]

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -175,9 +175,13 @@ body {
     display: flex;
     flex-direction: column;
 }
+.mud-layout {
+    display: flex;
+}
 .mud-main-content {
     display: flex;
     flex-direction: column;
+    flex: 1;
 }
 .main-content {
     flex: 1;


### PR DESCRIPTION
## Summary
- enable flexbox on MudLayout
- ensure MudMainContent stretches to fill the layout
- verify new styles in layout tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685922dbf0508328853d0305ed2ca8eb