### PR TITLE
Remove menu tooltips

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -15,38 +15,20 @@
   <data name="Epics" xml:space="preserve">
     <value>Épicas y Características</value>
   </data>
-  <data name="EpicsTooltip" xml:space="preserve">
-    <value>Seleccione un backlog y haga clic en Cargar para ver épicas y características. Los elementos se agrupan jerárquicamente y los estados sugeridos aparecen cuando los padres difieren de sus hijos. Use Actualizar para mantenerlos sincronizados.</value>
-  </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Notas de lanzamiento</value>
-  </data>
-  <data name="ReleaseNotesTooltip" xml:space="preserve">
-    <value>Busque y seleccione historias de usuario, luego haga clic en Generar para crear un resumen para las notas de lanzamiento. Use el botón copiar para copiar el texto generado.</value>
   </data>
   <data name="Validation" xml:space="preserve">
     <value>Validación de historias</value>
   </data>
-  <data name="ValidationTooltip" xml:space="preserve">
-    <value>Seleccione un backlog y estados y haga clic en Comprobar para validar los elementos según sus reglas configuradas. Se enumerarán las infracciones.</value>
-  </data>
   <data name="StoryReview" xml:space="preserve">
     <value>Calidad de la historia</value>
-  </data>
-  <data name="StoryReviewTooltip" xml:space="preserve">
-    <value>Seleccione un backlog y estados y haga clic en Generar para crear un prompt para revisar historias de usuario.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Métricas</value>
   </data>
-  <data name="MetricsTooltip" xml:space="preserve">
-    <value>Elija un backlog y haga clic en Cargar para mostrar el rendimiento semanal y los tiempos de ciclo y entrega. Los gráficos muestran estas métricas de las últimas doce semanas.</value>
-  </data>
   <data name="RequirementPlanner" xml:space="preserve">
     <value>Planificador de requisitos</value>
-  </data>
-  <data name="RequirementPlannerTooltip" xml:space="preserve">
-    <value>Seleccione páginas de wiki o cargue un documento de requisitos para generar un prompt que lo divida en épicas, características y historias de usuario. Pegue la respuesta del LLM abajo para importar elementos y crearlos en un backlog.</value>
   </data>
   <data name="SignOut" xml:space="preserve">
     <value>Cerrar sesión</value>
@@ -90,9 +72,6 @@
   <data name="BranchHealth" xml:space="preserve">
     <value>Estado de Ramas</value>
   </data>
-  <data name="BranchHealthTooltip" xml:space="preserve">
-    <value>Seleccione un repositorio y haga clic en Cargar para ver la actividad de las ramas. Las ramas sin commits recientes se marcan con un ícono de advertencia.</value>
-  </data>
   <data name="Help" xml:space="preserve">
     <value>Ayuda</value>
   </data>
@@ -112,6 +91,6 @@
     <value>Confirmar</value>
   </data>
   <data name="FooterCopyright" xml:space="preserve">
-    <value>&#169; {0} TommCarrr industries</value>
+    <value>© {0} TommCarrr industries</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -42,31 +42,17 @@
     <MudDrawer @bind-Open="_drawerOpen" Variant="DrawerVariant.Responsive" Elevation="1" Class="mud-width-220" ClipMode="DrawerClipMode.Always">
             <MudNavMenu>
                 <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
-                    <MudTooltip Text="@L["EpicsTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["ValidationTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
-                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
-                    <MudTooltip Text="@L["StoryReviewTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/story-review")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["StoryReview"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["RequirementPlannerTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/requirements-planner")" Icon="@Icons.Material.Filled.NoteAlt" Disabled="@IsProjectInvalid">@L["RequirementPlanner"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["ReleaseNotesTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/release-notes")" Icon="@Icons.Material.Filled.Article" Disabled="@IsProjectInvalid">@L["ReleaseNotes"]</MudNavLink>
-                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["Reports"]" Expanded="true">
-                    <MudTooltip Text="@L["MetricsTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/metrics")" Icon="@Icons.Material.Filled.Insights" Disabled="@IsProjectInvalid">@L["Metrics"]</MudNavLink>
-                    </MudTooltip>
-                    <MudTooltip Text="@L["BranchHealthTooltip"]">
                         <MudNavLink Href="@($"projects/{_selectedProject}/branch-health")" Icon="@Icons.Material.Filled.Source" Disabled="@IsProjectInvalid">@L["BranchHealth"]</MudNavLink>
-                    </MudTooltip>
                 </MudNavGroup>
                 <MudNavLink Href="@($"/projects/{_selectedProject}/settings")" Icon="@Icons.Material.Filled.Settings">@L["Settings"]</MudNavLink>
             </MudNavMenu>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -15,38 +15,20 @@
   <data name="Epics" xml:space="preserve">
     <value>Epics &amp; Features</value>
   </data>
-  <data name="EpicsTooltip" xml:space="preserve">
-    <value>Select a backlog and click Load to view epics and features. Items are grouped hierarchically and suggested states appear when parents differ from their children. Use Update to keep them in sync.</value>
-  </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Release Notes</value>
-  </data>
-  <data name="ReleaseNotesTooltip" xml:space="preserve">
-    <value>Search and select user stories, then click Generate to build a prompt summarizing them for release notes. Use the copy button to copy the generated text.</value>
   </data>
   <data name="Validation" xml:space="preserve">
     <value>Story Validation</value>
   </data>
-  <data name="ValidationTooltip" xml:space="preserve">
-    <value>Select a backlog and states then click Check to validate work items against your configured rules. Any violations will be listed below.</value>
-  </data>
   <data name="StoryReview" xml:space="preserve">
     <value>Story Quality</value>
-  </data>
-  <data name="StoryReviewTooltip" xml:space="preserve">
-    <value>Select a backlog and states then click Generate to build a prompt for reviewing user stories.</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>Metrics</value>
   </data>
-  <data name="MetricsTooltip" xml:space="preserve">
-    <value>Choose a backlog and click Load to display weekly throughput, lead time and cycle time statistics. Charts visualize these metrics for the last twelve weeks.</value>
-  </data>
   <data name="RequirementPlanner" xml:space="preserve">
     <value>Requirement Planner</value>
-  </data>
-  <data name="RequirementPlannerTooltip" xml:space="preserve">
-    <value>Select wiki pages or upload a requirements document to generate a prompt that breaks it into Epics, Features and User Stories. Paste the LLM response below to import items and create them in a backlog.</value>
   </data>
   <data name="SignOut" xml:space="preserve">
     <value>Sign Out</value>
@@ -90,9 +72,6 @@
   <data name="BranchHealth" xml:space="preserve">
     <value>Branch Health</value>
   </data>
-  <data name="BranchHealthTooltip" xml:space="preserve">
-    <value>Select a repository and click Load to view branch activity. Branches without recent commits are marked with a warning icon.</value>
-  </data>
   <data name="Help" xml:space="preserve">
     <value>Help</value>
   </data>
@@ -112,6 +91,6 @@
     <value>Confirm</value>
   </data>
   <data name="FooterCopyright" xml:space="preserve">
-    <value>&#169; {0} TommCarrr industries</value>
+    <value>© {0} TommCarrr industries</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- remove `MudTooltip` wrappers from the navigation menu
- drop tooltip entries from `MainLayout` resource files

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685b1f49660c83289f1d1aa934721219