### PR TITLE
Add spec selector for starter prompt

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="UseDocumentTooltip" xml:space="preserve">
+    <value>Cargue un documento en lugar de seleccionar páginas wiki</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
@@ -1,0 +1,36 @@
+@using DevOpsAssistant.Services.Models
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<WikiDocumentSelector> L
+
+<MudTooltip Text='@L["UseDocumentTooltip"]'>
+    <MudSwitch T="bool" @bind-Value="UseDocument" Color="Color.Primary" Label="Use Document" />
+</MudTooltip>
+@if (UseDocument)
+{
+    <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx,.md" />
+}
+else if (WikiItems != null)
+{
+    <MudTreeView T="WikiPageNode" Items="@WikiItems" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="SelectedPages" Class="scroll-300">
+        <ItemTemplate>
+            <MudTreeViewItem Items="@context.Children" Value="@context.Value" Text="@context.Text" @bind-Expanded="@context.Expanded" />
+        </ItemTemplate>
+    </MudTreeView>
+}
+
+@code {
+    [Parameter] public bool UseDocument { get; set; }
+    [Parameter] public EventCallback<bool> UseDocumentChanged { get; set; }
+    [Parameter] public IBrowserFile? File { get; set; }
+    [Parameter] public EventCallback<IBrowserFile?> FileChanged { get; set; }
+    [Parameter] public List<TreeItemData<WikiPageNode>>? WikiItems { get; set; }
+    [Parameter] public IReadOnlyCollection<WikiPageNode>? SelectedPages { get; set; }
+    [Parameter] public EventCallback<IReadOnlyCollection<WikiPageNode>?> SelectedPagesChanged { get; set; }
+
+    private Task OnFileSelected(InputFileChangeEventArgs e)
+    {
+        File = e.File;
+        return FileChanged.InvokeAsync(File);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="UseDocumentTooltip" xml:space="preserve">
+    <value>Upload a document instead of selecting wiki pages</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -28,7 +28,7 @@
     <value>Copiar prompt inicial</value>
   </data>
   <data name="CopyPromptMessage" xml:space="preserve">
-    <value>Si necesita ayuda para recopilar los requisitos, copie este prompt inicial y péguelo en su LLM. Este paso es opcional.</value>
+    <value>Si necesita ayuda para recopilar los requisitos, despliegue para generar un prompt inicial e incluya opcionalmente un documento o páginas wiki del proyecto.</value>
   </data>
   <data name="CopyToast" xml:space="preserve">
     <value>Copiado al portapapeles</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -6,6 +6,7 @@
 @using DevOpsAssistant.Services.Models
 @using DevOpsAssistant.Utils
 @using Microsoft.AspNetCore.Components.Forms
+@using DevOpsAssistant.Components
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject PageStateService StateService
@@ -16,10 +17,20 @@
 
 <PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
-<MudAlert Severity="Severity.Info">
-    @L["CopyPromptMessage"]
-    <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton>
-</MudAlert>
+<MudExpansionPanels>
+    <MudExpansionPanel Text="@L["CopyPromptMessage"]">
+        <MudStack Spacing="2">
+            <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton>
+            <WikiDocumentSelector UseDocument="@_promptUseDocument"
+                                   UseDocumentChanged="@(v => _promptUseDocument = v)"
+                                   File="@_promptFile"
+                                   FileChanged="@(f => _promptFile = f)"
+                                   WikiItems="@_wikiItems"
+                                   SelectedPages="@_promptSelectedPages"
+                                   SelectedPagesChanged="@(p => _promptSelectedPages = p)" />
+        </MudStack>
+    </MudExpansionPanel>
+</MudExpansionPanels>
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
@@ -28,21 +39,13 @@
 <MudStepper @ref="_stepper" ActionContent="@(_ => (RenderFragment)(builder => { }) )">
     <MudStep Title="Select Requirements">
         <MudStack Spacing="2">
-            <MudTooltip Text='@L["UseDocumentTooltip"]'>
-                <MudSwitch T="bool" @bind-Value="_useDocument" Color="Color.Primary" Label="Use Document" />
-            </MudTooltip>
-            @if (_useDocument)
-            {
-                <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx,.md" />
-            }
-            else if (_wikiItems != null)
-            {
-                <MudTreeView T="WikiPageNode" Items="@_wikiItems" SelectionMode="SelectionMode.MultiSelection" @bind-SelectedValues="_selectedPages" Class="scroll-300">
-                    <ItemTemplate>
-                        <MudTreeViewItem Items="@context.Children" Value="@context.Value" Text="@context.Text" @bind-Expanded="@context.Expanded" />
-                    </ItemTemplate>
-                </MudTreeView>
-            }
+            <WikiDocumentSelector UseDocument="@_useDocument"
+                                   UseDocumentChanged="@(v => _useDocument = v)"
+                                   File="@_file"
+                                   FileChanged="@(f => _file = f)"
+                                   WikiItems="@_wikiItems"
+                                   SelectedPages="@_selectedPages"
+                                   SelectedPagesChanged="@(p => _selectedPages = p)" />
             <MudTooltip Text='@L["StoriesOnlyTooltip"]'>
                 <MudSwitch T="bool" @bind-Value="_storiesOnly" Color="Color.Primary" Label="Stories Only" />
             </MudTooltip>
@@ -173,6 +176,9 @@
     private IReadOnlyCollection<WikiPageNode>? _selectedPages;
     private IBrowserFile? _file;
     private bool _useDocument;
+    private IReadOnlyCollection<WikiPageNode>? _promptSelectedPages;
+    private IBrowserFile? _promptFile;
+    private bool _promptUseDocument;
     private string _wikiId = string.Empty;
     private string _prompt = string.Empty;
     private List<string>? _promptParts;
@@ -349,7 +355,8 @@ Define what success looks like — business or system-level outcomes.
 
     private async Task CopyInitialPrompt()
     {
-        await JS.InvokeVoidAsync("copyText", InitialPrompt);
+        var prompt = await BuildInitialPrompt();
+        await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
 
@@ -381,6 +388,41 @@ Define what success looks like — business or system-level outcomes.
     {
         _file = e.File;
         return Task.CompletedTask;
+    }
+
+    private async Task<string> BuildInitialPrompt()
+    {
+        var sb = new System.Text.StringBuilder(InitialPrompt);
+        List<(string Name, string Text)> pages = [];
+        if (_promptUseDocument)
+        {
+            if (_promptFile != null)
+            {
+                using var stream = _promptFile.OpenReadStream(MaxFileSize);
+                var text = DocumentHelpers.ExtractText(stream, _promptFile.Name);
+                pages.Add((_promptFile.Name, text));
+            }
+        }
+        else if (_promptSelectedPages != null)
+        {
+            foreach (var p in _promptSelectedPages)
+            {
+                var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
+                pages.Add((p.Name, text));
+            }
+        }
+        if (pages.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Document:");
+            foreach (var page in pages)
+            {
+                sb.AppendLine($"## {page.Name}");
+                sb.AppendLine(page.Text);
+                sb.AppendLine();
+            }
+        }
+        return sb.ToString();
     }
 
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -28,7 +28,7 @@
     <value>Copy starter prompt</value>
   </data>
   <data name="CopyPromptMessage" xml:space="preserve">
-    <value>If you need help capturing requirements, paste this starter prompt into your LLM. This step is optional.</value>
+    <value>If you need help capturing requirements, expand to generate a starter prompt and optionally include a specification document or wiki pages.</value>
   </data>
   <data name="CopyToast" xml:space="preserve">
     <value>Copied to clipboard</value>


### PR DESCRIPTION
## Summary
- introduce `WikiDocumentSelector` reusable component for wiki page or document selection
- replace the old alert on the requirements planner page with an expansion panel
- include selected docs or pages when copying the starter prompt
- update localization

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_685eb24ad1448328b06008afb142c8d0