### PR TITLE
Improve top bar

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -129,4 +129,17 @@ public class MainLayoutTests : ComponentTestBase
 
         Assert.Equal("http://localhost/projects/Two/settings", nav.Uri);
     }
+
+    [Fact]
+    public async Task Current_Project_Name_Displayed_In_AppBar()
+    {
+        var config = SetupServices();
+        await config.AddProjectAsync("Demo");
+        await config.SelectProjectAsync("Demo");
+
+        var cut = RenderComponent<MainLayout>();
+
+        var text = cut.Find(".current-project");
+        Assert.Equal("Demo", text.TextContent);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -21,7 +21,6 @@
             <MudNavLink Href="" Match="NavLinkMatch.All" Style="color:inherit;text-decoration:none">DevOpsAssistant</MudNavLink>
         </MudText>
         <MudSpacer/>
-        <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)" Color="Color.Inherit" OnClick="ToggleDarkMode" class="me-2"/>
         <MudMenu Label='@L["Projects"]' Class="me-2">
             @foreach (var p in ConfigService.Projects)
             {
@@ -30,9 +29,14 @@
             <MudDivider />
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
         </MudMenu>
-        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]' class="me-2"/>
-        <MudIconButton Icon="@Icons.Material.Filled.Help" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="me-2"/>
-        <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
+        @if (!string.IsNullOrEmpty(_selectedProject))
+        {
+            <MudText Typo="Typo.subtitle2" Class="me-2 current-project">@_selectedProject</MudText>
+        }
+        <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)" Color="Color.Inherit" OnClick="ToggleDarkMode" class="me-2"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Inherit" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]' class="me-2"/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" Color="Color.Inherit" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="me-2"/>
+        <MudMenu Icon="@Icons.Material.Filled.Logout" Color="Color.Inherit" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
             <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
             <MudMenuItem OnClick="RemoveOrg">@L["RemoveOrg"]</MudMenuItem>
             <MudMenuItem OnClick="SignOut">@L["RemoveAll"]</MudMenuItem>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -19,9 +19,9 @@
         </MudText>
         <MudSpacer/>
         <MudIconButton Icon="@(_isDarkMode ? Icons.Material.Filled.DarkMode : Icons.Material.Filled.LightMode)" Color="Color.Inherit" OnClick="ToggleDarkMode" class="me-2"/>
-        <MudIconButton Icon="@Icons.Material.Filled.Settings" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]'/>
-        <MudIconButton Icon="@Icons.Material.Filled.Help" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="mx-2"/>
-        <MudMenu Icon="@Icons.Material.Filled.Logout" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
+        <MudIconButton Icon="@Icons.Material.Filled.Settings" Color="Color.Inherit" OnClick="OpenOptionsDialog" title='@L["GlobalSettings"]'/>
+        <MudIconButton Icon="@Icons.Material.Filled.Help" Color="Color.Inherit" OnClick="OpenHelpDialog" aria-label="@L["Help"]" title='@L["Help"]' class="mx-2"/>
+        <MudMenu Icon="@Icons.Material.Filled.Logout" Color="Color.Inherit" Dense="true" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.TopCenter" title='@L["SignOut"]'>
             <MudMenuItem OnClick="RemovePat">@L["RemovePat"]</MudMenuItem>
             <MudMenuItem OnClick="RemoveOrg">@L["RemoveOrg"]</MudMenuItem>
             <MudMenuItem OnClick="SignOut">@L["RemoveAll"]</MudMenuItem>


### PR DESCRIPTION
## Summary
- adjust app bar control order for better UX
- color icons to match dark mode
- display current project name
- test project name display

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685ab1d3e96483288558d23d593eba21