### PR TITLE
Add preferred output format setting

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -60,7 +60,7 @@ public class MetricsPageTests : ComponentTestBase
         periodType.GetProperty("Velocity")!.SetValue(period, 4.5);
         array.SetValue(period, 0);
 
-        var prompt = (string)method.Invoke(null, new object?[] { array })!;
+        var prompt = (string)method.Invoke(null, new object?[] { array, OutputFormat.Markdown })!;
 
         Assert.Contains("\"end\":\"2024-01-01\"", prompt);
         Assert.Contains("\"leadTime\":1.2", prompt);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -22,6 +22,7 @@ public class DevOpsConfigServiceTests
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
             MainBranch = " main ",
+            OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules
             {
                 Epic = new EpicRules { HasDescription = true },
@@ -53,6 +54,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("RN", storedCfg.ReleaseNotesPrompt);
         Assert.Equal("RP", storedCfg.RequirementsPrompt);
         Assert.Equal("main", storedCfg.MainBranch);
+        Assert.Equal(OutputFormat.Pdf, storedCfg.OutputFormat);
         Assert.True(storedCfg.Rules.Epic.HasDescription);
     }
 
@@ -69,6 +71,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = "SQ",
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
+            OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules
             {
                 Epic = new EpicRules { HasDescription = true },
@@ -97,6 +100,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("SQ", service.Config.StoryQualityPrompt);
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
+        Assert.Equal(OutputFormat.Pdf, service.Config.OutputFormat);
         Assert.True(service.Config.Rules.Epic.HasDescription);
         Assert.Equal("proj", service.CurrentProject.Name);
     }
@@ -115,6 +119,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = " SQ ",
             ReleaseNotesPrompt = " RN ",
             RequirementsPrompt = " RP ",
+            OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules()
         };
         await storage.SetItemAsync("devops-config", stored);
@@ -130,6 +135,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("SQ", service.Config.StoryQualityPrompt);
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
+        Assert.Equal(OutputFormat.Pdf, service.Config.OutputFormat);
         Assert.Equal("default", service.CurrentProject.Name);
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -576,7 +576,7 @@
         return sb.ToString();
     }
 
-    private static string BuildPrompt(IEnumerable<PeriodMetrics> periods)
+    private static string BuildPrompt(IEnumerable<PeriodMetrics> periods, OutputFormat format)
     {
         var sb = new StringBuilder();
         sb.AppendLine("You are an Agile Coach preparing a delivery metrics report for your Delivery Manager.");
@@ -602,6 +602,8 @@
 
         var payload = new { metrics, summary };
         sb.AppendLine(JsonSerializer.Serialize(payload));
+        sb.AppendLine();
+        sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
         return sb.ToString();
     }
 
@@ -615,7 +617,7 @@
     private async Task CopyPrompt()
     {
         if (_periods.Count == 0) return;
-        var prompt = BuildPrompt(_periods);
+        var prompt = BuildPrompt(_periods, ConfigService.Config.OutputFormat);
         await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -27,6 +27,9 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Límite de caracteres del prompt</value>
   </data>
+  <data name="OutputFormat" xml:space="preserve">
+    <value>Formato de salida</value>
+  </data>
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Tiene story points</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -64,6 +64,12 @@
                     <MudTextField T="string" Value="_model.ReleaseNotesPrompt" ValueChanged="v => OnPromptsChanged(() => _model.ReleaseNotesPrompt = v)" Label='@L["ReleaseNotesPrompt"]' Lines="3"/>
                     <MudTextField T="string" Value="_model.RequirementsPrompt" ValueChanged="v => OnPromptsChanged(() => _model.RequirementsPrompt = v)" Label='@L["RequirementsPrompt"]' Lines="3"/>
                     <MudTextField T="int" Value="_model.PromptCharacterLimit" ValueChanged="OnPromptsLimitChanged" Label='@L["PromptLimit"]' InputType="InputType.Number" />
+                    <MudSelect T="OutputFormat" Value="_model.OutputFormat" ValueChanged="OnOutputFormatChanged" Label='@L["OutputFormat"]'>
+                        <MudSelectItem Value="OutputFormat.Markdown">Markdown</MudSelectItem>
+                        <MudSelectItem Value="OutputFormat.Pdf">PDF</MudSelectItem>
+                        <MudSelectItem Value="OutputFormat.Word">Word</MudSelectItem>
+                        <MudSelectItem Value="OutputFormat.Html">HTML</MudSelectItem>
+                    </MudSelect>
                     <MudButton OnClick="SavePrompts" Variant="Variant.Filled" Color="Color.Primary" Disabled="!_promptsDirty">@L["Save"]</MudButton>
                     <MudButton OnClick="ApplyPromptsToAll" Variant="Variant.Outlined" Color="Color.Primary">@L["ApplyToAll"]</MudButton>
                 </MudStack>
@@ -144,6 +150,7 @@
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
+            OutputFormat = cfg.OutputFormat,
             Rules = new ValidationRules
             {
                 Epic = new EpicRules { HasDescription = cfg.Rules.Epic.HasDescription },
@@ -192,6 +199,7 @@
             ReleaseNotesPrompt = _model.ReleaseNotesPrompt,
             RequirementsPrompt = _model.RequirementsPrompt,
             PromptCharacterLimit = _model.PromptCharacterLimit,
+            OutputFormat = _model.OutputFormat,
             Rules = _model.Rules
         };
         var saved = await ConfigService.SaveCurrentAsync(_model.Project, toSave);
@@ -224,6 +232,7 @@
         cfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
         cfg.RequirementsPrompt = _model.RequirementsPrompt;
         cfg.PromptCharacterLimit = _model.PromptCharacterLimit;
+        cfg.OutputFormat = _model.OutputFormat;
         await ConfigService.SaveCurrentAsync(_model.Project, cfg);
         _promptsDirty = false;
         Snackbar.Add(string.Format(L["SectionSaved"].Value, L["PromptsTab"].Value, _model.Project), Severity.Success);
@@ -252,6 +261,7 @@
                 pcfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
                 pcfg.RequirementsPrompt = _model.RequirementsPrompt;
                 pcfg.PromptCharacterLimit = _model.PromptCharacterLimit;
+                pcfg.OutputFormat = _model.OutputFormat;
                 await ConfigService.UpdateProjectAsync(p.Name, p.Name, pcfg);
             }
             Snackbar.Add(string.Format(L["SectionSaved"].Value, L["PromptsTab"].Value, L["AllProjects"].Value), Severity.Success);
@@ -360,6 +370,13 @@
     private Task OnPromptsLimitChanged(int value)
     {
         _model.PromptCharacterLimit = value;
+        _promptsDirty = true;
+        return Task.CompletedTask;
+    }
+
+    private Task OnOutputFormatChanged(OutputFormat value)
+    {
+        _model.OutputFormat = value;
         _promptsDirty = true;
         return Task.CompletedTask;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -27,6 +27,9 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Prompt Character Limit</value>
   </data>
+  <data name="OutputFormat" xml:space="preserve">
+    <value>Output Format</value>
+  </data>
   <data name="BugHasStoryPoints" xml:space="preserve">
     <value>Has story points</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -483,6 +483,8 @@ else if (_promptParts != null)
         sb.AppendLine("Work items:");
 
         sb.AppendLine(json);
+        sb.AppendLine();
+        sb.AppendLine($"After generating the notes, convert the content to {config.OutputFormat} format and include that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -574,6 +574,8 @@ Define what success looks like — business or system-level outcomes.
             sb.AppendLine(page.Text);
             sb.AppendLine();
         }
+        sb.AppendLine();
+        sb.AppendLine($"Once finished, convert the entire output to {config.OutputFormat} format and provide that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -302,6 +302,8 @@ else if (_promptParts != null)
         sb.AppendLine();
         sb.AppendLine("Work items:");
         sb.AppendLine(json);
+        sb.AppendLine();
+        sb.AppendLine($"After completing the analysis, convert the output to {config.OutputFormat} format and include that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -13,5 +13,6 @@ public class DevOpsConfig
     public string ReleaseNotesPrompt { get; set; } = string.Empty;
     public string RequirementsPrompt { get; set; } = string.Empty;
     public int PromptCharacterLimit { get; set; }
+    public OutputFormat OutputFormat { get; set; }
     public ValidationRules Rules { get; set; } = new();
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -176,6 +176,7 @@ public class DevOpsConfigService
             ReleaseNotesPrompt = config.ReleaseNotesPrompt.Trim(),
             RequirementsPrompt = config.RequirementsPrompt.Trim(),
             PromptCharacterLimit = config.PromptCharacterLimit,
+            OutputFormat = config.OutputFormat,
             Rules = config.Rules
         };
     }
@@ -200,6 +201,7 @@ public class DevOpsConfigService
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
+            OutputFormat = cfg.OutputFormat,
             Rules = cfg.Rules
         };
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/OutputFormat.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/OutputFormat.cs
@@ -1,0 +1,9 @@
+namespace DevOpsAssistant.Services.Models;
+
+public enum OutputFormat
+{
+    Markdown,
+    Pdf,
+    Word,
+    Html
+}


### PR DESCRIPTION
## Summary
- introduce `OutputFormat` enum and property on `DevOpsConfig`
- allow users to select output format in project settings
- embed instructions to convert each prompt to the selected format
- adjust metrics prompt builder and unit tests

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_685c661d28d88328a9a675cd224cf8fd