### PR TITLE
Improve release notes filter

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -466,6 +466,14 @@ public class DevOpsApiServiceTests
     }
 
     [Fact]
+    public void BuildReleaseSearchWiql_Includes_Id_When_Numeric()
+    {
+        var query = InvokeBuildReleaseSearchWiql("123");
+
+        Assert.Contains("[System.Id] = 123", query);
+    }
+
+    [Fact]
     public async Task GetStoryHierarchyDetailsAsync_Throws_When_Config_Incomplete()
     {
         var configService = new DevOpsConfigService(new FakeLocalStorageService());

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
@@ -15,4 +15,7 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copiado al portapapeles</value>
   </data>
+  <data name="AutocompletePlaceholder" xml:space="preserve">
+    <value>Empieza a escribir para ver resultados</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -41,17 +41,17 @@
                             }
                         </MudSelect>
                         <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Load">Load</MudButton>
-                        <MudTextField T="string" Label="Filter" Value="_filter" Immediate="true" ValueChanged="OnFilterChanged" />
                     }
                     else
                     {
                         <MudAutocomplete T="WorkItemInfo"
                                          Label="Work Items"
+                                         Placeholder="@L["AutocompletePlaceholder"]"
                                          SearchFunc="SearchItems"
-                                 ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
-                                 Value="_searchValue"
-                                 ValueChanged="OnItemSelected"/>
-            }
+                                         ToStringFunc="@(s => $"{s.Id} - {s.Title}")"
+                                         Value="_searchValue"
+                                         ValueChanged="OnItemSelected" />
+                    }
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="Generate">Generate Prompt</MudButton>
                     <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
                 </MudStack>
@@ -59,6 +59,11 @@
         </MudPaper>
     </MudExpansionPanel>
 </MudExpansionPanels>
+
+@if (_treeView)
+{
+    <MudTextField T="string" Label="Filter" Value="_filter" Immediate="true" ValueChanged="OnFilterChanged" Class="mb-2" />
+}
 
 @if (_treeView && _displayTreeItems != null)
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
@@ -15,4 +15,7 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copied to clipboard</value>
   </data>
+  <data name="AutocompletePlaceholder" xml:space="preserve">
+    <value>Start typing to see results</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -756,8 +756,12 @@ public class DevOpsApiService
     private static string BuildReleaseSearchWiql(string term)
     {
         term = term.Replace("'", "''");
+        var idFilter = int.TryParse(term, out var id)
+            ? $"[System.Id] = {id} OR "
+            : string.Empty;
         return
-            $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] IN ('User Story','Bug') AND [System.Title] CONTAINS '{term}' ORDER BY [System.ChangedDate] DESC";
+            $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.WorkItemType] IN ('User Story','Bug') AND (" +
+            $"{idFilter}[System.Title] CONTAINS '{term}') ORDER BY [System.ChangedDate] DESC";
     }
 
     private async Task<List<WorkItemInfo>> SearchWorkItemsAsync(string wiql)


### PR DESCRIPTION
## Summary
- allow searching by work item id
- show release note filter below options panel
- add placeholder text for autocomplete
- tidy layout of options panel
- test release search by id

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -clp:Summary`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685b0d07c008832888cc8966d607c894