### PR TITLE
Add Doom theme with session toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,6 @@ where to connect.
 
 ## Accessibility
 
+## Doom Theme
+
+Type `iddqd` anywhere on the page to toggle a special Doom-inspired theme. Typing it again reverts to the default look. The choice is not saved between sessions.

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -23,6 +23,7 @@ public abstract class ComponentTestBase : TestContext
         var config = new DevOpsConfigService(storage);
         Services.AddSingleton(config);
         Services.AddSingleton(new PageStateService(storage, config));
+        Services.AddSingleton(new ThemeSessionService(JSInterop.JSRuntime));
         if (includeApi)
         {
             var deployment = new DeploymentConfigService(new HttpClient());

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -8,8 +8,9 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<MainLayout> L
 @using DevOpsAssistant.Utils
+@inject ThemeSessionService ThemeSession
 
-<MudThemeProvider Theme="@AzureDevOpsTheme.Theme" @bind-IsDarkMode="_isDarkMode"/>
+<MudThemeProvider Theme="@CurrentTheme" @bind-IsDarkMode="_isDarkMode"/>
 <MudDialogProvider/>
 <MudPopoverProvider/>
 <MudSnackbarProvider/>
@@ -83,6 +84,7 @@
     private string _selectedProject = string.Empty;
     private bool _initialized;
     private bool _isDarkMode;
+    private MudTheme CurrentTheme => ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme;
     
     private void HandleProjectChanged()
     {
@@ -93,6 +95,7 @@
     protected override void OnInitialized()
     {
         ConfigService.ProjectChanged += HandleProjectChanged;
+        ThemeSession.ThemeChanged += OnThemeChanged;
     }
 
     protected override void OnAfterRender(bool firstRender)
@@ -155,6 +158,11 @@
 
         await ConfigService.RemoveGlobalOrganizationAsync();
         StateHasChanged();
+    }
+
+    private void OnThemeChanged()
+    {
+        InvokeAsync(StateHasChanged);
     }
 
     private async Task OpenOptionsDialog()
@@ -225,6 +233,7 @@
     public void Dispose()
     {
         ConfigService.ProjectChanged -= HandleProjectChanged;
+        ThemeSession.ThemeChanged -= OnThemeChanged;
     }
 
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -1,13 +1,15 @@
 @using DevOpsAssistant.Components
 @inherits LayoutComponentBase
+@implements IDisposable
 @inject IDialogService DialogService
 @inject DevOpsConfigService ConfigService
 @inject VersionService VersionService
 @using DevOpsAssistant.Utils
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<SimpleLayout> L
+@inject ThemeSessionService ThemeSession
 
-<MudThemeProvider Theme="@AzureDevOpsTheme.Theme" @bind-IsDarkMode="_isDarkMode"/>
+<MudThemeProvider Theme="@CurrentTheme" @bind-IsDarkMode="_isDarkMode"/>
 <MudDialogProvider/>
 <MudPopoverProvider/>
 <MudSnackbarProvider/>
@@ -49,6 +51,12 @@
 
 @code {
     private bool _isDarkMode;
+    private MudTheme CurrentTheme => ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme;
+
+    protected override void OnInitialized()
+    {
+        ThemeSession.ThemeChanged += OnThemeChanged;
+    }
 
     protected override async Task OnInitializedAsync()
     {
@@ -106,5 +114,15 @@
     private async Task OpenHelpDialog()
     {
         await DialogService.ShowAsync<HelpDialog>(L["Help"]);
+    }
+
+    private void OnThemeChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        ThemeSession.ThemeChanged -= OnThemeChanged;
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddScoped<DevOpsApiService>();
 builder.Services.AddScoped<VersionService>();
 builder.Services.AddScoped<DeploymentConfigService>();
 builder.Services.AddLocalization();
+builder.Services.AddScoped<ThemeSessionService>();
 
 var host = builder.Build();
 var js = host.Services.GetRequiredService<IJSRuntime>();
@@ -37,5 +38,7 @@ if (!string.IsNullOrWhiteSpace(cultureName))
 }
 var labelLocalizer = host.Services.GetRequiredService<IStringLocalizer<ErrorUi>>();
 await js.InvokeVoidAsync("setErrorDismissLabel", labelLocalizer["DismissError"].Value);
+var themeService = host.Services.GetRequiredService<ThemeSessionService>();
+await themeService.InitializeAsync();
 await host.Services.GetRequiredService<DeploymentConfigService>().LoadAsync();
 await host.RunAsync();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/ThemeSessionService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/ThemeSessionService.cs
@@ -1,0 +1,39 @@
+using Microsoft.JSInterop;
+
+namespace DevOpsAssistant.Services;
+
+public class ThemeSessionService : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private DotNetObjectReference<ThemeSessionService>? _objRef;
+
+    public event Action? ThemeChanged;
+
+    public bool IsDoom { get; private set; }
+
+    public ThemeSessionService(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _objRef = DotNetObjectReference.Create(this);
+        await _jsRuntime.InvokeVoidAsync("themeShortcut.init", _objRef);
+        await _jsRuntime.InvokeVoidAsync("themeShortcut.setDoom", IsDoom);
+    }
+
+    [JSInvokable]
+    public async Task ToggleDoom()
+    {
+        IsDoom = !IsDoom;
+        await _jsRuntime.InvokeVoidAsync("themeShortcut.setDoom", IsDoom);
+        ThemeChanged?.Invoke();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _objRef?.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/DoomTheme.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/DoomTheme.cs
@@ -1,0 +1,58 @@
+using MudBlazor;
+
+namespace DevOpsAssistant.Utils;
+
+public static class DoomTheme
+{
+    public static MudTheme Theme { get; } = new MudTheme
+    {
+        LayoutProperties = new LayoutProperties
+        {
+            DefaultBorderRadius = "0px",
+        },
+        PaletteLight = new PaletteLight
+        {
+            Primary = "#E53935",
+            Secondary = "#FB8C00",
+            Tertiary = "#A84300",
+            Background = "#F5F5F5",
+            Surface = "#EEEEEE",
+            Info = "#C2185B",
+            Success = "#43A047",
+            Warning = "#FFB300",
+            Error = "#D32F2F",
+            TextPrimary = "#212121",
+            TextSecondary = "#616161",
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = "#D32F2F",
+            Secondary = "#FF8F00",
+            Tertiary = "#A84300",
+            Background = "#1B1B1B",
+            Surface = "#2E2E2E",
+            Info = "#C2185B",
+            Success = "#388E3C",
+            Warning = "#FBC02D",
+            Error = "#B71C1C",
+            Dark = "#000000",
+            TextPrimary = "#E0E0E0",
+            TextSecondary = "#9E9E9E",
+            LinesDefault = "#4F4F4F",
+            AppbarBackground = "#000000",
+            AppbarText = "#FFD600",
+            DrawerBackground = "#1F1F1F",
+            DrawerText = "#E0E0E0",
+            DrawerIcon = "#9E9E9E"
+        },
+        Shadows = new Shadow
+        {
+            Elevation = new[]
+            {
+                "none",
+                "0px 4px 2px -2px rgba(0,0,0,0.5)",
+                "0px 6px 3px -3px rgba(0,0,0,0.5)",
+            }
+        }
+    };
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
@@ -1,0 +1,51 @@
+@font-face {
+    font-family: 'Doom';
+    src: url('../fonts/doom/amazdoomleft-epw3-webfont.woff2') format('woff2'),
+         url('../fonts/doom/amazdoomleft-epw3-webfont.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+}
+
+body.doom-theme {
+    font-family: 'Doom', sans-serif;
+    background-image: url('/images/doom/wall.png');
+    background-size: cover;
+    background-position: center;
+    position: relative;
+}
+
+body.doom-theme::after {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(circle at center,
+                rgba(0,0,0,0) 60%,
+                rgba(0,0,0,0.7) 100%);
+    pointer-events: none;
+}
+
+body.doom-theme .mud-paper {
+    background-color: #2E2E2E !important;
+    background-image:
+        radial-gradient(circle at top left,
+                        rgba(255,0,0,0.1) 0%,
+                        transparent 70%),
+        url('/images/doom/stone.jpg');
+    background-size: contain;
+}
+
+body.doom-theme .mud-appbar {
+    background: linear-gradient(135deg,
+                #2f0f0f 0%,
+                #770000 70%);
+}
+
+body.doom-theme .mud-button-filled-primary {
+    background: linear-gradient(145deg,
+                #D32F2F,
+                #FF1744 70%);
+    box-shadow: inset 0 2px 2px rgba(0,0,0,0.5);
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/index.html
@@ -7,6 +7,7 @@
     <title>DevOpsAssistant</title>
     <base href="/"/>
     <link href="css/app.css" rel="stylesheet"/>
+    <link href="css/doom.css" rel="stylesheet"/>
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet"/>
     <link href="/apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180">
     <link href="/favicon-32x32.png" rel="icon" sizes="32x32" type="image/png">

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/scripts.js
@@ -38,3 +38,26 @@ window.blazorCulture = {
     }
 };
 
+window.themeShortcut = {
+    init: function (dotnetHelper) {
+        let buffer = '';
+        document.addEventListener('keydown', function (e) {
+            if (e.key.length === 1) {
+                buffer += e.key.toLowerCase();
+                if (buffer.length > 5)
+                    buffer = buffer.slice(-5);
+                if (buffer === 'iddqd') {
+                    dotnetHelper.invokeMethodAsync('ToggleDoom');
+                    buffer = '';
+                }
+            }
+        });
+    },
+    setDoom: function (isDoom) {
+        if (isDoom)
+            document.body.classList.add('doom-theme');
+        else
+            document.body.classList.remove('doom-theme');
+    }
+};
+


### PR DESCRIPTION
## Summary
- implement a new `DoomTheme` MudTheme
- add `ThemeSessionService` to toggle Doom mode
- capture `iddqd` keystroke in JS and apply `doom-theme` CSS
- link new styles and register the service
- update layouts to switch themes dynamically
- document the hidden theme
- fix tests for new service

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685d6f98b67483288671f6cbc2202721