### PR TITLE
Add help dialog

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -69,7 +69,6 @@ public class UiTests
     [InlineData("Metrics", "Metrics")]
     [InlineData("Requirement Planner", "Requirement Planner")]
     [InlineData("Branch Health", "Branch Health")]
-    [InlineData("Help", "Help & Instructions")]
     public async Task Nav_Menu_Navigates_To_Correct_Page(string linkText, string heading)
     {
         if (string.IsNullOrEmpty(_baseUrl))
@@ -83,6 +82,23 @@ public class UiTests
         await page.ReloadAsync();
         await page.GetByRole(AriaRole.Link, new() { Name = linkText }).ClickAsync();
         var element = await page.QuerySelectorAsync($"text={heading}");
+        Assert.NotNull(element);
+    }
+
+    [Fact]
+    public async Task Help_Button_Shows_Dialog()
+    {
+        if (string.IsNullOrEmpty(_baseUrl))
+            return;
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+        await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
+        await page.ReloadAsync();
+        await page.GetByRole(AriaRole.Button, new() { Name = "Help" }).ClickAsync();
+        var element = await page.QuerySelectorAsync("text=Help & Instructions");
         Assert.NotNull(element);
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -1,0 +1,42 @@
+@using DevOpsAssistant.Pages
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Help> L
+
+<MudText Typo="Typo.h4" Class="mb-4">@L["Heading"]</MudText>
+<MudText Typo="Typo.body1" Class="mb-4">@L["Intro"]</MudText>
+
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
+    <MudText Typo="Typo.body2">@L["Epics"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Story Validation</MudText>
+    <MudText Typo="Typo.body2">@L["Validation"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Story Quality</MudText>
+    <MudText Typo="Typo.body2">@L["Quality"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Requirement Planner</MudText>
+    <MudText Typo="Typo.body2">@L["RequirementsPlanner"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Release Notes</MudText>
+    <MudText Typo="Typo.body2">@L["ReleaseNotes"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Metrics</MudText>
+    <MudText Typo="Typo.body2">@L["Metrics"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Branch Health</MudText>
+    <MudText Typo="Typo.body2">@L["BranchHealth"]</MudText>
+</MudPaper>
+<MudPaper Class="pa-4 mb-4">
+    <MudText Typo="Typo.h6">Settings</MudText>
+    <MudText Typo="Typo.body2">
+        @((MarkupString)string.Format(L["Settings"],
+            "<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>this guide</a>"))
+    </MudText>
+</MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
@@ -1,0 +1,17 @@
+@using DevOpsAssistant.Pages
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<Help> L
+
+<MudDialog MaxWidth="MaxWidth.False" FullWidth="true" ContentClass="pa-4" ActionsClass="pa-4">
+    <DialogContent>
+        <HelpContent />
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Primary">@L["Close"]</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    private void Close() => MudDialog.Cancel();
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -31,7 +31,7 @@
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
         </MudMenu>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]' class="me-2"/>
-        <MudIconButton Icon="@Icons.Material.Filled.Help" Href="/help" title='@L["Help"]' class="me-2"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="me-2"/>
         <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
             <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
             <MudMenuItem OnClick="RemoveOrg">@L["RemoveOrg"]</MudMenuItem>
@@ -158,6 +158,11 @@
     private async Task OpenOptionsDialog()
     {
         await DialogService.ShowAsync<GlobalOptionsDialog>(L["GlobalSettings"]);
+    }
+
+    private async Task OpenHelpDialog()
+    {
+        await DialogService.ShowAsync<HelpDialog>(L["Help"]);
     }
 
     private async Task ChangeProject(string name)

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -20,7 +20,7 @@
         <MudSpacer/>
         <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)" Color="Color.Inherit" OnClick="ToggleDarkMode" class="me-2"/>
         <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]'/>
-        <MudIconButton Icon="@Icons.Material.Filled.Help" Href="/help" title='@L["Help"]' class="mx-2"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="mx-2"/>
         <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
             <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
             <MudMenuItem OnClick="RemoveOrg">@L["RemoveOrg"]</MudMenuItem>
@@ -101,5 +101,10 @@
     private async Task OpenOptionsDialog()
     {
         await DialogService.ShowAsync<GlobalOptionsDialog>(L["GlobalSettings"]);
+    }
+
+    private async Task OpenHelpDialog()
+    {
+        await DialogService.ShowAsync<HelpDialog>(L["Help"]);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -42,4 +42,7 @@
   <data name="Settings" xml:space="preserve">
     <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token. Consulte {0} para ver las instrucciones. El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.</value>
   </data>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
@@ -1,44 +1,8 @@
 @page "/help"
 @using Microsoft.Extensions.Localization
+@using DevOpsAssistant.Components
 @inject IStringLocalizer<Help> L
 
 <PageTitle>DevOpsAssistant - Help</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-4">@L["Heading"]</MudText>
-<MudText Typo="Typo.body1" Class="mb-4">@L["Intro"]</MudText>
-
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
-    <MudText Typo="Typo.body2">@L["Epics"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Story Validation</MudText>
-    <MudText Typo="Typo.body2">@L["Validation"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Story Quality</MudText>
-    <MudText Typo="Typo.body2">@L["Quality"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Requirement Planner</MudText>
-    <MudText Typo="Typo.body2">@L["RequirementsPlanner"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Release Notes</MudText>
-    <MudText Typo="Typo.body2">@L["ReleaseNotes"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Metrics</MudText>
-    <MudText Typo="Typo.body2">@L["Metrics"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Branch Health</MudText>
-    <MudText Typo="Typo.body2">@L["BranchHealth"]</MudText>
-</MudPaper>
-<MudPaper Class="pa-4 mb-4">
-    <MudText Typo="Typo.h6">Settings</MudText>
-    <MudText Typo="Typo.body2">
-        @((MarkupString)string.Format(L["Settings"],
-            "<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>this guide</a>"))
-    </MudText>
-</MudPaper>
+<HelpContent />

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -42,4 +42,7 @@
   <data name="Settings" xml:space="preserve">
     <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token. See {0} for instructions. The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.</value>
   </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/NewProject.razor
@@ -4,9 +4,11 @@
 @using DevOpsAssistant.Components
 @inject DevOpsConfigService ConfigService
 @inject NavigationManager NavigationManager
+@inject IDialogService DialogService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SettingsDialog> L
 @inject IStringLocalizer<GlobalOptionsDialog> TL
+@inject IStringLocalizer<Help> HL
 
 <PageTitle>DevOpsAssistant - New Project</PageTitle>
 
@@ -14,7 +16,7 @@
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@L["NewProject"]</MudText>
         <MudText Typo="Typo.body2" Class="mb-2">
-            For help finding these values see the <MudLink Href="/help">help page</MudLink>.
+            For help finding these values see the <MudLink Href="#" OnClick="OpenHelpDialog">help page</MudLink>.
         </MudText>
         @if (string.IsNullOrWhiteSpace(ConfigService.GlobalOrganization))
         {
@@ -180,5 +182,10 @@
     private void Back()
     {
         NavigationManager.NavigateTo("/projects");
+    }
+
+    private async Task OpenHelpDialog()
+    {
+        await DialogService.ShowAsync<HelpDialog>(HL["Heading"]);
     }
 }


### PR DESCRIPTION
## Summary
- show Help page as a dialog
- hook up toolbar Help buttons to open the dialog
- allow opening help dialog from the new project page
- update tests for the new behaviour

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685aac2342308328a88fbb6dc5660fc2