### PR TITLE
Improve chart dialog UI

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
@@ -1,0 +1,43 @@
+using Bunit;
+using DevOpsAssistant.Components;
+using DevOpsAssistant.Tests.Utils;
+using MudBlazor;
+
+namespace DevOpsAssistant.Tests.Components;
+
+public class ChartDialogTests : ComponentTestBase
+{
+    private class FakeDialog : IMudDialogInstance
+    {
+        public string Id => "1";
+        public string ElementId => "1";
+        public DialogOptions Options => new();
+        public string Title { get; set; } = string.Empty;
+        public Task SetOptionsAsync(DialogOptions options) => Task.CompletedTask;
+        public Task SetTitleAsync(string title) { Title = title; return Task.CompletedTask; }
+        public void Close() { }
+        public void Close(DialogResult result) { }
+        public void Close<T>(T returnValue) { }
+        public void Cancel() { }
+        public void CancelAll() { }
+        public void StateHasChanged() { }
+    }
+
+    [Fact]
+    public void Dialog_Shows_Title_And_Close_Button()
+    {
+        SetupServices();
+        var fake = new FakeDialog();
+        var cut = RenderComponent<ChartDialog>(parameters => parameters
+            .AddCascadingValue(fake)
+            .Add(p => p.Title, "Test Chart")
+            .Add(p => p.ChartType, ChartType.Line)
+            .Add(p => p.ChartSeries, new List<ChartSeries>())
+            .Add(p => p.XAxisLabels, Array.Empty<string>())
+            .Add(p => p.AxisChartOptions, new AxisChartOptions())
+        );
+
+        cut.Markup.Contains("Test Chart");
+        cut.Markup.Contains("Close");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Cerrar</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.razor
@@ -1,5 +1,13 @@
-<MudDialog ContentClass="pa-4">
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<ChartDialog> L
+
+<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
     <DialogContent>
+        <MudText Typo="Typo.h6" Class="mb-2">@Title</MudText>
+        @if (AdditionalControls != null)
+        {
+            @AdditionalControls
+        }
         <MudChart ChartType="@ChartType"
                   ChartSeries="ChartSeries"
                   XAxisLabels="XAxisLabels"
@@ -7,12 +15,19 @@
                   Height="100%"
                   AxisChartOptions="AxisChartOptions" />
     </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Close" Color="Color.Primary">@L["Close"]</MudButton>
+    </DialogActions>
 </MudDialog>
 
 @code {
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
+    [Parameter] public string Title { get; set; } = string.Empty;
     [Parameter] public ChartType ChartType { get; set; }
     [Parameter] public List<ChartSeries> ChartSeries { get; set; } = new();
     [Parameter] public string[] XAxisLabels { get; set; } = Array.Empty<string>();
     [Parameter] public AxisChartOptions AxisChartOptions { get; set; } = new();
+    [Parameter] public RenderFragment? AdditionalControls { get; set; }
+
+    private void Close() => MudDialog.Cancel();
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -197,6 +197,12 @@
     private double? _errorRange;
     private string _nonSprintTag = string.Empty;
     private bool _useSprintEfficiency;
+    private RenderFragment BurnUpControls => @<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap" Class="mb-2">
+        <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points" />
+        <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %" />
+        <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %" />
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="UpdateBurnUp">Update</MudButton>
+    </MudStack>;
 
     private string[] _xAxisLabels = [];
     private List<ChartSeries> _leadCycleSeries = [];
@@ -605,23 +611,25 @@
         return dt.Date.AddDays(-diff);
     }
 
-    private async Task ShowLeadCycleChart() => await ShowChartDialog(ChartType.Line, _leadCycleSeries, _xAxisLabels);
-    private async Task ShowBarChart() => await ShowChartDialog(ChartType.Bar, _barSeries, _xAxisLabels);
-    private async Task ShowWipChart() => await ShowChartDialog(ChartType.Line, _wipSeries, _xAxisLabels);
-    private async Task ShowSprintChart() => await ShowChartDialog(ChartType.Line, _sprintSeries, _xAxisLabels);
-    private async Task ShowBurnChart() => await ShowChartDialog(ChartType.Line, _burnSeries, _burnLabels);
-    private async Task ShowFlowChart() => await ShowChartDialog(ChartType.StackedBar, _flowSeries, _flowLabels);
+    private async Task ShowLeadCycleChart() => await ShowChartDialog(ChartType.Line, _leadCycleSeries, _xAxisLabels, "Lead & Cycle Time");
+    private async Task ShowBarChart() => await ShowChartDialog(ChartType.Bar, _barSeries, _xAxisLabels, "Throughput & Velocity");
+    private async Task ShowWipChart() => await ShowChartDialog(ChartType.Line, _wipSeries, _xAxisLabels, "Avg WIP");
+    private async Task ShowSprintChart() => await ShowChartDialog(ChartType.Line, _sprintSeries, _xAxisLabels, "Sprint Efficiency");
+    private async Task ShowBurnChart() => await ShowChartDialog(ChartType.Line, _burnSeries, _burnLabels, L["BurnUp"], BurnUpControls);
+    private async Task ShowFlowChart() => await ShowChartDialog(ChartType.StackedBar, _flowSeries, _flowLabels, L["Flow"]);
 
-    private async Task ShowChartDialog(ChartType type, List<ChartSeries> series, string[] labels)
+    private async Task ShowChartDialog(ChartType type, List<ChartSeries> series, string[] labels, string title, RenderFragment? controls = null)
     {
         var parameters = new DialogParameters
         {
             [nameof(ChartDialog.ChartType)] = type,
             [nameof(ChartDialog.ChartSeries)] = series,
             [nameof(ChartDialog.XAxisLabels)] = labels,
-            [nameof(ChartDialog.AxisChartOptions)] = _axisOptions
+            [nameof(ChartDialog.AxisChartOptions)] = _axisOptions,
+            [nameof(ChartDialog.Title)] = title,
+            [nameof(ChartDialog.AdditionalControls)] = controls
         };
-        await DialogService.ShowAsync<ChartDialog>("", parameters, new DialogOptions { FullScreen = true });
+        await DialogService.ShowAsync<ChartDialog>(title, parameters, new DialogOptions { FullScreen = true });
     }
 
     private class PeriodMetrics


### PR DESCRIPTION
## Summary
- add title and close button to ChartDialog
- allow passing extra controls to ChartDialog
- display burn-up controls in full-screen dialog
- unit test for ChartDialog

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685c4c49ecd48328b2c9054b514480ec