### PR TITLE
Fix burn up update and trendline

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -149,6 +149,28 @@ public class MetricsPageTests : ComponentTestBase
     }
 
     [Fact]
+    public void ComputeBurnUp_Trendline_Starts_At_Zero_And_Ends_With_Total()
+    {
+        SetupServices();
+
+        var metrics = new TestMetrics();
+        var type = typeof(Metrics);
+        var compute = type.GetMethod("ComputeBurnUp", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var seriesField = type.GetField("_burnApex", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        List<StoryMetric> items = [
+            new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
+            new() { CreatedDate = DateTime.Today.AddDays(-1), ActivatedDate = DateTime.Today, ClosedDate = DateTime.Today, StoryPoints = 2 }
+        ];
+        compute.Invoke(metrics, new object?[] { items });
+
+        var series = (List<ApexSeries>)seriesField.GetValue(metrics)!;
+        var trend = series.First(s => s.Name == "Trend").Points;
+
+        Assert.Equal(0, trend[0].Value);
+        Assert.Equal(5, trend[1].Value);
+    }
+
+    [Fact]
     public void ComputeFlow_DoesNot_Aggregate_Labels()
     {
         SetupServices();

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -157,9 +157,9 @@ else if (_periods.Any())
                     <MudGrid Spacing="2">
                         <MudItem xs="12" md="6">
                             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
-                                <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points"/>
-                                <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %"/>
-                                <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %"/>
+                                <MudNumericField T="double?" @bind-Value="_additionalPoints" Label="Additional Points" Immediate="true" />
+                                <MudNumericField T="double?" @bind-Value="_efficiency" Label="Efficiency %" Immediate="true" />
+                                <MudNumericField T="double?" @bind-Value="_errorRange" Label="Error %" Immediate="true" />
                                 <MudButton Variant="Variant.Filled" Color="Mud.Color.Primary" OnClick="UpdateBurnUp">
                                     Update
                                 </MudButton>
@@ -547,22 +547,13 @@ else if (_periods.Any())
             target.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(finalTarget, 2) });
         }
 
-        // Linear regression for trend line
-        double sumX = daysActual * (daysActual - 1) / 2.0;
-        double sumX2 = (daysActual - 1) * daysActual * (2 * daysActual - 1) / 6.0;
-        double sumY = doneActual.Sum();
-        double sumXY = 0;
-        for (int i = 0; i < daysActual; i++)
-        {
-            sumXY += i * doneActual[i];
-        }
-        double slope = (daysActual * sumXY - sumX * sumY) / (daysActual * sumX2 - sumX * sumX);
-        double intercept = (sumY - slope * sumX) / daysActual;
+        // Straight trend line from 0 to final completion
+        double slope = daysActual > 1 ? sum / (daysActual - 1) : 0;
         for (int i = 0; i < projLen; i++)
         {
             if (i < daysActual)
             {
-                var val = intercept + slope * i;
+                var val = slope * i;
                 trend.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(val, 2) });
             }
             else


### PR DESCRIPTION
## Summary
- refresh burn up chart immediately when projection fields change
- draw burn up trendline from zero to final completed point
- test trendline start and end

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore --verbosity diag`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68627dba66d48328888947ffa512aa34