### PR TITLE
Fix cumulative flow chart rendering

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
@@ -9,12 +9,12 @@ public class ChartDialogTests : ComponentTestBase
 {
     private class FakeDialog : IMudDialogInstance
     {
-        public string Id => "1";
+        public Guid Id => Guid.Empty;
         public string ElementId => "1";
         public DialogOptions Options => new();
         public string Title { get; set; } = string.Empty;
         public Task SetOptionsAsync(DialogOptions options) => Task.CompletedTask;
-        public Task SetTitleAsync(string title) { Title = title; return Task.CompletedTask; }
+        public Task SetTitleAsync(string? title) { Title = title ?? string.Empty; return Task.CompletedTask; }
         public void Close() { }
         public void Close(DialogResult result) { }
         public void Close<T>(T returnValue) { }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -112,6 +112,29 @@ public class MetricsPageTests : ComponentTestBase
         Assert.True(list.Count > 0);
     }
 
+    [Fact]
+    public void ComputeFlow_Produces_Data()
+    {
+        SetupServices();
+
+        var metrics = new TestMetrics();
+        var type = typeof(Metrics);
+        var compute = type.GetMethod("ComputeFlow", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var seriesField = type.GetField("_flowSeries", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var labelsField = type.GetField("_flowLabels", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var items = new List<StoryMetric>
+        {
+            new() { CreatedDate = DateTime.Today.AddDays(-3), ActivatedDate = DateTime.Today.AddDays(-2), ClosedDate = DateTime.Today.AddDays(-1) },
+            new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today }
+        };
+        compute.Invoke(metrics, new object?[] { items });
+
+        var series = (IList<ChartSeries>)seriesField.GetValue(metrics)!;
+        var labels = (string[])labelsField.GetValue(metrics)!;
+        Assert.True(series.Count > 0);
+        Assert.True(labels.Length > 0);
+    }
+
     private class TestMetrics : Metrics
     {
         protected override Task OnInitializedAsync() => Task.CompletedTask;

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -507,7 +507,10 @@
             wip[i] = items.Count(it => it.ActivatedDate.Date <= day && it.ClosedDate.Date > day);
             done[i] = items.Count(it => it.ClosedDate.Date <= day);
         }
-        _flowLabels = Enumerable.Range(0, days).Select(i => start.AddDays(i).ToLocalDateString()).ToArray();
+        int step = Math.Max(1, (int)Math.Ceiling(days / 10.0));
+        _flowLabels = Enumerable.Range(0, days)
+            .Select(i => i % step == 0 ? start.AddDays(i).ToLocalDateString() : string.Empty)
+            .ToArray();
         _flowSeries =
         [
             new ChartSeries { Name = "Backlog", Data = backlog },


### PR DESCRIPTION
## Summary
- reduce cumulative flow labels so stacked bar renders
- update ChartDialog test double for current IMudDialogInstance
- test that ComputeFlow outputs chart data

## Testing
- `dotnet format whitespace --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685c512a50808328aa2c1e6fe11087a5