### PR TITLE
Fix metrics query for open items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -537,6 +537,15 @@ public class DevOpsApiServiceTests
     }
 
     [Fact]
+    public void BuildMetricsWiql_Includes_Open_Items()
+    {
+        var query = InvokeBuildMetricsWiql("Area", DateTime.Today);
+
+        Assert.Contains("System.State", query);
+        Assert.Contains("<> 'Closed'", query);
+    }
+
+    [Fact]
     public void BuildStoriesWiql_Includes_States_When_Provided()
     {
         var query = InvokeBuildStoriesWiql("Area", ["New", "Active"], null);

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -880,7 +880,7 @@ public class DevOpsApiService
         areaPath = NormalizeAreaPath(areaPath);
         var start = startDate.ToString("yyyy-MM-dd");
         return
-            $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AreaPath] UNDER '{areaPath}' AND [System.WorkItemType] = 'User Story' AND [Microsoft.VSTS.Common.ClosedDate] >= '{start}' ORDER BY [Microsoft.VSTS.Common.ClosedDate]";
+            $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AreaPath] UNDER '{areaPath}' AND [System.WorkItemType] = 'User Story' AND ([Microsoft.VSTS.Common.ClosedDate] >= '{start}' OR [System.State] <> 'Closed') ORDER BY [Microsoft.VSTS.Common.ClosedDate]";
     }
 
     private static string BuildStorySearchWiql(string term)


### PR DESCRIPTION
## Summary
- include open work items when generating metrics
- validate that metrics query includes open items

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862a786aefc83288edf81294f731d87