### PR TITLE
Fix 404s due to missing staticwebapp config

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Build/PublishTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Build/PublishTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace DevOpsAssistant.Tests.Build;
+
+public class PublishTests
+{
+    [Fact]
+    public void Publish_Copies_StaticWebAppConfig_To_Wwwroot()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+
+        var projectPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../DevOpsAssistant/DevOpsAssistant.csproj"));
+        var info = new ProcessStartInfo("dotnet",
+            $"publish \"{projectPath}\" -c Release -o \"{tempDir}\" --no-restore --nologo")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+
+        using var process = Process.Start(info);
+        process!.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            throw new Xunit.Sdk.XunitException($"dotnet publish failed: {output}");
+        }
+
+        var configPath = Path.Combine(tempDir, "wwwroot", "staticwebapp.config.json");
+        Assert.True(File.Exists(configPath), $"Expected file '{configPath}' to exist.");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj
@@ -39,6 +39,7 @@
   <!-- Ensure Azure Static Web Apps configuration is included -->
   <ItemGroup>
     <Content Update="staticwebapp.config.json">
+      <Link>wwwroot/staticwebapp.config.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>


### PR DESCRIPTION
## Summary
- ensure `staticwebapp.config.json` lands in the published `wwwroot` directory
- add regression test to verify the file is included after `dotnet publish`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685e745b11008328976818c204fb8ee7