### PR TITLE
Fix translation keys

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.es.resx
@@ -42,9 +42,6 @@
   <data name="Project" xml:space="preserve">
     <value>Proyecto de DevOps</value>
   </data>
-  <data name="ProjectName" xml:space="preserve">
-    <value>Nombre del Proyecto</value>
-  </data>
   <data name="Organization" xml:space="preserve">
     <value>Organización de DevOps</value>
   </data>
@@ -60,14 +57,14 @@
   <data name="CloneSource" xml:space="preserve">
     <value>Proyecto a clonar</value>
   </data>
-  <data name="ImportFrom" xml:space="preserve">
-    <value>Importar De</value>
-  </data>
   <data name="DeleteProject" xml:space="preserve">
     <value>Eliminar Proyecto</value>
   </data>
   <data name="ConfirmDelete" xml:space="preserve">
     <value>Eliminar proyecto</value>
+  </data>
+  <data name="Create" xml:space="preserve">
+    <value>Crear</value>
   </data>
   <data name="Confirm" xml:space="preserve">
     <value>Confirmar</value>
@@ -83,9 +80,6 @@
   </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>Ya existe un proyecto con ese nombre.</value>
-  </data>
-  <data name="MissingName" xml:space="preserve">
-    <value>Se requiere el nombre del proyecto.</value>
   </data>
   <data name="MissingOrganization" xml:space="preserve">
     <value>Se requiere la organización.</value>
@@ -122,11 +116,5 @@
   </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
-  </data>
-  <data name="OverrideWarning" xml:space="preserve">
-    <value>Esto sobrescribirá la configuración existente.</value>
-  </data>
-  <data name="None" xml:space="preserve">
-    <value>Ninguno</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/SettingsDialog.resx
@@ -42,9 +42,6 @@
   <data name="Project" xml:space="preserve">
     <value>DevOps Project</value>
   </data>
-  <data name="ProjectName" xml:space="preserve">
-    <value>Project Name</value>
-  </data>
   <data name="Organization" xml:space="preserve">
     <value>DevOps Organization</value>
   </data>
@@ -60,14 +57,14 @@
   <data name="CloneSource" xml:space="preserve">
     <value>Project to clone</value>
   </data>
-  <data name="ImportFrom" xml:space="preserve">
-    <value>Import From</value>
-  </data>
   <data name="DeleteProject" xml:space="preserve">
     <value>Delete Project</value>
   </data>
   <data name="ConfirmDelete" xml:space="preserve">
     <value>Delete project</value>
+  </data>
+  <data name="Create" xml:space="preserve">
+    <value>Create</value>
   </data>
   <data name="Confirm" xml:space="preserve">
     <value>Confirm</value>
@@ -83,9 +80,6 @@
   </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>A project with that name already exists.</value>
-  </data>
-  <data name="MissingName" xml:space="preserve">
-    <value>Project name is required.</value>
   </data>
   <data name="MissingOrganization" xml:space="preserve">
     <value>Organization is required.</value>
@@ -122,11 +116,5 @@
   </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
-  </data>
-  <data name="OverrideWarning" xml:space="preserve">
-    <value>This will override existing settings.</value>
-  </data>
-  <data name="None" xml:space="preserve">
-    <value>None</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -84,6 +84,9 @@
   <data name="Project" xml:space="preserve">
     <value>Proyecto</value>
   </data>
+  <data name="Projects" xml:space="preserve">
+    <value>Proyectos</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>Nuevo Proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -84,6 +84,9 @@
   <data name="Project" xml:space="preserve">
     <value>Project</value>
   </data>
+  <data name="Projects" xml:space="preserve">
+    <value>Projects</value>
+  </data>
   <data name="NewProject" xml:space="preserve">
     <value>New Project</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -42,9 +42,6 @@
   <data name="Project" xml:space="preserve">
     <value>Proyecto de DevOps</value>
   </data>
-  <data name="ProjectName" xml:space="preserve">
-    <value>Nombre del Proyecto</value>
-  </data>
   <data name="Organization" xml:space="preserve">
     <value>Organización de DevOps</value>
   </data>
@@ -59,9 +56,6 @@
   </data>
   <data name="CloneSource" xml:space="preserve">
     <value>Proyecto a clonar</value>
-  </data>
-  <data name="ImportFrom" xml:space="preserve">
-    <value>Importar De</value>
   </data>
   <data name="DeleteProject" xml:space="preserve">
     <value>Eliminar Proyecto</value>
@@ -83,9 +77,6 @@
   </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>Ya existe un proyecto con ese nombre.</value>
-  </data>
-  <data name="MissingName" xml:space="preserve">
-    <value>Se requiere el nombre del proyecto.</value>
   </data>
   <data name="MissingOrganization" xml:space="preserve">
     <value>Se requiere la organización.</value>
@@ -122,11 +113,5 @@
   </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
-  </data>
-  <data name="OverrideWarning" xml:space="preserve">
-    <value>Esto sobrescribirá la configuración existente.</value>
-  </data>
-  <data name="None" xml:space="preserve">
-    <value>Ninguno</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -42,9 +42,6 @@
   <data name="Project" xml:space="preserve">
     <value>DevOps Project</value>
   </data>
-  <data name="ProjectName" xml:space="preserve">
-    <value>Project Name</value>
-  </data>
   <data name="Organization" xml:space="preserve">
     <value>DevOps Organization</value>
   </data>
@@ -59,9 +56,6 @@
   </data>
   <data name="CloneSource" xml:space="preserve">
     <value>Project to clone</value>
-  </data>
-  <data name="ImportFrom" xml:space="preserve">
-    <value>Import From</value>
   </data>
   <data name="DeleteProject" xml:space="preserve">
     <value>Delete Project</value>
@@ -83,9 +77,6 @@
   </data>
   <data name="DuplicateName" xml:space="preserve">
     <value>A project with that name already exists.</value>
-  </data>
-  <data name="MissingName" xml:space="preserve">
-    <value>Project name is required.</value>
   </data>
   <data name="MissingOrganization" xml:space="preserve">
     <value>Organization is required.</value>
@@ -122,11 +113,5 @@
   </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
-  </data>
-  <data name="OverrideWarning" xml:space="preserve">
-    <value>This will override existing settings.</value>
-  </data>
-  <data name="None" xml:space="preserve">
-    <value>None</value>
   </data>
 </root>


### PR DESCRIPTION
## Summary
- ensure all resx keys are used
- add missing translations for `Projects` and `Create`
- remove unused resx entries

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685c1362d0008328b4678ffe3881df6c