### PR TITLE
Refine help page layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -2,41 +2,43 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Help> L
 
+<div class="help-content">
 <MudText Typo="Typo.h4" Class="mb-4">@L["Heading"]</MudText>
-<MudText Typo="Typo.body1" Class="mb-4">@L["Intro"]</MudText>
+<MudText Typo="Typo.body1" Class="mb-6">@((MarkupString)L["Intro"].Value)</MudText>
 
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
-    <MudText Typo="Typo.body2">@L["Epics"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["Epics"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Story Validation</MudText>
-    <MudText Typo="Typo.body2">@L["Validation"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["Validation"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Story Quality</MudText>
-    <MudText Typo="Typo.body2">@L["Quality"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["Quality"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Requirement Planner</MudText>
-    <MudText Typo="Typo.body2">@L["RequirementsPlanner"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["RequirementsPlanner"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Release Notes</MudText>
-    <MudText Typo="Typo.body2">@L["ReleaseNotes"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["ReleaseNotes"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Metrics</MudText>
-    <MudText Typo="Typo.body2">@L["Metrics"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["Metrics"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Branch Health</MudText>
-    <MudText Typo="Typo.body2">@L["BranchHealth"]</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["BranchHealth"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4 mb-4">
+<MudPaper Class="pa-4 mb-6">
     <MudText Typo="Typo.h6">Settings</MudText>
     <MudText Typo="Typo.body2">
         @((MarkupString)string.Format(L["Settings"],
             "<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>this guide</a>"))
     </MudText>
 </MudPaper>
+</div>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -16,31 +16,31 @@
     <value>Ayuda e instrucciones</value>
   </data>
   <data name="Intro" xml:space="preserve">
-    <value>Esta página describe cómo usar cada sección de DevOpsAssistant.</value>
+    <value>&lt;p&gt;Bienvenido a DevOpsAssistant. Esta página explica brevemente cómo funciona cada sección.&lt;/p&gt;&lt;p&gt;Utilice estas herramientas para revisar su backlog y generar métricas que mejoren la planificación.&lt;/p&gt;</value>
   </data>
   <data name="Epics" xml:space="preserve">
-    <value>Cargue un backlog para visualizar épicas y características. Los estados sugeridos aparecen cuando los padres difieren de sus hijos y se pueden actualizar.</value>
+    <value>&lt;p&gt;Cargue un backlog para visualizar épicas y características. Los estados sugeridos aparecen cuando los padres difieren de sus hijos.&lt;/p&gt;&lt;p&gt;Aplique esos estados para mantener la jerarquía coherente.&lt;/p&gt;</value>
   </data>
   <data name="Validation" xml:space="preserve">
-    <value>Seleccione un backlog y estados y luego verifique los elementos de trabajo con sus reglas. Las violaciones pueden etiquetarse para seguimiento.</value>
+    <value>&lt;p&gt;Seleccione un backlog y estados y luego verifique los elementos de trabajo con sus reglas.&lt;/p&gt;&lt;p&gt;Las violaciones pueden etiquetarse para seguimiento y asegurar que nada se escape.&lt;/p&gt;</value>
   </data>
   <data name="Quality" xml:space="preserve">
-    <value>Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready. Los prompts largos se dividen en partes y puede cambiar entre ellas con las flechas.</value>
+    <value>&lt;p&gt;Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready.&lt;/p&gt;&lt;p&gt;Los prompts largos se dividen en partes y puede cambiar entre ellas con las flechas.&lt;/p&gt;</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos. Utilice HTML en las descripciones y criterios cuando ayude a formatear listas u otra estructura; no agregue etiquetas innecesarias. Active Vista previa HTML tras importar para verificar el marcado.</value>
+    <value>&lt;p&gt;Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos.&lt;/p&gt;&lt;p&gt;Utilice HTML en las descripciones y criterios cuando ayude al formato. Active Vista previa HTML tras importar para verificar el marcado.&lt;/p&gt;</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento. Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.</value>
+    <value>&lt;p&gt;Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.&lt;/p&gt;&lt;p&gt;Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.&lt;/p&gt;</value>
   </data>
   <data name="Metrics" xml:space="preserve">
-    <value>Muestre gráficos de rendimiento, tiempo de entrega y tiempo de ciclo para el backlog elegido.</value>
+    <value>&lt;p&gt;Muestre gráficos de rendimiento, tiempo de entrega y tiempo de ciclo para el backlog elegido.&lt;/p&gt;&lt;p&gt;Utilice las gráficas para detectar tendencias y planificar iteraciones futuras.&lt;/p&gt;</value>
   </data>
   <data name="BranchHealth" xml:space="preserve">
-    <value>Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.</value>
+    <value>&lt;p&gt;Vea las ramas del repositorio y resalte las ramas obsoletas o la diferencia con la rama base.&lt;/p&gt;&lt;p&gt;Limpiar regularmente las ramas antiguas mantiene su repositorio ordenado.&lt;/p&gt;</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto. También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token. Consulte {0} para ver las instrucciones. El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.</value>
+    <value>&lt;p&gt;Configure su organización de DevOps, proyecto de DevOps y token PAT desde el cuadro de configuración. Use el menú de proyectos para agregar o cambiar de proyecto.&lt;/p&gt;&lt;p&gt;También puede personalizar los prompts y las reglas de validación. Cree un PAT desde el menú de perfil en Azure DevOps eligiendo Nuevo token. Consulte {0} para ver las instrucciones. El nombre de la organización es la primera parte después de dev.azure.com/ en la URL y el nombre del proyecto aparece junto al icono de inicio al ver un proyecto.&lt;/p&gt;</value>
   </data>
   <data name="Close" xml:space="preserve">
     <value>Cerrar</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -16,31 +16,31 @@
     <value>Help &amp; Instructions</value>
   </data>
   <data name="Intro" xml:space="preserve">
-    <value>This page describes how to use each section of DevOpsAssistant.</value>
+    <value>&lt;p&gt;Welcome to DevOpsAssistant! This page explains how each section can help you manage your workflow.&lt;/p&gt;&lt;p&gt;Explore the tools below to review your backlog and generate insights that drive better planning.&lt;/p&gt;</value>
   </data>
   <data name="Epics" xml:space="preserve">
-    <value>Load a backlog to visualize Epics and Features. Suggested states appear when parents differ from their children and can be updated.</value>
+    <value>&lt;p&gt;Load a backlog to visualize Epics and Features. Suggested states appear when parents differ from their children.&lt;/p&gt;&lt;p&gt;Apply those suggestions to keep your hierarchy consistent.&lt;/p&gt;</value>
   </data>
   <data name="Validation" xml:space="preserve">
-    <value>Select a backlog and states then check work items against your rules. Violations can be tagged for follow up.</value>
+    <value>&lt;p&gt;Select a backlog and states then check work items against your rules.&lt;/p&gt;&lt;p&gt;Violations can be tagged for follow up so nothing slips through the cracks.&lt;/p&gt;</value>
   </data>
   <data name="Quality" xml:space="preserve">
-    <value>Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready. Long prompts are split into parts and you can switch between them using the arrows.</value>
+    <value>&lt;p&gt;Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready.&lt;/p&gt;&lt;p&gt;Long prompts are split into parts—navigate between them with the arrows.&lt;/p&gt;</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items. Use HTML in descriptions and acceptance criteria when it helps with lists or other formatting—don't add tags just for the sake of it. Toggle Preview HTML after importing to verify markup.</value>
+    <value>&lt;p&gt;Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items.&lt;/p&gt;&lt;p&gt;Use HTML in descriptions and acceptance criteria when it helps with lists or formatting, and toggle Preview HTML after importing to verify markup.&lt;/p&gt;</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>Select stories and build a prompt that summarizes them for release notes. Prompts can be copied or downloaded, splitting into parts with arrows to navigate.</value>
+    <value>&lt;p&gt;Select stories and build a prompt that summarizes them for release notes.&lt;/p&gt;&lt;p&gt;Prompts can be copied or downloaded, splitting into parts with arrows to navigate.&lt;/p&gt;</value>
   </data>
   <data name="Metrics" xml:space="preserve">
-    <value>Display throughput, lead time and cycle time charts for the chosen backlog.</value>
+    <value>&lt;p&gt;Display throughput, lead time and cycle time charts for the chosen backlog.&lt;/p&gt;&lt;p&gt;Use these charts to spot trends and plan future iterations.&lt;/p&gt;</value>
   </data>
   <data name="BranchHealth" xml:space="preserve">
-    <value>View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.</value>
+    <value>&lt;p&gt;View repository branches and highlight stale branches or ahead/behind counts compared to a base branch.&lt;/p&gt;&lt;p&gt;Regularly cleaning up old branches keeps your repo tidy.&lt;/p&gt;</value>
   </data>
   <data name="Settings" xml:space="preserve">
-    <value>Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects. You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token. See {0} for instructions. The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.</value>
+    <value>&lt;p&gt;Configure your DevOps organization, DevOps project and PAT token using the settings dialog. Use the project dropdown to add or switch projects.&lt;/p&gt;&lt;p&gt;You can also customize prompts and validation rules. Create a PAT from your profile menu in Azure DevOps and select New Token. See {0} for instructions. The organization name is the first segment after dev.azure.com/ in the URL and the project name appears next to the home icon when viewing a project.&lt;/p&gt;</value>
   </data>
   <data name="Close" xml:space="preserve">
     <value>Close</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -204,3 +204,8 @@ body {
     max-height: 600px;
 }
 
+/* Styling for links inside the help page */
+.help-content a {
+    color: var(--color-bug);
+}
+


### PR DESCRIPTION
## Summary
- restructure help page with markup paragraphs
- style help page links for more contrast
- update English and Spanish resource files

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685abacc37c083288122240993988775