### PR TITLE
Align version text

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -62,10 +62,10 @@
         </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
-                <MudText Typo="Typo.body2" Align="Align.Left">
+                <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
                     @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
                 </MudText>
-                <MudText Typo="Typo.caption" Align="Align.Right">
+                <MudText Typo="Typo.caption" Align="Align.Right" Inline="true">
                     Version @VersionService.Version
                 </MudText>
             </MudContainer>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -33,10 +33,10 @@
         </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="py-2 footer-content">
-                <MudText Typo="Typo.body2" Align="Align.Left">
+                <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
                     @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
                 </MudText>
-                <MudText Typo="Typo.caption" Align="Align.Right">
+                <MudText Typo="Typo.caption" Align="Align.Right" Inline="true">
                     Version @VersionService.Version
                 </MudText>
             </MudContainer>


### PR DESCRIPTION
## Summary
- keep version text inline in footer containers

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6859673982388328ac38188ec6d8347c