### PR TITLE
Fix Doom logo styling

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/doom.css
@@ -51,15 +51,16 @@ body.doom-theme .mud-button-filled-primary {
 }
 body.doom-theme .app-logo {
     font-family: 'Doom', sans-serif;
+    font-size: 2rem;
     background: linear-gradient(180deg,
         #375a7f 0%,
         #375a7f 30%,
         #ff851b 60%,
         #ff4136 100%);
     -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    -webkit-text-fill-color: transparent !important;
     background-clip: text;
-    color: transparent;
+    color: transparent !important;
     text-transform: uppercase;
 }
 


### PR DESCRIPTION
## Summary
- force gradient fill for Doom theme logo
- enlarge Doom theme logo

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6862b1a6310c83288c456cb4239adf22