### PR TITLE
Add hidden Doom theme

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
@@ -1,0 +1,62 @@
+@import url('https://fonts.cdnfonts.com/css/amazdoom');
+
+body.doom-theme {
+    --doom-rock: #423A31;
+    --doom-abyss: #0D0D0D;
+    --doom-steel: #7C7C7C;
+    --doom-blood: #A00000;
+    --doom-hellfire: #FF6600;
+    --doom-bone: #D1C6B9;
+    --doom-toxic: #00A000;
+
+    background-color: var(--doom-rock);
+    color: var(--doom-bone);
+    font-family: 'AmazDooM', sans-serif;
+}
+
+body.doom-theme .mud-appbar {
+    background: linear-gradient(160deg, var(--doom-abyss) 10%, var(--doom-rock) 90%);
+    color: var(--doom-bone);
+}
+
+body.doom-theme .mud-button,
+body.doom-theme .btn-primary {
+    background: linear-gradient(to bottom, var(--doom-blood), var(--doom-abyss));
+    color: #fff;
+    border: 1px solid var(--doom-bone);
+}
+
+body.doom-theme .mud-button:hover,
+body.doom-theme .btn-primary:hover {
+    background: linear-gradient(to bottom, var(--doom-abyss), var(--doom-blood));
+}
+
+body.doom-theme .mud-paper,
+body.doom-theme .card {
+    background: var(--doom-steel);
+    background-image: linear-gradient(90deg,
+        rgba(255, 255, 255, 0.05) 0%,
+        rgba(255, 255, 255, 0.05) 50%,
+        transparent 50%,
+        transparent 100%);
+    background-size: 4px 4px;
+    border: 1px solid var(--doom-abyss);
+    color: var(--doom-bone);
+}
+
+body.doom-theme .mud-alert,
+body.doom-theme .alert-danger {
+    background: linear-gradient(to right, var(--doom-blood), var(--doom-hellfire));
+    color: #fff;
+    padding: 0.75rem 1rem;
+    border-radius: 0.25rem;
+}
+
+body.doom-theme .app-footer {
+    background-color: var(--doom-abyss);
+    color: var(--doom-bone);
+}
+
+body.doom-theme .text-success {
+    color: var(--doom-toxic);
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -48,3 +48,47 @@ window.setHighContrast = function (enabled) {
 if (window.matchMedia && window.matchMedia('(prefers-contrast: more)').matches) {
     window.setHighContrast(true);
 }
+
+(function () {
+    const cheat = 'iddqd';
+    let buffer = '';
+
+    function activateDoomTheme() {
+        if (document.body.classList.contains('doom-theme'))
+            return;
+
+        let link = document.getElementById('doom-stylesheet');
+        if (!link) {
+            link = document.createElement('link');
+            link.id = 'doom-stylesheet';
+            link.rel = 'stylesheet';
+            link.href = 'css/doom.css';
+            document.head.appendChild(link);
+        }
+
+        document.body.classList.add('doom-theme');
+        localStorage['doom-theme'] = '1';
+    }
+
+    function removeDoomTheme() {
+        const link = document.getElementById('doom-stylesheet');
+        if (link)
+            link.remove();
+        document.body.classList.remove('doom-theme');
+        localStorage.removeItem('doom-theme');
+    }
+
+    document.addEventListener('keydown', function (e) {
+        buffer += e.key.toLowerCase();
+        if (buffer.length > cheat.length)
+            buffer = buffer.slice(-cheat.length);
+        if (buffer === cheat)
+            activateDoomTheme();
+    });
+
+    if (localStorage['doom-theme'] === '1')
+        activateDoomTheme();
+
+    window.activateDoomTheme = activateDoomTheme;
+    window.removeDoomTheme = removeDoomTheme;
+})();


### PR DESCRIPTION
## Summary
- implement cheat code detection in `scripts.js`
- create `doom.css` with colors and fonts for secret theme
- allow removing the theme via `removeDoomTheme`

## Testing
- `./dotnet-install.sh --channel 9.0`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6859bb31f67883289e6090a668a976f4