### PR TITLE
Refactor charts and unify padding

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExpandChart" xml:space="preserve">
+    <value>Ampliar gráfico</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.razor
@@ -1,0 +1,44 @@
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<ChartCard> L
+
+<MudPaper Class="pa-6" Style="height:100%">
+    <MudStack Spacing="1">
+        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+            <MudText Typo="Typo.h6">@Title</MudText>
+            @if (OnExpand.HasDelegate)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.OpenInFull"
+                               Size="Size.Small"
+                               OnClick="OnExpand"
+                               title="@ExpandTitle" />
+            }
+        </MudStack>
+        @if (AdditionalControls != null)
+        {
+            @AdditionalControls
+        }
+        <MudChart ChartType="@ChartType"
+                  ChartSeries="ChartSeries"
+                  XAxisLabels="XAxisLabels"
+                  Class="responsive-chart"
+                  Width="100%"
+                  Height="100%"
+                  AxisChartOptions="AxisChartOptions" />
+    </MudStack>
+</MudPaper>
+
+@code {
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public ChartType ChartType { get; set; }
+    [Parameter] public List<ChartSeries> ChartSeries { get; set; } = new();
+    [Parameter] public string[] XAxisLabels { get; set; } = Array.Empty<string>();
+    [Parameter] public AxisChartOptions AxisChartOptions { get; set; } = new();
+    [Parameter] public EventCallback OnExpand { get; set; }
+    [Parameter] public string? ExpandTitle { get; set; }
+    [Parameter] public RenderFragment? AdditionalControls { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        ExpandTitle ??= L["ExpandChart"];
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartCard.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ExpandChart" xml:space="preserve">
+    <value>Expand Chart</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/ChartDialog.razor
@@ -1,7 +1,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<ChartDialog> L
 
-<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
+<MudDialog ContentClass="pa-6" ActionsClass="pa-6">
     <DialogContent>
         <MudText Typo="Typo.h6" Class="mb-2">@Title</MudText>
         @if (AdditionalControls != null)

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
@@ -4,7 +4,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<GlobalOptionsDialog> L
 
-<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
+<MudDialog ContentClass="pa-6" ActionsClass="pa-6">
     <DialogContent>
         <MudStack Spacing="2">
             <MudTextField @bind-Value="_organization" Label='@L["Organization"]' />

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -5,35 +5,35 @@
 <MudText Typo="Typo.h4">@L["Heading"]</MudText>
 <MudText Typo="Typo.body1">@((MarkupString)L["Intro"].Value)</MudText>
 
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Epics"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Story Validation</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Validation"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Story Quality</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Quality"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Requirement Planner</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["RequirementsPlanner"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Release Notes</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["ReleaseNotes"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Metrics</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Metrics"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Branch Health</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["BranchHealth"].Value)</MudText>
 </MudPaper>
-<MudPaper Class="pa-4">
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Settings</MudText>
     <MudText Typo="Typo.body2">
         @((MarkupString)string.Format(L["Settings"],

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpDialog.razor
@@ -2,7 +2,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Help> L
 
-<MudDialog ContentClass="pa-4" ActionsClass="pa-4">
+<MudDialog ContentClass="pa-6" ActionsClass="pa-6">
     <DialogContent>
         <HelpContent />
     </DialogContent>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -60,7 +60,7 @@
 
     <MudMainContent>
         <div class="main-content">
-            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-6">
                 @Body
             </MudContainer>
         </div>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -30,7 +30,7 @@
 
     <MudMainContent>
         <div class="main-content">
-            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-4">
+            <MudContainer MaxWidth="MaxWidth.Large" Class="pa-6">
                 @Body
             </MudContainer>
         </div>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -13,7 +13,7 @@
         <MudText Typo="Typo.h4">@L["Welcome"]</MudText>
     </MudItem>
     <MudItem xs="12">
-        <MudPaper Class="pa-4">
+        <MudPaper Class="pa-6">
             <MudText Typo="Typo.body1">
                 @L["Description"]
             </MudText>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -91,85 +91,60 @@ else if (_periods.Any())
 
     <MudGrid>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudText Typo="Typo.h6">Lead &amp; Cycle Time</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowLeadCycleChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
-                    <MudChart ChartType="ChartType.Line"
-                              ChartSeries="_leadCycleSeries"
-                              XAxisLabels="_xAxisLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+            <ChartCard Title="Lead &amp; Cycle Time"
+                       ChartType="ChartType.Line"
+                       ChartSeries="_leadCycleSeries"
+                       XAxisLabels="_xAxisLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowLeadCycleChart"
+                       ExpandTitle="@L["ExpandChart"]" />
         </MudItem>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudText Typo="Typo.h6">Throughput &amp; Velocity</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowBarChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
-                    <MudChart ChartType="ChartType.Bar"
-                              ChartSeries="_barSeries"
-                              XAxisLabels="_xAxisLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+            <ChartCard Title="Throughput &amp; Velocity"
+                       ChartType="ChartType.Bar"
+                       ChartSeries="_barSeries"
+                       XAxisLabels="_xAxisLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowBarChart"
+                       ExpandTitle="@L["ExpandChart"]" />
         </MudItem>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudText Typo="Typo.h6">@L["AvgWip"]</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowWipChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
-                    <MudChart ChartType="ChartType.Line"
-                              ChartSeries="_wipSeries"
-                              XAxisLabels="_xAxisLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+            <ChartCard Title="@L["AvgWip"]"
+                       ChartType="ChartType.Line"
+                       ChartSeries="_wipSeries"
+                       XAxisLabels="_xAxisLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowWipChart"
+                       ExpandTitle="@L["ExpandChart"]" />
         </MudItem>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudText Typo="Typo.h6">@L["SprintEff"]</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowSprintChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
-                    <MudChart ChartType="ChartType.Line"
-                              ChartSeries="_sprintSeries"
-                              XAxisLabels="_xAxisLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+            <ChartCard Title="@L["SprintEff"]"
+                       ChartType="ChartType.Line"
+                       ChartSeries="_sprintSeries"
+                       XAxisLabels="_xAxisLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowSprintChart"
+                       ExpandTitle="@L["ExpandChart"]" />
         </MudItem>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudButton OnClick="ToggleBurnChartControls" EndIcon="@(_showBurnChartControls ? Icons.Material.Outlined.ArrowDropUp : Icons.Material.Outlined.ArrowDropDown)">@L["BurnUp"]</MudButton>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowBurnChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
+            <ChartCard Title="@L["BurnUp"]"
+                       ChartType="ChartType.Line"
+                       ChartSeries="_burnSeries"
+                       XAxisLabels="_burnLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowBurnChart"
+                       ExpandTitle="@L["ExpandChart"]">
+                <AdditionalControls>
+                    <MudButton OnClick="ToggleBurnChartControls"
+                               EndIcon="@(_showBurnChartControls ? Icons.Material.Outlined.ArrowDropUp : Icons.Material.Outlined.ArrowDropDown)"
+                               Class="mb-2">
+                        @L["BurnUp"]
+                    </MudButton>
                     <MudCollapse Expanded="_showBurnChartControls">
                         <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
-                            <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points"/>
-                            <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %"/>
-                            <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %"/>
+                            <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points" />
+                            <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %" />
+                            <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %" />
                             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="UpdateBurnUp">Update</MudButton>
                         </MudStack>
                         @if (_daysMin.HasValue && _daysMax.HasValue)
@@ -189,32 +164,17 @@ else if (_periods.Any())
                             </MudStack>
                         }
                     </MudCollapse>
-                    <MudChart ChartType="ChartType.Line"
-                              ChartSeries="_burnSeries"
-                              XAxisLabels="_burnLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+                </AdditionalControls>
+            </ChartCard>
         </MudItem>
         <MudItem xs="12" md="6">
-            <MudPaper Class="pa-2" Style="height:100%">
-                <MudStack Spacing="1">
-                    <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
-                        <MudText Typo="Typo.h6">@L["Flow"]</MudText>
-                        <MudIconButton Icon="@Icons.Material.Filled.OpenInFull" Size="Size.Small" OnClick="ShowFlowChart" title='@L["ExpandChart"]'/>
-                    </MudStack>
-                    <MudChart ChartType="ChartType.StackedBar"
-                              ChartSeries="_flowSeries"
-                              XAxisLabels="_flowLabels"
-                              Class="responsive-chart"
-                              Width="100%"
-                              Height="100%"
-                              AxisChartOptions="_axisOptions"/>
-                </MudStack>
-            </MudPaper>
+            <ChartCard Title="@L["Flow"]"
+                       ChartType="ChartType.StackedBar"
+                       ChartSeries="_flowSeries"
+                       XAxisLabels="_flowLabels"
+                       AxisChartOptions="_axisOptions"
+                       OnExpand="ShowFlowChart"
+                       ExpandTitle="@L["ExpandChart"]" />
         </MudItem>
     </MudGrid>
     <MudButton Variant="Variant.Filled"

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -105,7 +105,7 @@
 }
 else if (_promptParts != null)
 {
-    <MudPaper Class="pa-2">
+    <MudPaper Class="pa-6">
         <MudStack Spacing="2">
             <MudButton Variant="Variant.Text"
                        StartIcon="@Icons.Material.Filled.Download"

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -84,7 +84,7 @@
 
                 @foreach (var story in _plan.Stories)
                 {
-                    <MudPaper Class="@($"pa-2 {WorkItemHelpers.GetItemClass("User Story")}")">
+                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("User Story")}")">
                         <MudText Typo="Typo.subtitle2">Story</MudText>
                         @if (_previewHtml)
                         {
@@ -109,21 +109,21 @@
             {
                 @foreach (var epic in _plan.Epics)
                 {
-                    <MudPaper Class="@($"pa-2 {WorkItemHelpers.GetItemClass("Epic")}")">
+                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("Epic")}")">
                         <MudText Typo="Typo.h6">Epic</MudText>
                         <MudTextField @bind-Value="epic.Title" Label="Title" />
                         <MudTextField @bind-Value="epic.Description" Label="Description" Lines="3" />
 
                         @foreach (var feature in epic.Features)
                         {
-                            <MudPaper Class="@($"pa-2 {WorkItemHelpers.GetItemClass("Feature")}")">
+                            <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("Feature")}")">
                                 <MudText Typo="Typo.subtitle1">Feature</MudText>
                                 <MudTextField @bind-Value="feature.Title" Label="Title" />
                                 <MudTextField @bind-Value="feature.Description" Label="Description" Lines="3" />
 
                                 @foreach (var story in feature.Stories)
                                 {
-                                    <MudPaper Class="@($"pa-2 {WorkItemHelpers.GetItemClass("User Story")}")">
+                                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("User Story")}")">
                                         <MudText Typo="Typo.subtitle2">Story</MudText>
                                         @if (_previewHtml)
                                         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/StoryReview.razor
@@ -48,7 +48,7 @@
 }
 else if (_promptParts != null)
 {
-    <MudPaper Class="pa-2">
+    <MudPaper Class="pa-6">
         <MudStack Spacing="2">
             <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
             <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" />

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -84,7 +84,7 @@ else if (_results != null)
         <MudStack Row="true" Spacing="2">
             <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@_loading" OnClick="TagAll">Tag All</MudButton>
         </MudStack>
-        <MudPaper Class="pa-2 work-item-container">
+        <MudPaper Class="pa-6 work-item-container">
             <MudList T="ResultItem" Dense="true" Class="work-item-tree">
                 @foreach (var r in _results)
                 {


### PR DESCRIPTION
## Summary
- create `ChartCard` component for chart displays
- update `Metrics` page to use new component
- bump padding across layouts, pages and dialogs

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release`
- `DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685d474ba84883289ca86dced2201109