### PR TITLE
Add metrics prompt copy

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -44,6 +44,29 @@ public class MetricsPageTests : ComponentTestBase
     }
 
     [Fact]
+    public void BuildPrompt_Includes_Metrics()
+    {
+        SetupServices();
+
+        var method = typeof(Metrics).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var periodType = typeof(Metrics).GetNestedType("PeriodMetrics", BindingFlags.NonPublic)!;
+        var array = Array.CreateInstance(periodType, 1);
+        var period = Activator.CreateInstance(periodType)!;
+        periodType.GetProperty("End")!.SetValue(period, new DateTime(2024, 1, 1));
+        periodType.GetProperty("AvgLeadTime")!.SetValue(period, 1.2);
+        periodType.GetProperty("AvgCycleTime")!.SetValue(period, 2.3);
+        periodType.GetProperty("Throughput")!.SetValue(period, 3);
+        periodType.GetProperty("Velocity")!.SetValue(period, 4.5);
+        array.SetValue(period, 0);
+
+        var prompt = (string)method.Invoke(null, new object?[] { array })!;
+
+        Assert.Contains("2024-01-01", prompt);
+        Assert.Contains("1.2", prompt);
+        Assert.Contains("4.5", prompt);
+    }
+
+    [Fact]
     public void Fortnight_Mode_Uses_Two_Week_Period()
     {
         SetupServices();

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
@@ -27,4 +27,10 @@
   <data name="ChartsHeading" xml:space="preserve">
     <value>Gráficos</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generar prompt</value>
+  </data>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copiado al portapapeles</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -8,6 +8,7 @@
 @inject PageStateService StateService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Metrics> L
+@inject ISnackbar Snackbar
 @inherits ProjectComponentBase
 
 <PageTitle>DevOpsAssistant - Metrics</PageTitle>
@@ -92,6 +93,11 @@
                   Height="100%"
                   AxisChartOptions="_axisOptions" />
     </MudPaper>
+    <MudButton Variant="Variant.Filled"
+               Color="Color.Primary"
+               StartIcon="@Icons.Material.Filled.ContentCopy"
+               Disabled="_periods.Count == 0"
+               OnClick="CopyPrompt">@L["GeneratePrompt"]</MudButton>
 }
 
 @code {
@@ -258,11 +264,31 @@
         return sb.ToString();
     }
 
+    private static string BuildPrompt(IEnumerable<PeriodMetrics> periods)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("You are an Agile Coach preparing a delivery metrics report for your Delivery Manager.");
+        sb.AppendLine("Highlight any trends or issues based on the data below.");
+        sb.AppendLine();
+        sb.AppendLine("Period End,Avg Lead Time,Avg Cycle Time,Throughput,Velocity");
+        foreach (var p in periods)
+            sb.AppendLine($"{p.End:yyyy-MM-dd},{p.AvgLeadTime:0.0},{p.AvgCycleTime:0.0},{p.Throughput},{p.Velocity:0.0}");
+        return sb.ToString();
+    }
+
     private async Task ExportCsv()
     {
         if (_periods.Count == 0) return;
         var csv = BuildCsv(_periods);
         await JS.InvokeVoidAsync("downloadCsv", "metrics.csv", csv);
+    }
+
+    private async Task CopyPrompt()
+    {
+        if (_periods.Count == 0) return;
+        var prompt = BuildPrompt(_periods);
+        await JS.InvokeVoidAsync("copyText", prompt);
+        Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
     private async Task Reset()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
@@ -27,4 +27,10 @@
   <data name="ChartsHeading" xml:space="preserve">
     <value>Charts</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generate Prompt</value>
+  </data>
+  <data name="CopyToast" xml:space="preserve">
+    <value>Copied to clipboard</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- let Metrics page copy a prompt summarizing stats to clipboard
- localize prompt button text
- add unit test for prompt builder

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685be98f14d08328b1d3597d233b1b20