### PR TITLE
Fix bug rules defaults

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -160,9 +160,9 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.PatToken);
         Assert.False(service.Config.DarkMode);
         Assert.False(service.Config.ReleaseNotesTreeView);
-        Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
-        Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
-        Assert.True(service.Config.Rules.Bug.HasStoryPoints);
+        Assert.False(service.Config.Rules.Bug.IncludeReproSteps);
+        Assert.False(service.Config.Rules.Bug.IncludeSystemInfo);
+        Assert.False(service.Config.Rules.Bug.HasStoryPoints);
         Assert.Equal(string.Empty, service.Config.DefaultStates);
         Assert.NotNull(service.Config.Rules);
     }
@@ -182,9 +182,9 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.ReleaseNotesPrompt);
         Assert.Equal(string.Empty, service.Config.RequirementsPrompt);
         Assert.False(service.Config.ReleaseNotesTreeView);
-        Assert.True(service.Config.Rules.Bug.IncludeReproSteps);
-        Assert.True(service.Config.Rules.Bug.IncludeSystemInfo);
-        Assert.True(service.Config.Rules.Bug.HasStoryPoints);
+        Assert.False(service.Config.Rules.Bug.IncludeReproSteps);
+        Assert.False(service.Config.Rules.Bug.IncludeSystemInfo);
+        Assert.False(service.Config.Rules.Bug.HasStoryPoints);
         Assert.False(await storage.ContainKeyAsync("devops-projects"));
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/BugRules.cs
@@ -2,7 +2,7 @@ namespace DevOpsAssistant.Services.Models;
 
 public class BugRules
 {
-    public bool IncludeReproSteps { get; set; } = true;
-    public bool IncludeSystemInfo { get; set; } = true;
-    public bool HasStoryPoints { get; set; } = true;
+    public bool IncludeReproSteps { get; set; } = false;
+    public bool IncludeSystemInfo { get; set; } = false;
+    public bool HasStoryPoints { get; set; } = false;
 }


### PR DESCRIPTION
## Summary
- ensure bug validation rules default to false
- update unit tests for new defaults

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6859722c98dc83289f78c9061047bb0e