### PR TITLE
Add iteration autocomplete

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Threading;
+using System.Linq;
+using System.Collections.Generic;
+using Bunit;
+using DevOpsAssistant.Components;
+using DevOpsAssistant.Services;
+using DevOpsAssistant.Services.Models;
+using DevOpsAssistant.Tests.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
+
+namespace DevOpsAssistant.Tests.Components;
+
+public class WorkItemSelectorTests : ComponentTestBase
+{
+    [Fact]
+    public async Task Shows_Iteration_Autocomplete_When_Enabled()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+
+        var backlogJson = "{\"path\":\"Area\"}";
+        var statesJson = "{\"value\":[{\"name\":\"New\"}]}";
+        var iterationsJson = "{\"children\":[{\"name\":\"Sprint\",\"path\":\"Proj\\Sprint\",\"attributes\":{\"startDate\":\"2024-01-01T00:00:00Z\",\"finishDate\":\"2024-01-15T00:00:00Z\"}}]}";
+        var handler = new FakeHttpMessageHandler(req =>
+        {
+            var url = req.RequestUri!.AbsoluteUri;
+            if (url.Contains("classificationnodes/areas"))
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(backlogJson) };
+            if (url.Contains("classificationnodes/iterations"))
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(iterationsJson) };
+            if (url.Contains("states"))
+                return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(statesJson) };
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+        });
+        var client = new HttpClient(handler);
+        Services.AddSingleton(new DeploymentConfigService(new HttpClient()));
+        Services.AddSingleton(sp => new DevOpsApiService(
+            client,
+            config,
+            sp.GetRequiredService<DeploymentConfigService>(),
+            sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
+
+        var cut = RenderWithProvider<WorkItemSelector>();
+        cut.SetParametersAndRender(parameters => parameters.Add(c => c.UseIteration, true));
+        cut.WaitForAssertion(() => Assert.Contains("Iteration", cut.Markup));
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItemSelector.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItemSelector.razor
@@ -15,13 +15,11 @@
                     </MudSelect>
                     @if (UseIteration)
                     {
-                        <MudSelect T="string" @bind-Value="_iteration" Label="Iteration" Clearable="true">
-                            <MudSelectItem Value="@(null as string)">All</MudSelectItem>
-                            @foreach (var it in _iterations)
-                            {
-                                <MudSelectItem Value="@it.Path">@it.Path</MudSelectItem>
-                            }
-                        </MudSelect>
+                        <MudAutocomplete T="string"
+                                         Label="Iteration"
+                                         @bind-Value="_iteration"
+                                         SearchFunc="SearchIterations"
+                                         Clearable="true" />
                     }
                     <MudSelect T="string" MultiSelection="true" SelectedValues="SelectedStates" SelectedValuesChanged="@(vals => SelectedStates = vals.ToHashSet())" Label="States">
                         @foreach (var s in _states)
@@ -138,6 +136,14 @@
             return Array.Empty<WorkItemInfo>();
         var result = await ApiService.SearchReleaseItemsAsync(value);
         return result.Where(r => !_searchSelected.Contains(r));
+    }
+
+    private Task<IEnumerable<string>> SearchIterations(string value, CancellationToken _)
+    {
+        IEnumerable<string> result = _iterations.Select(i => i.Path);
+        if (!string.IsNullOrWhiteSpace(value))
+            result = result.Where(i => i.Contains(value, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(result);
     }
 
     private void OnItemSelected(WorkItemInfo? item)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -21,7 +21,7 @@
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading || !_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
 <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -40,7 +40,7 @@
     </MudCollapse>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load" Disabled="!_hasRules || !_selectedItems.Any()">Check</MudButton>
 <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
 


### PR DESCRIPTION
## Summary
- switch iteration select to use a MudAutocomplete
- enable iteration filter on release notes and validation pages
- add tests for the new iteration autocomplete

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685e94616f2c83288243bce040039795