### PR TITLE
Add navigation tooltips

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -15,20 +15,38 @@
   <data name="Epics" xml:space="preserve">
     <value>Épicas y Características</value>
   </data>
+  <data name="EpicsTooltip" xml:space="preserve">
+    <value>Seleccione un backlog y haga clic en Cargar para ver épicas y características. Los elementos se agrupan jerárquicamente y los estados sugeridos aparecen cuando los padres difieren de sus hijos. Use Actualizar para mantenerlos sincronizados.</value>
+  </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Notas de lanzamiento</value>
+  </data>
+  <data name="ReleaseNotesTooltip" xml:space="preserve">
+    <value>Busque y seleccione historias de usuario, luego haga clic en Generar para crear un resumen para las notas de lanzamiento. Use el botón copiar para copiar el texto generado.</value>
   </data>
   <data name="Validation" xml:space="preserve">
     <value>Validación de historias</value>
   </data>
+  <data name="ValidationTooltip" xml:space="preserve">
+    <value>Seleccione un backlog y estados y haga clic en Comprobar para validar los elementos según sus reglas configuradas. Se enumerarán las infracciones.</value>
+  </data>
   <data name="StoryReview" xml:space="preserve">
     <value>Calidad de la historia</value>
+  </data>
+  <data name="StoryReviewTooltip" xml:space="preserve">
+    <value>Seleccione un backlog y estados y haga clic en Generar para crear un prompt para revisar historias de usuario.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Métricas</value>
   </data>
+  <data name="MetricsTooltip" xml:space="preserve">
+    <value>Elija un backlog y haga clic en Cargar para mostrar el rendimiento semanal y los tiempos de ciclo y entrega. Los gráficos muestran estas métricas de las últimas doce semanas.</value>
+  </data>
   <data name="RequirementPlanner" xml:space="preserve">
     <value>Planificador de requisitos</value>
+  </data>
+  <data name="RequirementPlannerTooltip" xml:space="preserve">
+    <value>Seleccione páginas de wiki o cargue un documento de requisitos para generar un prompt que lo divida en épicas, características y historias de usuario. Pegue la respuesta del LLM abajo para importar elementos y crearlos en un backlog.</value>
   </data>
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
@@ -71,6 +89,9 @@
   </data>
   <data name="BranchHealth" xml:space="preserve">
     <value>Estado de Ramas</value>
+  </data>
+  <data name="BranchHealthTooltip" xml:space="preserve">
+    <value>Seleccione un repositorio y haga clic en Cargar para ver la actividad de las ramas. Las ramas sin commits recientes se marcan con un ícono de advertencia.</value>
   </data>
   <data name="Help" xml:space="preserve">
     <value>Ayuda</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -42,17 +42,31 @@
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
             <MudNavMenu>
                 <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
-                    <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
-                    <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
+                    <MudTooltip Text="@L["EpicsTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
+                    </MudTooltip>
+                    <MudTooltip Text="@L["ValidationTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
+                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
-                    <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
-                    <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
-                    <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
+                    <MudTooltip Text="@L["StoryReviewTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
+                    </MudTooltip>
+                    <MudTooltip Text="@L["RequirementPlannerTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
+                    </MudTooltip>
+                    <MudTooltip Text="@L["ReleaseNotesTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
+                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["Reports"]" Expanded="true">
-                    <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
-                    <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
+                    <MudTooltip Text="@L["MetricsTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
+                    </MudTooltip>
+                    <MudTooltip Text="@L["BranchHealthTooltip"]">
+                        <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
+                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
             </MudNavMenu>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -15,20 +15,38 @@
   <data name="Epics" xml:space="preserve">
     <value>Epics &amp; Features</value>
   </data>
+  <data name="EpicsTooltip" xml:space="preserve">
+    <value>Select a backlog and click Load to view epics and features. Items are grouped hierarchically and suggested states appear when parents differ from their children. Use Update to keep them in sync.</value>
+  </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Release Notes</value>
+  </data>
+  <data name="ReleaseNotesTooltip" xml:space="preserve">
+    <value>Search and select user stories, then click Generate to build a prompt summarizing them for release notes. Use the copy button to copy the generated text.</value>
   </data>
   <data name="Validation" xml:space="preserve">
     <value>Story Validation</value>
   </data>
+  <data name="ValidationTooltip" xml:space="preserve">
+    <value>Select a backlog and states then click Check to validate work items against your configured rules. Any violations will be listed below.</value>
+  </data>
   <data name="StoryReview" xml:space="preserve">
     <value>Story Quality</value>
+  </data>
+  <data name="StoryReviewTooltip" xml:space="preserve">
+    <value>Select a backlog and states then click Generate to build a prompt for reviewing user stories.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Metrics</value>
   </data>
+  <data name="MetricsTooltip" xml:space="preserve">
+    <value>Choose a backlog and click Load to display weekly throughput, lead time and cycle time statistics. Charts visualize these metrics for the last twelve weeks.</value>
+  </data>
   <data name="RequirementPlanner" xml:space="preserve">
     <value>Requirement Planner</value>
+  </data>
+  <data name="RequirementPlannerTooltip" xml:space="preserve">
+    <value>Select wiki pages or upload a requirements document to generate a prompt that breaks it into Epics, Features and User Stories. Paste the LLM response below to import items and create them in a backlog.</value>
   </data>
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
@@ -71,6 +89,9 @@
   </data>
   <data name="BranchHealth" xml:space="preserve">
     <value>Branch Health</value>
+  </data>
+  <data name="BranchHealthTooltip" xml:space="preserve">
+    <value>Select a repository and click Load to view branch activity. Branches without recent commits are marked with a warning icon.</value>
   </data>
   <data name="Help" xml:space="preserve">
     <value>Help</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BranchHealth.razor
@@ -10,10 +10,6 @@
 
 <PageTitle>DevOpsAssistant - Branch Health</PageTitle>
 
-<MudAlert Severity="Severity.Info">
-    Select a repository and click <b>Load</b> to view branch activity.
-    Branches without recent commits are marked with a warning icon.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -14,11 +14,6 @@
 
 <MudText Typo="Typo.h4">@L["PageHeading"]</MudText>
 
-<MudAlert Severity="Severity.Info">
-    Choose a backlog and click <b>Load</b> to display weekly throughput,
-    lead time and cycle time statistics. Charts visualize these metrics
-    for the last twelve weeks.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -16,11 +16,6 @@
 
 <PageTitle>DevOpsAssistant - Release Notes</PageTitle>
 
-<MudAlert Severity="Severity.Info">
-    Search and select user stories, then click <b>Generate</b> to build a
-    prompt summarizing them for release notes. Use the copy button to
-    copy the generated text to the clipboard.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -20,11 +20,6 @@
     @L["CopyPromptMessage"]
     <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton>
 </MudAlert>
-
-<MudAlert Severity="Severity.Info">
-    Select wiki pages or upload a requirements document to generate a prompt that breaks it into Epics, Features and User Stories.
-    Paste the LLM response below to import items and create them in a backlog.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -14,9 +14,6 @@
 
 <PageTitle>DevOpsAssistant - Story Quality</PageTitle>
 
-<MudAlert Severity="Severity.Info">
-    Select a backlog and states then click <b>Generate</b> to build a prompt for reviewing user stories.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -25,29 +25,19 @@
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
-else
+@if (_hasRules)
 {
-    <MudAlert Severity="Severity.Info">
-        Select a backlog and states then click <b>Check</b> to validate work items against
-        your configured rules. Any violations will be listed below.
-        @if (_hasRules)
-        {
-            <MudButton
-                       Variant="Variant.Text"
-                       OnClick="ToggleRules"
-                       StartIcon="@(_rulesExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)">
-                @(_rulesExpanded ? "Hide Rules" : "Show Rules")
-            </MudButton>
-            <MudCollapse Expanded="_rulesExpanded">
-                <MudList T="string" Dense="true">
-                    @foreach (var r in _activeRules)
-                    {
-                        <MudListItem T="string">@r</MudListItem>
-                    }
-                </MudList>
-            </MudCollapse>
-        }
-    </MudAlert>
+    <MudButton Variant="Variant.Text" OnClick="ToggleRules" StartIcon="@(_rulesExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)">
+        @(_rulesExpanded ? "Hide Rules" : "Show Rules")
+    </MudButton>
+    <MudCollapse Expanded="_rulesExpanded">
+        <MudList T="string" Dense="true">
+            @foreach (var r in _activeRules)
+            {
+                <MudListItem T="string">@r</MudListItem>
+            }
+        </MudList>
+    </MudCollapse>
 }
 
 <MudExpansionPanels>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItems.razor
@@ -6,11 +6,6 @@
 
 <PageTitle>DevOpsAssistant - Epics and Features</PageTitle>
 
-<MudAlert Severity="Severity.Info">
-    Select a backlog and click <b>Load</b> to view epics and features.
-    Items are grouped hierarchically and suggested states appear when
-    parents differ from their children. Use <b>Update</b> to keep them in sync.
-</MudAlert>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>


### PR DESCRIPTION
## Summary
- drop top-of-page instructions
- move guidance strings to the main layout resources
- show instructions as tooltips on the navigation items

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685b12926ef08328be974e261b3a6d6d