### PR TITLE
Add inline format option

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -191,6 +191,18 @@ public class ReleaseNotesPageTests : ComponentTestBase
         Assert.DoesNotContain("SystemInfo", result);
     }
 
+    [Fact]
+    public void BuildPrompt_Inline_Format_Does_Not_Request_Conversion()
+    {
+        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cfg = new DevOpsConfig { OutputFormat = OutputFormat.Inline };
+
+        var result = (string)method.Invoke(null, [new List<StoryHierarchyDetails>(), cfg])!;
+
+        Assert.DoesNotContain("convert the content", result);
+        Assert.Contains("Reply inline", result);
+    }
+
     [Fact(Skip = "Updated")]
     public void ReleaseNotes_Uses_TreeView_When_Configured()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -788,7 +788,10 @@ else if (_periods.Any())
         sb.AppendLine();
         sb.AppendLine($"Data: {json}");
         sb.AppendLine();
-        sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
+        if (format == OutputFormat.Inline)
+            sb.AppendLine("Reply inline with the final report.");
+        else
+            sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/MetricsBeta.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/MetricsBeta.razor
@@ -789,7 +789,10 @@ else if (_periods.Any())
         sb.AppendLine();
         sb.AppendLine($"Data: {json}");
         sb.AppendLine();
-        sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
+        if (format == OutputFormat.Inline)
+            sb.AppendLine("Reply inline with the final report.");
+        else
+            sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -69,6 +69,7 @@
                         <MudSelectItem Value="OutputFormat.Pdf">PDF</MudSelectItem>
                         <MudSelectItem Value="OutputFormat.Word">Word</MudSelectItem>
                         <MudSelectItem Value="OutputFormat.Html">HTML</MudSelectItem>
+                        <MudSelectItem Value="OutputFormat.Inline">Inline</MudSelectItem>
                     </MudSelect>
                     <MudButton OnClick="SavePrompts" Variant="Variant.Filled" Color="Color.Primary" Disabled="!_promptsDirty">@L["Save"]</MudButton>
                     <MudButton OnClick="ApplyPromptsToAll" Variant="Variant.Outlined" Color="Color.Primary">@L["ApplyToAll"]</MudButton>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -249,7 +249,10 @@ else if (_promptParts != null)
 
         sb.AppendLine(json);
         sb.AppendLine();
-        sb.AppendLine($"After generating the notes, convert the content to {config.OutputFormat} format and include that version.");
+        if (config.OutputFormat == OutputFormat.Inline)
+            sb.AppendLine("Reply inline with the final notes.");
+        else
+            sb.AppendLine($"After generating the notes, convert the content to {config.OutputFormat} format and include that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -555,7 +555,10 @@ Define what success looks like — business or system-level outcomes.
             sb.AppendLine();
         }
         sb.AppendLine();
-        sb.AppendLine($"Once finished, convert the entire output to {config.OutputFormat} format and provide that version.");
+        if (config.OutputFormat == OutputFormat.Inline)
+            sb.AppendLine("Reply inline with the final requirements.");
+        else
+            sb.AppendLine($"Once finished, convert the entire output to {config.OutputFormat} format and provide that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -261,7 +261,10 @@ else if (_promptParts != null)
         sb.AppendLine("Work items:");
         sb.AppendLine(json);
         sb.AppendLine();
-        sb.AppendLine($"After completing the analysis, convert the output to {config.OutputFormat} format and include that version.");
+        if (config.OutputFormat == OutputFormat.Inline)
+            sb.AppendLine("Reply inline with the analysis results.");
+        else
+            sb.AppendLine($"After completing the analysis, convert the output to {config.OutputFormat} format and include that version.");
         return sb.ToString();
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/OutputFormat.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/OutputFormat.cs
@@ -5,5 +5,6 @@ public enum OutputFormat
     Markdown,
     Pdf,
     Word,
-    Html
+    Html,
+    Inline
 }


### PR DESCRIPTION
## Summary
- support OutputFormat.Inline
- update prompts to handle inline format
- show Inline option in settings
- test new behavior

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685eb14894a48328969f882c21b0b7db