### PR TITLE
Fix burnup controls disappearing

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -140,7 +140,7 @@ else if (_periods.Any())
             </MudPaper>
         </MudItem>
         <MudItem xs="12" md="@(_burnExpanded ? 12 : 6)">
-            <MudPaper Class="pa-6">
+            <MudPaper Class="pa-6" Style="overflow:visible">
                 <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
                     <MudText Typo="Typo.h6">@L["BurnUp"]</MudText>
                     <MudIconButton Icon="@(_burnExpanded ? Icons.Material.Filled.CloseFullscreen : Icons.Material.Filled.OpenInFull)"


### PR DESCRIPTION
## Summary
- ensure burnup projection controls stay visible when expanding chart

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6861964ee2d08328bf1bc1b469c58943