### PR TITLE
Fix build errors in HelpDialog

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Help> L
 
-<MudDialog MaxWidth="MaxWidth.False" FullWidth="true" ContentClass="pa-4" ActionsClass="pa-4">
+<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
     <DialogContent>
         <HelpContent />
     </DialogContent>


### PR DESCRIPTION
## Summary
- remove unsupported `MaxWidth` and `FullWidth` parameters from `HelpDialog`

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685ab462b53483289a091343bfca8778