### PR TITLE
Fix build warnings

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Restore
         run: dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln
       - name: Build (Release)
-        run: dotnet publish src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release -o publish --no-restore
+        run: dotnet publish src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release -o publish --no-restore -warnaserror
       - name: Test with coverage
         run: dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-restore --verbosity normal --collect:"XPlat Code Coverage"
       - name: Install ReportGenerator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ Codex must be proficient in the following technologies and frameworks, which are
 - Codex must ensure that the app builds and passes tests via GitHub Actions or another CI system.
 - Linting and formatting checks (e.g., `dotnet format`) should be used to enforce consistency.
 - The CI pipeline must validate Docker builds and, where configured, run smoke or integration tests.
-- Always attempt a production build (for example `dotnet publish -c Release`)
-   to surface Blazor issues that appear only in release mode.
+- Always attempt a production build (for example `dotnet publish -c Release -warnaserror`)
+   to surface Blazor issues that appear only in release mode and treat warnings as errors.
 
 ### Running the Application
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -28,7 +28,7 @@
 
 <MudPaper Class="p-15 mb-15">
     <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
-        <MudSwitch T="bool" Checked="_treeView" CheckedChanged="OnTreeViewChanged" Color="Color.Primary" Label="Tree View" Class="mr-05" />
+        <MudSwitch T="bool" Value="_treeView" ValueChanged="OnTreeViewChanged" Color="Color.Primary" Label="Tree View" Class="mr-05" />
         @if (_treeView)
         {
             <MudSelect T="string" @bind-Value="_path" Label="Backlog">


### PR DESCRIPTION
## Summary
- build ReleaseNotes page without `MudSwitch` warnings
- enforce `-warnaserror` on PR workflow
- update contributing guide to mention `-warnaserror`

## Testing
- `dotnet publish src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685ad55e1ef8832892cd505ff1437f1e