### PR TITLE
Improve bulk tagging UX

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
@@ -15,4 +15,13 @@
   <data name="DeleteTooltip" xml:space="preserve">
     <value>Quitar elemento</value>
   </data>
+  <data name="AddTag" xml:space="preserve">
+    <value>Añadir</value>
+  </data>
+  <data name="AddTags" xml:space="preserve">
+    <value>Agregar etiquetas</value>
+  </data>
+  <data name="AddedMessage" xml:space="preserve">
+    <value>Etiquetas agregadas</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -16,14 +16,19 @@
 
 <WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
 <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Class="mb-4">
-    <MudSelect T="string" MultiSelection="true" SelectedValues="_selectedTags" SelectedValuesChanged="@(v => _selectedTags = v.ToHashSet())" Label="Tags">
-        @foreach (var t in _tags)
-        {
-            <MudSelectItem Value="@t">@t</MudSelectItem>
-        }
-    </MudSelect>
-    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ApplyTags" Disabled="!_selectedItems.Any() || !_selectedTags.Any() || _loading">Add Tags</MudButton>
+    <MudAutocomplete T="string" @bind-Value="_tag" Label="@L["TagLabel"]" SearchFunc="SearchTags" Class="min-w-200" />
+    <MudButton Variant="Variant.Text" OnClick="AddTag" Disabled="string.IsNullOrWhiteSpace(_tag)">@L["AddTag"]</MudButton>
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ApplyTags" Disabled="!_selectedItems.Any() || !_selectedTags.Any() || _loading">@L["AddTags"]</MudButton>
 </MudStack>
+@if (_selectedTags.Any())
+{
+    <MudChipSet T="string" Class="mb-2">
+        @foreach (var t in _selectedTags)
+        {
+            <MudChip Value="@t" OnClose="(MudChip<string> _) => RemoveTag(t)" Closeable="true">@t</MudChip>
+        }
+    </MudChipSet>
+}
 
 @if (_loading)
 {
@@ -56,6 +61,7 @@
     private readonly HashSet<WorkItemInfo> _selectedItems = [];
     private HashSet<string> _selectedTags = new();
     private string[] _tags = [];
+    private string _tag = string.Empty;
     private bool _loading;
     private string? _error;
     private bool _filtersExpanded = true;
@@ -93,6 +99,29 @@
         _selectedItems.Remove(item);
     }
 
+    private Task<IEnumerable<string>> SearchTags(string value, CancellationToken _)
+    {
+        IEnumerable<string> result = _tags;
+        if (!string.IsNullOrWhiteSpace(value))
+            result = result.Where(t => t.Contains(value, StringComparison.OrdinalIgnoreCase));
+        result = result.Where(t => !_selectedTags.Contains(t));
+        return Task.FromResult(result);
+    }
+
+    private void AddTag()
+    {
+        if (string.IsNullOrWhiteSpace(_tag))
+            return;
+        _selectedTags.Add(_tag);
+        _tag = string.Empty;
+    }
+
+    private void RemoveTag(string tag)
+    {
+        _selectedTags.Remove(tag);
+    }
+
+
     private async Task ApplyTags()
     {
         if (_selectedItems.Count == 0 || _selectedTags.Count == 0) return;
@@ -103,7 +132,7 @@
             foreach (var item in _selectedItems)
                 foreach (var tag in _selectedTags)
                     await ApiService.AddTagAsync(item.Id, tag);
-            Snackbar.Add("Tags added", Severity.Success);
+            Snackbar.Add(L["AddedMessage"].Value, Severity.Success);
             await StateService.SaveAsync(StateKey, new object());
             _error = null;
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
@@ -15,4 +15,13 @@
   <data name="DeleteTooltip" xml:space="preserve">
     <value>Remove item</value>
   </data>
+  <data name="AddTag" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="AddTags" xml:space="preserve">
+    <value>Add Tags</value>
+  </data>
+  <data name="AddedMessage" xml:space="preserve">
+    <value>Tags added</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add autocomplete and chip set for selecting tags
- localize bulk tag messages

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686287d02ecc8328975166445e6c2c05