### PR TITLE
Fix responsive chart height

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -188,7 +188,7 @@ body {
 /* Responsive chart container */
 .responsive-chart {
     width: 100%;
-    height: auto !important;
+    height: auto;
     aspect-ratio: 2 / 1;
     padding-bottom: 3rem;
 }


### PR DESCRIPTION
## Summary
- ensure CSS doesn't override chart height
- revert chart height parameter to int and use numeric expanded height

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj --verify-no-changes`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal` *(fails: Build FAILED)*

------
https://chatgpt.com/codex/tasks/task_e_685ed8595680832886aa9cc66bed8945