### PR TITLE
Add AI Helpers menu section

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -66,6 +66,9 @@
   <data name="Reports" xml:space="preserve">
     <value>Informes</value>
   </data>
+  <data name="AIHelpers" xml:space="preserve">
+    <value>Asistentes de IA</value>
+  </data>
   <data name="BranchHealth" xml:space="preserve">
     <value>Estado de Ramas</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -44,20 +44,22 @@
     </MudAppBar>
 
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
-        <MudNavMenu>
-            <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
-                <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
-                <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
-                <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
-                <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
-            </MudNavGroup>
-            <MudNavGroup Title="@L["Reports"]" Expanded="true">
-                <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
-                <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
-                <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
-            </MudNavGroup>
-            <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
-        </MudNavMenu>
+            <MudNavMenu>
+                <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
+                    <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
+                </MudNavGroup>
+                <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
+                    <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
+                </MudNavGroup>
+                <MudNavGroup Title="@L["Reports"]" Expanded="true">
+                    <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
+                </MudNavGroup>
+                <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
+            </MudNavMenu>
     </MudDrawer>
 
     <MudMainContent>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -66,6 +66,9 @@
   <data name="Reports" xml:space="preserve">
     <value>Reports</value>
   </data>
+  <data name="AIHelpers" xml:space="preserve">
+    <value>AI Helpers</value>
+  </data>
   <data name="BranchHealth" xml:space="preserve">
     <value>Branch Health</value>
   </data>


### PR DESCRIPTION
## Summary
- create 'AI Helpers' nav group
- move Story Review, Requirements Planner and Release Notes links into the new group
- localize new menu label in English and Spanish

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685ac96b5f2883289694d1c0ff332570