### PR TITLE
Persist work item selector state

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
@@ -42,7 +42,8 @@ public class WorkItemSelectorTests : ComponentTestBase
             sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var cut = RenderWithProvider<WorkItemSelector>();
-        cut.SetParametersAndRender(parameters => parameters.Add(c => c.UseIteration, true));
+        cut.SetParametersAndRender(parameters => parameters.Add(c => c.UseIteration, true)
+                                                 .Add(c => c.StateKey, "test"));
         cut.WaitForAssertion(() => Assert.Contains("Iteration", cut.Markup));
     }
 
@@ -79,6 +80,7 @@ public class WorkItemSelectorTests : ComponentTestBase
             sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var cut = RenderWithProvider<WorkItemSelector>();
+        cut.SetParametersAndRender(p => p.Add(c => c.StateKey, "test"));
         var loadButton = cut.FindAll("button").First(b => b.TextContent.Contains("Load"));
         loadButton.Click();
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItemSelector.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItemSelector.razor
@@ -1,8 +1,10 @@
 @using DevOpsAssistant.Services.Models
+@using DevOpsAssistant.Services
 @using MudBlazor
 @using Microsoft.Extensions.Localization
 @inject DevOpsApiService ApiService
 @inject IStringLocalizer<WorkItemSelector> L
+@inject PageStateService StateService
 
 <MudExpansionPanels>
     <MudExpansionPanel Text="Work Item Selection" Expanded="@Expanded" ExpandedChanged="OnExpandedChanged">
@@ -111,6 +113,7 @@
     [Parameter] public EventCallback<bool> ExpandedChanged { get; set; }
     [Parameter] public EventCallback<IReadOnlyCollection<WorkItemInfo>> SelectedChanged { get; set; }
     [Parameter] public bool UseIteration { get; set; }
+    [Parameter] public string? StateKey { get; set; }
 
     private string _path = string.Empty;
     private string _treePath = string.Empty;
@@ -141,6 +144,22 @@
         SelectedTypes = _types.ToHashSet();
         if (UseIteration)
             _iterations = await ApiService.GetIterationsAsync();
+        if (!string.IsNullOrWhiteSpace(StateKey))
+        {
+            var state = await StateService.LoadAsync<SelectorState>(StateKey);
+            if (state != null)
+            {
+                if (!string.IsNullOrWhiteSpace(state.Path))
+                    _path = state.Path;
+                if (!string.IsNullOrWhiteSpace(state.TreePath))
+                    _treePath = state.TreePath;
+                if (state.States != null)
+                    SelectedStates = state.States.ToHashSet();
+                if (state.Types != null)
+                    SelectedTypes = state.Types.ToHashSet();
+                _iteration = state.Iteration;
+            }
+        }
     }
 
     private async Task<IEnumerable<WorkItemInfo>> SearchItems(string value, CancellationToken _)
@@ -186,12 +205,14 @@
         foreach (var i in items)
             _listSelected.Add(i);
         UpdateSelected();
+        await SaveState();
     }
 
     private async Task LoadTree()
     {
         var roots = await ApiService.GetWorkItemHierarchyAsync(_treePath);
         _treeItems = roots.Select(BuildTreeItem).ToList();
+        await SaveState();
     }
 
     private static TreeItemData<WorkItemNode> BuildTreeItem(WorkItemNode node)
@@ -222,6 +243,7 @@
             foreach (var n in _selectedNodes)
                 set.Add(n.Info);
         await SelectedChanged.InvokeAsync(set.ToList());
+        await SaveState();
     }
 
     private Task OnExpandedChanged(bool value)
@@ -230,4 +252,27 @@
         return ExpandedChanged.InvokeAsync(value);
     }
 
+    private async Task SaveState()
+    {
+        if (string.IsNullOrWhiteSpace(StateKey))
+            return;
+        var state = new SelectorState
+        {
+            Path = _path,
+            TreePath = _treePath,
+            States = SelectedStates.ToArray(),
+            Types = SelectedTypes.ToArray(),
+            Iteration = _iteration
+        };
+        await StateService.SaveAsync(StateKey, state);
+    }
+
+    private class SelectorState
+    {
+        public string Path { get; set; } = string.Empty;
+        public string TreePath { get; set; } = string.Empty;
+        public string[]? States { get; set; }
+        public string[]? Types { get; set; }
+        public string? Iteration { get; set; }
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -1,7 +1,6 @@
 @page "/projects/{ProjectName}/bulk-tag"
 @using DevOpsAssistant.Services.Models
 @inject DevOpsApiService ApiService
-@inject PageStateService StateService
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<BulkTag> L
@@ -14,7 +13,7 @@
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Class="mb-4">
     <MudSelect T="string" MultiSelection="true" SelectedValues="_selectedTags" SelectedValuesChanged="@(v => _selectedTags = v.ToHashSet())" Label="Tags">
         @foreach (var t in _tags)
@@ -71,7 +70,6 @@
         try
         {
             _tags = (await ApiService.GetTagsAsync()).ToArray();
-            await StateService.LoadAsync<object>(StateKey);
             _error = null;
         }
         catch (Exception ex)
@@ -104,7 +102,6 @@
                 foreach (var tag in _selectedTags)
                     await ApiService.AddTagAsync(item.Id, tag);
             Snackbar.Add("Tags added", Severity.Success);
-            await StateService.SaveAsync(StateKey, new object());
             _error = null;
         }
         catch (Exception ex)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -8,7 +8,6 @@
 @using MudBlazor
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
-@inject PageStateService StateService
 @inherits ProjectComponentBase
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
@@ -21,7 +20,7 @@
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading || !_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
 
 @if (_selectedItems.Any())
@@ -106,7 +105,6 @@ else if (_promptParts != null)
         {
             await ConfigService.SelectProjectAsync(ProjectName);
         }
-        await StateService.LoadAsync<object>(StateKey);
     }
 
     private async Task Generate()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Validation.razor
@@ -40,7 +40,7 @@
     </MudCollapse>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
 <MudStack Row="true" Spacing="2" Class="mb-4">
     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Load" Disabled="!_hasRules || !_selectedItems.Any()">Check</MudButton>
     <MudButton Variant="Variant.Outlined" OnClick="Reset">Reset</MudButton>
@@ -115,7 +115,6 @@ else if (_results != null)
         }
         try
         {
-            var state = await StateService.LoadAsync<PageState>(StateKey);
             _error = null;
         }
         catch (Exception ex)
@@ -136,7 +135,6 @@ else if (_results != null)
         {
             var details = await ApiService.GetWorkItemDetailsAsync(_selectedItems.Select(i => i.Id));
             _results = Validate(details);
-            await StateService.SaveAsync(StateKey, new PageState());
             _error = null;
         }
         catch (Exception ex)
@@ -286,12 +284,6 @@ else if (_results != null)
         public bool NeedsAttention { get; set; }
     }
 
-    private class PageState
-    {
-        public string Path { get; set; } = string.Empty;
-        public string[]? States { get; set; }
-        public string[]? Types { get; set; }
-    }
 
     protected override Task OnProjectChangedAsync()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -6,7 +6,6 @@
 @using DevOpsAssistant.Utils
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
-@inject PageStateService StateService
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<WorkItemQuality> L
@@ -19,7 +18,7 @@
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
 
 @if (_loading)
@@ -67,7 +66,6 @@ else if (_promptParts != null)
         }
         try
         {
-            await StateService.LoadAsync<PageState>(StateKey);
             _error = null;
         }
         catch (Exception ex)
@@ -87,7 +85,6 @@ else if (_promptParts != null)
             _prompt = BuildPrompt(details, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
-            await StateService.SaveAsync(StateKey, new PageState());
             _error = null;
             await CopyPrompt();
         }
@@ -272,12 +269,6 @@ else if (_promptParts != null)
         return sb.ToString();
     }
 
-    private class PageState
-    {
-        public string Path { get; set; } = string.Empty;
-        public string[]? States { get; set; }
-        public string? Iteration { get; set; }
-    }
 
     protected override Task OnProjectChangedAsync()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -66,7 +66,7 @@ public class DevOpsConfigService
         if (legacy != null)
         {
             var project = new DevOpsProject { Name = "default", Config = Normalize(legacy) };
-            Projects = [ project ];
+            Projects = [project];
             CurrentProject = project;
             await SaveProjectsAsync();
             await _localStorage.RemoveItemAsync(LegacyStorageKey);

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/PromptHelpers.cs
@@ -7,12 +7,12 @@ public static class PromptHelpers
     public static IReadOnlyList<string> SplitPrompt(string text, int limit)
     {
         if (string.IsNullOrWhiteSpace(text))
-            return [ text ];
+            return [text];
 
         text = text.Replace("\r\n", "\n").Replace('\r', '\n');
 
         if (limit <= 0 || AdjustedLength(text) <= limit)
-            return [ text.Replace("\n", NewLine) ];
+            return [text.Replace("\n", NewLine)];
 
         var adjustedLimit = limit;
         var parts = SplitInternal(text, adjustedLimit);


### PR DESCRIPTION
## Summary
- persist WorkItemSelector settings in local storage via PageStateService
- add StateKey parameter to WorkItemSelector
- connect pages to unique state keys
- adjust tests for new parameter

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6862864522148328b3ee2b007b3b21a5