### PR TITLE
Redirect new project creation to settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -127,7 +127,7 @@
         {
             await ConfigService.SaveGlobalPatAsync(_patToken);
         }
-        NavigationManager.NavigateTo($"/projects/{_name}", forceLoad: true);
+        NavigationManager.NavigateTo($"/projects/{_name}/settings", forceLoad: true);
     }
 
     private void Back()


### PR DESCRIPTION
## Summary
- navigate to `/projects/{name}/settings` after project creation so the user can immediately configure the new project

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68592e02b1d48328a178cbd3bf9fb9c5