### PR TITLE
Add high contrast toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,5 @@ where to connect.
 Common colors are now defined using CSS variables. When the browser indicates a
 need for high contrast, the site automatically switches to a simplified color
 palette. You can also force this mode by adding the `high-contrast` class to the
-`<body>` element.
+`<body>` element or by toggling the High Contrast option in the Global Settings
+dialog.

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -274,6 +274,19 @@ public class DevOpsConfigServiceTests
     }
 
     [Fact]
+    public async Task SaveGlobalHighContrastAsync_Persists_Value()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+
+        await service.SaveGlobalHighContrastAsync(true);
+
+        Assert.True(service.GlobalHighContrast);
+        var stored = await storage.GetItemAsync<bool?>("devops-contrast");
+        Assert.True(stored);
+    }
+
+    [Fact]
     public async Task SaveCurrentAsync_Raises_Event_When_Validity_Changes()
     {
         var storage = new FakeLocalStorageService();

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
@@ -27,4 +27,7 @@
   <data name="DarkMode" xml:space="preserve">
     <value>Modo oscuro</value>
   </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>Alto contraste</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
@@ -1,6 +1,7 @@
 @inject DevOpsConfigService ConfigService
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
+@inject IJSRuntime JS
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<GlobalOptionsDialog> L
 
@@ -9,6 +10,7 @@
         <MudStack Spacing="2">
             <MudTextField @bind-Value="_token" Label='@L["PatToken"]' InputType="InputType.Password" />
             <MudSwitch T="bool" @bind-Value="_darkMode" Color="Color.Primary" Label='@L["DarkMode"]'/>
+            <MudSwitch T="bool" @bind-Value="_highContrast" Color="Color.Primary" Label='@L["HighContrast"]'/>
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -21,18 +23,22 @@
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
     private string _token = string.Empty;
     private bool _darkMode;
+    private bool _highContrast;
 
     protected override async Task OnInitializedAsync()
     {
         await ConfigService.LoadAsync();
         _token = ConfigService.GlobalPatToken;
         _darkMode = ConfigService.GlobalDarkMode;
+        _highContrast = ConfigService.GlobalHighContrast;
     }
 
     private async Task Save()
     {
         await ConfigService.SaveGlobalPatAsync(_token);
         await ConfigService.SaveGlobalDarkModeAsync(_darkMode);
+        await ConfigService.SaveGlobalHighContrastAsync(_highContrast);
+        await JS.InvokeVoidAsync("setHighContrast", _highContrast);
         Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
         MudDialog.Close(DialogResult.Ok(true));
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
@@ -27,4 +27,7 @@
   <data name="DarkMode" xml:space="preserve">
     <value>Dark Mode</value>
   </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>High Contrast</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -90,8 +90,12 @@
         ConfigService.ProjectChanged += HandleProjectChanged;
     }
 
-    protected override void OnAfterRender(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("setHighContrast", ConfigService.GlobalHighContrast);
+        }
         if (!_initialized)
             return;
         EnsureSettingsIfNeeded();

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -3,6 +3,7 @@
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
 @inject VersionService VersionService
+@inject IJSRuntime JS
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SimpleLayout> L
 
@@ -49,6 +50,14 @@
     {
         await VersionService.LoadAsync();
         await ConfigService.LoadAsync();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JS.InvokeVoidAsync("setHighContrast", ConfigService.GlobalHighContrast);
+        }
     }
 
     private async Task SignOut()

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -8,6 +8,7 @@ public class DevOpsConfigService
     private const string StorageKey = "devops-projects";
     private const string GlobalPatKey = "devops-pat";
     private const string GlobalDarkKey = "devops-dark";
+    private const string GlobalContrastKey = "devops-contrast";
     private readonly ILocalStorageService _localStorage;
 
     public event Action? ProjectChanged;
@@ -24,6 +25,7 @@ public class DevOpsConfigService
 
     public string GlobalPatToken { get; private set; } = string.Empty;
     public bool GlobalDarkMode { get; private set; }
+    public bool GlobalHighContrast { get; private set; }
 
     public DevOpsConfig Config => CurrentProject.Config;
 
@@ -38,6 +40,7 @@ public class DevOpsConfigService
     {
         GlobalPatToken = await _localStorage.GetItemAsync<string>(GlobalPatKey) ?? string.Empty;
         GlobalDarkMode = await _localStorage.GetItemAsync<bool?>(GlobalDarkKey) ?? false;
+        GlobalHighContrast = await _localStorage.GetItemAsync<bool?>(GlobalContrastKey) ?? false;
         var projects = await _localStorage.GetItemAsync<List<DevOpsProject>>(StorageKey);
         if (projects != null && projects.Count > 0)
         {
@@ -91,6 +94,12 @@ public class DevOpsConfigService
     {
         GlobalDarkMode = value;
         await _localStorage.SetItemAsync(GlobalDarkKey, GlobalDarkMode);
+    }
+
+    public async Task SaveGlobalHighContrastAsync(bool value)
+    {
+        GlobalHighContrast = value;
+        await _localStorage.SetItemAsync(GlobalContrastKey, GlobalHighContrast);
     }
 
     public async Task<bool> UpdateProjectAsync(string existingName, string newName, DevOpsConfig config)
@@ -214,10 +223,12 @@ public class DevOpsConfigService
         CurrentProject = new DevOpsProject();
         GlobalPatToken = string.Empty;
         GlobalDarkMode = false;
+        GlobalHighContrast = false;
         await _localStorage.RemoveItemAsync(StorageKey);
         await _localStorage.RemoveItemAsync(LegacyStorageKey);
         await _localStorage.RemoveItemAsync(GlobalPatKey);
         await _localStorage.RemoveItemAsync(GlobalDarkKey);
+        await _localStorage.RemoveItemAsync(GlobalContrastKey);
         OnProjectChanged();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -31,6 +31,13 @@ window.blazorCulture = {
     }
 };
 
+window.setHighContrast = function (enabled) {
+    if (enabled)
+        document.body.classList.add('high-contrast');
+    else
+        document.body.classList.remove('high-contrast');
+};
+
 if (window.matchMedia && window.matchMedia('(prefers-contrast: more)').matches) {
-    document.body.classList.add('high-contrast');
+    window.setHighContrast(true);
 }


### PR DESCRIPTION
## Summary
- add high-contrast switch in global options
- store preference in `DevOpsConfigService`
- add JS helper and apply in layouts
- document high contrast toggle in README
- test persistence of new option

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685934e0fc8c8328bb0bf4cc11ed7ac8