### PR TITLE
Fix test warnings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
@@ -55,7 +55,7 @@ public class DocumentHelpersTests
             var slidePart = presPart.AddNewPart<Pkg.SlidePart>("rId1");
             slidePart.Slide = new P.Slide(new P.CommonSlideData(new P.ShapeTree()));
             presPart.Presentation.SlideIdList = new P.SlideIdList(new P.SlideId { Id = 256U, RelationshipId = "rId1" });
-            var tree = slidePart.Slide.CommonSlideData!.ShapeTree;
+            var tree = slidePart.Slide.CommonSlideData!.ShapeTree!;
             tree.Append(new P.Shape(
                 new P.NonVisualShapeProperties(
                     new P.NonVisualDrawingProperties { Id = 2U, Name = "Title" },

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/TextHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/TextHelpers.cs
@@ -5,7 +5,7 @@ namespace DevOpsAssistant.Utils;
 
 public static class TextHelpers
 {
-    public static string Sanitize(string input)
+    public static string Sanitize(string? input)
     {
         if (string.IsNullOrWhiteSpace(input))
             return string.Empty;


### PR DESCRIPTION
## Summary
- fix nullable arguments in TextHelpers
- ensure slide tree is treated non-null in tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685b1e52af98832886d34db382818c40