### PR TITLE
Add undo option for new work items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
@@ -1,7 +1,12 @@
 using System.Reflection;
 using Bunit;
+using System.Net;
+using System.Collections.Generic;
 using DevOpsAssistant.Pages;
 using DevOpsAssistant.Tests.Utils;
+using DevOpsAssistant.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Localization;
 
 namespace DevOpsAssistant.Tests.Pages;
 
@@ -56,6 +61,39 @@ public class RequirementsPlannerPageTests : ComponentTestBase
         var epics = (System.Collections.ICollection?)plan!.GetType().GetProperty("Epics")!.GetValue(plan);
         Assert.Equal(1, epics?.Count);
     }
+
+    [Fact]
+    public async Task DeleteCreatedItems_Removes_All_In_Reverse_Order()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        var deleted = new List<int>();
+        var handler = new FakeHttpMessageHandler(req =>
+        {
+            var idPart = req.RequestUri!.Segments.Last();
+            deleted.Add(int.Parse(idPart.Split('?')[0]));
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{}") };
+        });
+        var client = new HttpClient(handler);
+        Services.AddSingleton(new DeploymentConfigService(new HttpClient()));
+        Services.AddSingleton(sp => new DevOpsApiService(
+            client,
+            config,
+            sp.GetRequiredService<DeploymentConfigService>(),
+            sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
+
+        var cut = RenderWithProvider<TestPage>();
+        var field = typeof(RequirementsPlanner).GetField("_createdItems", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var list = new List<int> { 1, 2, 3 };
+        field.SetValue(cut.Instance, list);
+
+        var method = typeof(RequirementsPlanner).GetMethod("DeleteCreatedItems", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, null)!);
+
+        Assert.Empty(list);
+        Assert.Equal(new[] { 3, 2, 1 }, deleted);
+    }
+
 
     private class TestPage : RequirementsPlanner
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -39,4 +39,13 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copiado al portapapeles</value>
   </data>
+  <data name="Undo" xml:space="preserve">
+    <value>Deshacer</value>
+  </data>
+  <data name="UndoWarning" xml:space="preserve">
+    <value>Esto eliminará los elementos creados recientemente. ¿Continuar?</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -14,6 +14,7 @@
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<RequirementsPlanner> L
+@inject IDialogService DialogService
 
 <PageTitle>DevOpsAssistant - Requirement Planner</PageTitle>
 
@@ -163,6 +164,7 @@
                     }
                 </MudSelect>
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">Create Work Items</MudButton>
+                <MudButton Variant="Variant.Outlined" Color="Color.Error" Disabled="_loading || _createdItems.Count == 0" OnClick="UndoCreatedItems">@L["Undo"]</MudButton>
             </MudStack>
         }
     </MudStep>
@@ -197,6 +199,7 @@
     private bool _previewHtml;
     private WorkItemInfo? _feature;
     private Plan? _plan;
+    private readonly List<int> _createdItems = new();
     private const string StateKey = "requirements-planner";
     private const long MaxFileSize = 10 * 1024 * 1024;
 
@@ -348,6 +351,38 @@ Define what success looks like — business or system-level outcomes.
         }
     }
 
+    private async Task UndoCreatedItems()
+    {
+        if (_createdItems.Count == 0) return;
+        var parameters = new DialogParameters { ["Message"] = L["UndoWarning"].Value };
+        var dialog = await DialogService.ShowAsync<ConfirmDialog>(L["Confirm"], parameters);
+        var result = await dialog.Result;
+        if (result?.Canceled != false) return;
+
+        _loading = true;
+        StateHasChanged();
+        try
+        {
+            await DeleteCreatedItems();
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+    }
+
+    private async Task DeleteCreatedItems()
+    {
+        for (var i = _createdItems.Count - 1; i >= 0; i--)
+            await ApiService.DeleteWorkItemAsync(_createdItems[i]);
+        _createdItems.Clear();
+    }
+
     private async Task CopyPrompt()
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
@@ -495,6 +530,7 @@ Define what success looks like — business or system-level outcomes.
                         story.AcceptanceCriteria,
                         tags
                     );
+                    _createdItems.Add(story.Id);
                 }
             }
             else
@@ -502,22 +538,25 @@ Define what success looks like — business or system-level outcomes.
                 foreach (var epic in _plan.Epics)
                 {
                     epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog, null, null, ["AI Generated"]);
+                    _createdItems.Add(epic.Id);
                     foreach (var feature in epic.Features)
                     {
                         feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id, null, ["AI Generated"]);
+                        _createdItems.Add(feature.Id);
                         foreach (var story in feature.Stories)
-                            {
-                                var tags2 = story.Tags.Concat(["AI Generated"]).ToArray();
-                                story.Id = await ApiService.CreateWorkItemAsync(
-                                    "User Story",
-                                    story.Title,
-                                    story.Description,
-                                    _backlog,
-                                    feature.Id,
-                                    story.AcceptanceCriteria,
-                                    tags2
-                                );
-                            }
+                        {
+                            var tags2 = story.Tags.Concat(["AI Generated"]).ToArray();
+                            story.Id = await ApiService.CreateWorkItemAsync(
+                                "User Story",
+                                story.Title,
+                                story.Description,
+                                _backlog,
+                                feature.Id,
+                                story.AcceptanceCriteria,
+                                tags2
+                            );
+                            _createdItems.Add(story.Id);
+                        }
                     }
                 }
             }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -39,4 +39,13 @@
   <data name="CopyToast" xml:space="preserve">
     <value>Copied to clipboard</value>
   </data>
+  <data name="Undo" xml:space="preserve">
+    <value>Undo</value>
+  </data>
+  <data name="UndoWarning" xml:space="preserve">
+    <value>This will delete the newly created work items. Continue?</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -616,6 +616,17 @@ public class DevOpsApiService
         await SendAsync(request);
     }
 
+    public async Task DeleteWorkItemAsync(int id)
+    {
+        var config = GetValidatedConfig();
+        ApplyAuthentication(config);
+
+        var baseUri = BuildBaseUri(config);
+        var request = new HttpRequestMessage(HttpMethod.Delete,
+            $"{baseUri}/workitems/{id}?api-version={ApiVersion}");
+        await SendAsync(request);
+    }
+
     public Task<List<WorkItemInfo>> SearchUserStoriesAsync(string term)
     {
         var wiql = BuildStorySearchWiql(term);


### PR DESCRIPTION
## Summary
- allow deleting work items via `DeleteWorkItemAsync`
- support undoing created work items in the requirements planner
- delete children before parents so epics and features can be removed
- localize undo strings in English and Spanish
- test undo deletion order

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68627e40e2648328a9ec2358f2d3bdd5