### PR TITLE
Remove duplicate work item table

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
@@ -18,9 +18,6 @@
   <data name="AutocompletePlaceholder" xml:space="preserve">
     <value>Empieza a escribir para ver resultados</value>
   </data>
-  <data name="DeleteTooltip" xml:space="preserve">
-    <value>Quitar elemento</value>
-  </data>
   <data name="PrevPartTooltip" xml:space="preserve">
     <value>Parte anterior</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -23,30 +23,6 @@
 
 <WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading || !_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
-
-@if (_selectedItems.Any())
-{
-    <MudTable Items="_selectedItems" Dense="true">
-        <HeaderContent>
-            <MudTh>ID</MudTh>
-            <MudTh>Title</MudTh>
-            <MudTh></MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="ID">@context.Id</MudTd>
-            <MudTd DataLabel="Title">@context.Title</MudTd>
-            <MudTd>
-                <MudTooltip Text='@L["DeleteTooltip"]'>
-                    <MudIconButton Icon="@Icons.Material.Filled.Delete"
-                                   Color="Color.Error"
-                                   Size="Size.Small"
-                                   OnClick="() => RemoveSelected(context)" />
-                </MudTooltip>
-            </MudTd>
-        </RowTemplate>
-    </MudTable>
-}
-
 @if (_loading)
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
@@ -170,11 +146,6 @@ else if (_promptParts != null)
     }
 
 
-    private void RemoveSelected(WorkItemInfo item)
-    {
-        _selectedItems.Remove(item);
-        StateHasChanged();
-    }
 
     private Task OnWorkItemsSelected(IReadOnlyCollection<WorkItemInfo> items)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
@@ -18,9 +18,6 @@
   <data name="AutocompletePlaceholder" xml:space="preserve">
     <value>Start typing to see results</value>
   </data>
-  <data name="DeleteTooltip" xml:space="preserve">
-    <value>Remove item</value>
-  </data>
   <data name="PrevPartTooltip" xml:space="preserve">
     <value>Previous part</value>
   </data>


### PR DESCRIPTION
## Summary
- remove selected items table from Release Notes page
- drop unused DeleteTooltip strings

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862886d126883288d15fb9561eafe23