### PR TITLE
Remove menu tooltips

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -142,4 +142,14 @@ public class MainLayoutTests : ComponentTestBase
         var button = cut.Find("div.mud-menu button");
         Assert.Contains("Demo", button.TextContent);
     }
+
+    [Fact]
+    public void Menu_Does_Not_Contain_Tooltips()
+    {
+        SetupServices();
+
+        var cut = RenderComponent<MainLayout>();
+
+        Assert.DoesNotContain("mud-tooltip", cut.Markup);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -42,31 +42,17 @@
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
             <MudNavMenu>
                 <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
-                    <MudTooltip Text="@L["EpicsTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["ValidationTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
-                    </MudTooltip>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
-                    <MudTooltip Text="@L["StoryReviewTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["RequirementPlannerTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["ReleaseNotesTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
-                    </MudTooltip>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["Reports"]" Expanded="true">
-                    <MudTooltip Text="@L["MetricsTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["BranchHealthTooltip"]">
-                        <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
-                    </MudTooltip>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
+                    <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
                 </MudNavGroup>
                 <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
             </MudNavMenu>


### PR DESCRIPTION
## Summary
- clean up tooltips from the sidebar navigation
- verify the menu markup no longer renders tooltips

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685b1f49660c83289f1d1aa934721219