### PR TITLE
Add missing translation keys

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.es.resx
@@ -33,6 +33,9 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copiado al portapapeles</value>
   </data>
+  <data name="SprintEfficiencyOptionsHeading" xml:space="preserve">
+    <value>Opciones de eficiencia de sprint</value>
+  </data>
   <data name="AvgWip" xml:space="preserve">
     <value>WIP medio</value>
   </data>
@@ -56,6 +59,9 @@
   </data>
   <data name="ExpandChart" xml:space="preserve">
     <value>Ampliar gráfico</value>
+  </data>
+  <data name="ProjectionOptions" xml:space="preserve">
+    <value>Opciones de proyección</value>
   </data>
   <data name="ProjectionHeading" xml:space="preserve">
     <value>Proyección</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.resx
@@ -33,6 +33,9 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copied to clipboard</value>
   </data>
+  <data name="SprintEfficiencyOptionsHeading" xml:space="preserve">
+    <value>Sprint Efficiency Options</value>
+  </data>
   <data name="AvgWip" xml:space="preserve">
     <value>Avg WIP</value>
   </data>
@@ -56,6 +59,9 @@
   </data>
   <data name="ExpandChart" xml:space="preserve">
     <value>Expand Chart</value>
+  </data>
+  <data name="ProjectionOptions" xml:space="preserve">
+    <value>Projection Options</value>
   </data>
   <data name="ProjectionHeading" xml:space="preserve">
     <value>Projection</value>


### PR DESCRIPTION
## Summary
- add `SprintEfficiencyOptionsHeading` entry to Metrics resource files
- add `ProjectionOptions` entry to Metrics resource files

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685d679e45e88328adba8fe241939953