### PR TITLE
Add bulk tag page

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/BulkTagPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/BulkTagPageTests.cs
@@ -1,0 +1,27 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+using DevOpsAssistant.Services;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class BulkTagPageTests : ComponentTestBase
+{
+    [Fact]
+    public async Task BulkTag_Renders()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+
+        var exception = Record.Exception(() => RenderWithProvider<TestPage>());
+        Assert.Null(exception);
+    }
+
+    private class TestPage : BulkTag
+    {
+        protected override Task OnInitializedAsync()
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -26,6 +26,10 @@
     <MudText Typo="Typo.body2">@((MarkupString)L["ReleaseNotes"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
+    <MudText Typo="Typo.h6">Bulk Tag</MudText>
+    <MudText Typo="Typo.body2">@((MarkupString)L["BulkTag"].Value)</MudText>
+</MudPaper>
+<MudPaper Class="pa-6">
     <MudText Typo="Typo.h6">Metrics</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Metrics"].Value)</MudText>
 </MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -21,6 +21,9 @@
   <data name="Validation" xml:space="preserve">
     <value>Validación de elementos de trabajo</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>Etiquetado masivo</value>
+  </data>
   <data name="WorkItemQuality" xml:space="preserve">
     <value>Calidad de elemento de trabajo</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -45,6 +45,7 @@
                 <MudNavGroup Title="@L["WorkItems"]" Expanded="true">
                         <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
                         <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
+                        <MudNavLink Href="@($"projects/{_selectedProject}/bulk-tag")" Icon="@Icons.Material.Filled.Label" Disabled="@IsProjectInvalid">@L["BulkTag"]</MudNavLink>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
                         <MudNavLink Href="@($"projects/{_selectedProject}/work-item-quality")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["WorkItemQuality"]</MudNavLink>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -21,6 +21,9 @@
   <data name="Validation" xml:space="preserve">
     <value>Work Item Validation</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>Bulk Tag</value>
+  </data>
   <data name="WorkItemQuality" xml:space="preserve">
     <value>Work Item Quality</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeleteTooltip" xml:space="preserve">
+    <value>Quitar elemento</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -1,0 +1,124 @@
+@page "/projects/{ProjectName}/bulk-tag"
+@using DevOpsAssistant.Services.Models
+@inject DevOpsApiService ApiService
+@inject PageStateService StateService
+@inject ISnackbar Snackbar
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<BulkTag> L
+@inherits ProjectComponentBase
+
+<PageTitle>DevOpsAssistant - Bulk Tag</PageTitle>
+
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error">@_error</MudAlert>
+}
+
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Class="mb-4">
+    <MudSelect T="string" MultiSelection="true" SelectedValues="_selectedTags" SelectedValuesChanged="@(v => _selectedTags = v.ToHashSet())" Label="Tags">
+        @foreach (var t in _tags)
+        {
+            <MudSelectItem Value="@t">@t</MudSelectItem>
+        }
+    </MudSelect>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ApplyTags" Disabled="!_selectedItems.Any() || !_selectedTags.Any() || _loading">Add Tags</MudButton>
+</MudStack>
+
+@if (_loading)
+{
+    <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+}
+
+@if (_selectedItems.Any())
+{
+    <MudTable Items="_selectedItems" Dense="true">
+        <HeaderContent>
+            <MudTh>ID</MudTh>
+            <MudTh>Title</MudTh>
+            <MudTh></MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="ID">@context.Id</MudTd>
+            <MudTd DataLabel="Title">@context.Title</MudTd>
+            <MudTd>
+                <MudTooltip Text='@L["DeleteTooltip"]'>
+                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveItem(context)" />
+                </MudTooltip>
+            </MudTd>
+        </RowTemplate>
+    </MudTable>
+}
+
+@code {
+    [Parameter] public string ProjectName { get; set; } = string.Empty;
+
+    private readonly HashSet<WorkItemInfo> _selectedItems = [];
+    private HashSet<string> _selectedTags = new();
+    private string[] _tags = [];
+    private bool _loading;
+    private string? _error;
+    private bool _filtersExpanded = true;
+    private const string StateKey = "bulk-tag";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ConfigService.LoadAsync();
+        if (!string.IsNullOrWhiteSpace(ProjectName) && ConfigService.CurrentProject.Name != ProjectName)
+        {
+            await ConfigService.SelectProjectAsync(ProjectName);
+        }
+        try
+        {
+            _tags = (await ApiService.GetTagsAsync()).ToArray();
+            await StateService.LoadAsync<object>(StateKey);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+    }
+
+    private Task OnWorkItemsSelected(IReadOnlyCollection<WorkItemInfo> items)
+    {
+        _selectedItems.Clear();
+        foreach (var i in items)
+            _selectedItems.Add(i);
+        return Task.CompletedTask;
+    }
+
+    private void RemoveItem(WorkItemInfo item)
+    {
+        _selectedItems.Remove(item);
+    }
+
+    private async Task ApplyTags()
+    {
+        if (_selectedItems.Count == 0 || _selectedTags.Count == 0) return;
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            foreach (var item in _selectedItems)
+                foreach (var tag in _selectedTags)
+                    await ApiService.AddTagAsync(item.Id, tag);
+            Snackbar.Add("Tags added", Severity.Success);
+            await StateService.SaveAsync(StateKey, new object());
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DeleteTooltip" xml:space="preserve">
+    <value>Remove item</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -33,6 +33,9 @@
   <data name="ReleaseNotes" xml:space="preserve">
     <value>&lt;p&gt;Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.&lt;/p&gt;&lt;p&gt;Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.&lt;/p&gt;</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>&lt;p&gt;Elija varias historias, seleccione una o más etiquetas y aplíquelas de una vez.&lt;/p&gt;</value>
+  </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Muestre gráficas de rendimiento, tiempo de entrega, tiempo de ciclo, velocidad, burn up y flujo para el backlog elegido.&lt;/p&gt;&lt;p&gt;El rendimiento cuenta los elementos cerrados en cada periodo. El tiempo de entrega es la diferencia entre la Fecha de creación y la Fecha de cierre. El tiempo de ciclo se calcula desde la Fecha de activación hasta el cierre. La velocidad suma los Puntos de Historia o la Estimación Original de las historias completadas. La gráfica burn up proyecta la finalización usando los puntos adicionales, la eficiencia y el rango de error, mientras que el flujo acumulado muestra backlog, trabajo en progreso y tareas terminadas día a día.&lt;/p&gt;&lt;p&gt;Utilice las gráficas para detectar tendencias y planificar iteraciones futuras.&lt;/p&gt;</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -33,6 +33,9 @@
   <data name="ReleaseNotes" xml:space="preserve">
     <value>&lt;p&gt;Select stories and build a prompt that summarizes them for release notes.&lt;/p&gt;&lt;p&gt;Prompts can be copied or downloaded, splitting into parts with arrows to navigate.&lt;/p&gt;</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>&lt;p&gt;Choose multiple stories, pick one or more tags, and apply them all at once.&lt;/p&gt;</value>
+  </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Display throughput, lead time, cycle time, velocity, burn up and flow charts for the chosen backlog.&lt;/p&gt;&lt;p&gt;Throughput counts the work items closed in each period. Lead time is the number of days from Created Date to Closed Date. Cycle time measures Activated Date to Closed Date. Velocity sums Story Points or Original Estimate for completed stories. The burn up forecast uses additional points, efficiency and error range, while cumulative flow tracks backlog, work in progress and done items each day.&lt;/p&gt;&lt;p&gt;Use these charts to spot trends and plan future iterations.&lt;/p&gt;</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
@@ -27,6 +27,9 @@
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Notas de lanzamiento — genere un resumen para las historias completadas</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>Etiquetado masivo — agrega etiquetas a varias historias</value>
+  </data>
   <data name="Quality" xml:space="preserve">
     <value>Calidad de la historia — revise las historias para el cumplimiento de INVEST</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.razor
@@ -21,6 +21,7 @@
                 <MudListItem T="string">@L["Epics"]</MudListItem>
                 <MudListItem T="string">@L["Validation"]</MudListItem>
                 <MudListItem T="string">@L["ReleaseNotes"]</MudListItem>
+                <MudListItem T="string">@L["BulkTag"]</MudListItem>
                 <MudListItem T="string">@L["Quality"]</MudListItem>
                 <MudListItem T="string">@L["Metrics"]</MudListItem>
             </MudList>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
@@ -27,6 +27,9 @@
   <data name="ReleaseNotes" xml:space="preserve">
     <value>Release Notes — generate a summary prompt for completed stories</value>
   </data>
+  <data name="BulkTag" xml:space="preserve">
+    <value>Bulk Tag — apply existing tags to multiple stories</value>
+  </data>
   <data name="Quality" xml:space="preserve">
     <value>Story Quality — review stories for INVEST compliance</value>
   </data>


### PR DESCRIPTION
## Summary
- implement BulkTag page for tagging many work items
- localize new strings and add navigation link
- document feature in home/help pages
- test page render

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet publish src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -c Release -warnaserror`

------
https://chatgpt.com/codex/tasks/task_e_68627fd6e6688328aab5177084a506c6