### PR TITLE
Fix initialization override

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -93,7 +93,7 @@
         ConfigService.ProjectChanged += HandleProjectChanged;
     }
 
-    protected override async Task OnAfterRenderAsync(bool firstRender)
+    protected override void OnAfterRender(bool firstRender)
     {
         if (!_initialized)
             return;


### PR DESCRIPTION
## Summary
- use `OnAfterRender` instead of async override for initialization

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`
- `dotnet publish src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release -o publish`


------
https://chatgpt.com/codex/tasks/task_e_685a918237488328b9f48f8b3850092e