### PR TITLE
Improve flagged item info with tooltip

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.es.resx
@@ -15,4 +15,7 @@
   <data name="BugStoryPointsRule" xml:space="preserve">
     <value>Los bugs deben tener story points</value>
   </data>
+  <data name="AlreadyTaggedTooltip" xml:space="preserve">
+    <value>Este elemento ya está etiquetado</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -100,10 +100,12 @@ else if (_results != null)
                                 <MudText>
                                     <MudLink Href="@r.Info.Url" Class="@WorkItemHelpers.GetItemClass(r.Info.WorkItemType)" Target="_blank">@r.Info.Title</MudLink> - @r.Info.WorkItemType (@r.Info.State)
                                 </MudText>
-                                <MudButton Variant="Variant.Text" Size="Size.Small" Disabled="@(_loading || r.NeedsAttention)" OnClick="() => TagItem(r)">Tag</MudButton>
+                                <MudButton Variant="Variant.Filled" Color="Color.Primary" Size="Size.Small" Disabled="@(_loading || r.NeedsAttention)" OnClick="() => TagItem(r)">Tag</MudButton>
                                 @if (r.NeedsAttention)
                                 {
-                                    <MudIcon Icon="@Icons.Material.Filled.Flag" Color="Color.Error" Class="ml-025" />
+                                    <MudTooltip Text='@L["AlreadyTaggedTooltip"]'>
+                                        <MudIcon Icon="@Icons.Material.Filled.Flag" Color="Color.Error" Class="ml-025" />
+                                    </MudTooltip>
                                 }
                             </MudStack>
                             <ul class="work-item-violations">

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.resx
@@ -15,4 +15,7 @@
   <data name="BugStoryPointsRule" xml:space="preserve">
     <value>Bugs must have story points</value>
   </data>
+  <data name="AlreadyTaggedTooltip" xml:space="preserve">
+    <value>This item is already tagged</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -185,7 +185,7 @@ else if (_roots != null)
                 builder.CloseElement();
                 builder.AddMarkupContent(3, "&nbsp;");
                 builder.OpenComponent<MudButton>(4);
-                builder.AddAttribute(5, "Variant", Variant.Text);
+                builder.AddAttribute(5, "Variant", Variant.Filled);
                 builder.AddAttribute(6, "Size", Size.Small);
                 builder.AddAttribute(6, "Color", Color.Primary);
                 builder.AddAttribute(7, "OnClick", EventCallback.Factory.Create<MouseEventArgs>(this, () => UpdateState(node)));


### PR DESCRIPTION
## Summary
- restore help text without red-flag explanation
- show Tag buttons and Update buttons with filled style
- display tooltip on red flag icons to indicate items are already tagged

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685ac916d4388328a6ef46b4b7641f80