### PR TITLE
Fix translation for ProjectSettings header

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -3,7 +3,7 @@
 @using DevOpsAssistant.Services.Models
 @using DevOpsAssistant.Components
 @using Microsoft.Extensions.Localization
-@inject IStringLocalizer<SettingsDialog> L
+@inject IStringLocalizer<ProjectSettings> L
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject NavigationManager NavigationManager


### PR DESCRIPTION
## Summary
- resolve bad localization key in `ProjectSettings.razor`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685be942008c83289cf236f69a45d01f