### PR TITLE
Add prototype disclaimer to footer

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -75,6 +75,16 @@ public class MainLayoutTests : ComponentTestBase
     }
 
     [Fact]
+    public void Footer_Displays_Disclaimer()
+    {
+        SetupServices();
+
+        var cut = RenderComponent<MainLayout>();
+
+        cut.WaitForAssertion(() => Assert.Contains("This is a prototype", cut.Markup));
+    }
+
+    [Fact]
     public void Footer_Uses_Sticky_Flexbox_Css()
     {
         var cssPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory,

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -105,4 +105,7 @@
   <data name="FooterCopyright" xml:space="preserve">
     <value>© {0} TommCarrr industries</value>
   </data>
+  <data name="FooterDisclaimer" xml:space="preserve">
+    <value>Este es un prototipo. Todos los datos deben comprobarse.</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -68,12 +68,15 @@
         </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="footer-content">
-                <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
-                    @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
-                </MudText>
-                <MudText Typo="Typo.caption" Class="float-right" Inline="true">
-                    Version @VersionService.Version
-                </MudText>
+            <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
+                @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+            </MudText>
+            <MudText Typo="Typo.caption" Align="Align.Left" Inline="true">
+                @L["FooterDisclaimer"]
+            </MudText>
+            <MudText Typo="Typo.caption" Class="float-right" Inline="true">
+                Version @VersionService.Version
+            </MudText>
             </MudContainer>
         </footer>
     </MudMainContent>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -105,4 +105,7 @@
   <data name="FooterCopyright" xml:space="preserve">
     <value>© {0} TommCarrr industries</value>
   </data>
+  <data name="FooterDisclaimer" xml:space="preserve">
+    <value>This is a prototype. All data should be checked.</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.es.resx
@@ -45,4 +45,7 @@
   <data name="FooterCopyright" xml:space="preserve">
     <value>&#169; {0} TommCarrr industries</value>
   </data>
+  <data name="FooterDisclaimer" xml:space="preserve">
+    <value>Este es un prototipo. Todos los datos deben comprobarse.</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -38,12 +38,15 @@
         </div>
         <footer class="app-footer">
             <MudContainer MaxWidth="MaxWidth.Large" Class="footer-content">
-                <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
-                    @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
-                </MudText>
-                <MudText Typo="Typo.caption" Class="float-right" Inline="true">
-                    Version @VersionService.Version
-                </MudText>
+            <MudText Typo="Typo.body2" Align="Align.Left" Inline="true">
+                @string.Format(L["FooterCopyright"], System.DateTime.Now.Year)
+            </MudText>
+            <MudText Typo="Typo.caption" Align="Align.Left" Inline="true">
+                @L["FooterDisclaimer"]
+            </MudText>
+            <MudText Typo="Typo.caption" Class="float-right" Inline="true">
+                Version @VersionService.Version
+            </MudText>
             </MudContainer>
         </footer>
     </MudMainContent>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.resx
@@ -45,4 +45,7 @@
   <data name="FooterCopyright" xml:space="preserve">
     <value>&#169; {0} TommCarrr industries</value>
   </data>
+  <data name="FooterDisclaimer" xml:space="preserve">
+    <value>This is a prototype. All data should be checked.</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add localized `FooterDisclaimer` strings for English and Spanish
- display disclaimer in MainLayout and SimpleLayout footers
- test footer disclaimer text

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6862a9207d2483288dfb2c84a1675e9f