### PR TITLE
Fix metrics charts formatting

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/Apex/SimpleApexChart.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/Apex/SimpleApexChart.razor
@@ -1,7 +1,7 @@
 @using ApexCharts
 @using DevOpsAssistant.Components.Apex
 
-<ApexChart TItem="ChartPoint" Options="Options" Height="300">
+<ApexChart TItem="ChartPoint" Options="Options" Height="300" FormatYAxisLabel="FormatYAxisLabel">
 @foreach (var series in Series)
 {
     <ApexPointSeries TItem="ChartPoint"
@@ -17,4 +17,5 @@
     [Parameter] public List<ApexSeries> Series { get; set; } = new();
     [Parameter] public SeriesType SeriesType { get; set; } = SeriesType.Line;
     [Parameter] public ApexChartOptions<ChartPoint>? Options { get; set; }
+    [Parameter] public Func<decimal, string>? FormatYAxisLabel { get; set; }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/MetricsBeta.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/MetricsBeta.razor
@@ -98,25 +98,25 @@ else if (_periods.Any())
         <MudItem xs="12" md="6">
             <MudPaper Class="pa-6">
                 <MudText Typo="Typo.h6">Lead &amp; Cycle Time</MudText>
-                <SimpleApexChart SeriesType="SeriesType.Line" Series="_leadCycleApex" />
+                <SimpleApexChart SeriesType="SeriesType.Line" Series="_leadCycleApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="6">
             <MudPaper Class="pa-6">
                 <MudText Typo="Typo.h6">Throughput &amp; Velocity</MudText>
-                <SimpleApexChart SeriesType="SeriesType.Bar" Series="_barApex" />
+                <SimpleApexChart SeriesType="SeriesType.Bar" Series="_barApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="6">
             <MudPaper Class="pa-6">
                 <MudText Typo="Typo.h6">@L["AvgWip"]</MudText>
-                <SimpleApexChart SeriesType="SeriesType.Line" Series="_wipApex" />
+                <SimpleApexChart SeriesType="SeriesType.Line" Series="_wipApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="6">
             <MudPaper Class="pa-6">
                 <MudText Typo="Typo.h6">@L["SprintEff"]</MudText>
-                <SimpleApexChart SeriesType="SeriesType.Line" Series="_sprintApex" />
+                <SimpleApexChart SeriesType="SeriesType.Line" Series="_sprintApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="6">
@@ -167,13 +167,13 @@ else if (_periods.Any())
                         </MudItem>
                     </MudGrid>
                 </MudCollapse>
-                <SimpleApexChart SeriesType="SeriesType.Line" Series="_burnApex" />
+                <SimpleApexChart SeriesType="SeriesType.Line" Series="_burnApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="6">
             <MudPaper Class="pa-6">
                 <MudText Typo="Typo.h6">@L["Flow"]</MudText>
-                <SimpleApexChart SeriesType="SeriesType.Area" Options="_flowOptions" Series="_flowApex" />
+                <SimpleApexChart SeriesType="SeriesType.Area" Options="_flowOptions" Series="_flowApex" FormatYAxisLabel="FormatNumber" />
             </MudPaper>
         </MudItem>
     </MudGrid>
@@ -498,6 +498,7 @@ else if (_periods.Any())
         if (items.Count == 0 || efficiency is null || _errorRange is null)
         {
             _burnLabels = [];
+            _burnApex.Clear();
             return;
         }
 
@@ -577,6 +578,7 @@ else if (_periods.Any())
         if (items.Count == 0)
         {
             _flowLabels = [];
+            _flowApex.Clear();
             return;
         }
 
@@ -653,6 +655,11 @@ else if (_periods.Any())
             result.Add(converted);
         }
         return result;
+    }
+
+    private static string FormatNumber(decimal value)
+    {
+        return value.ToString("0.0");
     }
 
     private static string BuildCsv(IEnumerable<PeriodMetrics> periods)


### PR DESCRIPTION
## Summary
- show formatted Y axis labels in Apex charts
- clear Apex series if burnup or flow data can't be computed
- expose formatting delegate on `SimpleApexChart`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685e7da935488328b83a9caa89f2c64b