### PR TITLE
Fix MudChip analyzer error

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -24,7 +24,7 @@
     <MudChipSet T="string" Class="mb-2">
         @foreach (var t in _selectedTags)
         {
-            <MudChip Value="@t" OnClose="(MudChip<string> _) => RemoveTag(t)" Closeable="true">@t</MudChip>
+            <MudChip Value="@t" OnClose="(MudChip<string> _) => RemoveTag(t)">@t</MudChip>
         }
     </MudChipSet>
 }


### PR DESCRIPTION
## Summary
- remove invalid MudChip `Closeable` attribute

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant.sln -c Release -warnaserror`


------
https://chatgpt.com/codex/tasks/task_e_68628ed901bc8328a1b3c60dc5d0784e