### PR TITLE
Sync burn-up chart dialog layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -226,12 +226,51 @@ else if (_periods.Any())
     private List<string> _tags = new();
     private bool _showBurnChartControls;
 
-    private RenderFragment BurnUpControls => @<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap" Style="margin-bottom:16px">
-                                                 <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points"/>
-                                                 <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %"/>
-                                                 <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %"/>
-                                                 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="UpdateBurnUp">Update</MudButton>
-                                             </MudStack>;
+    private RenderFragment BurnUpControls => @<>
+                                             <MudButton OnClick="ToggleBurnChartControls"
+                                                        EndIcon="@(_showBurnChartControls ? Icons.Material.Outlined.ArrowDropUp : Icons.Material.Outlined.ArrowDropDown)"
+                                                        Class="mb-2">
+                                                 @L["ProjectionOptions"]
+                                             </MudButton>
+                                             <MudCollapse Expanded="_showBurnChartControls">
+                                                 <MudGrid Spacing="2">
+                                                     <MudItem xs="12" md="6">
+                                                         <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+                                                             <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points"/>
+                                                             <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %"/>
+                                                             <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %"/>
+                                                             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="UpdateBurnUp">Update</MudButton>
+                                                         </MudStack>
+                                                     </MudItem>
+                                                     <MudItem xs="12" md="6">
+                                                         @if (_daysMin.HasValue && _daysMax.HasValue)
+                                                         {
+                                                             <MudText Typo="Typo.subtitle1" Class="mt-2">
+                                                                 @L["ProjectionHeading"]
+                                                             </MudText>
+                                                             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
+                                                                 <MudTable Items="new[] { 0 }" Dense="true">
+                                                                     <HeaderContent>
+                                                                         <MudTh>@L["ProjectedDays"]</MudTh>
+                                                                         <MudTh>@L["CompletionRange"]</MudTh>
+                                                                     </HeaderContent>
+                                                                     <RowTemplate>
+                                                                         <MudTd>
+                                                                             @(_daysMin == _daysMax
+                                                                                 ? _daysMin.Value.ToString()
+                                                                                 : $"{_daysMin}-{_daysMax}")
+                                                                         </MudTd>
+                                                                         <MudTd>
+                                                                             @($"{_dateMin?.ToLocalDateString()} - {_dateMax?.ToLocalDateString()}")
+                                                                         </MudTd>
+                                                                     </RowTemplate>
+                                                                 </MudTable>
+                                                             </MudStack>
+                                                         }
+                                                     </MudItem>
+                                                 </MudGrid>
+                                             </MudCollapse>
+                                         </>;
 
     private string[] _xAxisLabels = [];
     private List<ChartSeries> _leadCycleSeries = [];


### PR DESCRIPTION
## Summary
- make popup burn‑up chart use same projection controls as inline chart

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685d75324f3883289c3e37879ab9b60f