### PR TITLE
Fix date handling for burnup chart

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -91,6 +91,7 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today.AddDays(-3), ActivatedDate = DateTime.Today.AddDays(-2), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
             new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today, StoryPoints = 2 }
         ];
+        type.GetField("_startDate", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(metrics, items.Min(i => i.ClosedDate));
         compute.Invoke(metrics, new object?[] { items });
 
         var labels = (string[])labelsField.GetValue(metrics)!;
@@ -114,6 +115,7 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today.AddDays(-3), ActivatedDate = DateTime.Today.AddDays(-2), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
             new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today, StoryPoints = 2 }
         ];
+        type.GetField("_startDate", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(metrics, items.Min(i => i.ClosedDate));
         compute.Invoke(metrics, new object?[] { items });
 
         var series = (List<ApexSeries>)seriesField.GetValue(metrics)!;
@@ -140,6 +142,7 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today.AddDays(-3), ActivatedDate = DateTime.Today.AddDays(-2), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
             new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today, StoryPoints = 2 }
         ];
+        type.GetField("_startDate", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(metrics, items.Min(i => i.ClosedDate));
         compute.Invoke(metrics, new object?[] { items });
 
         var series = (List<ApexSeries>)seriesField.GetValue(metrics)!;
@@ -170,6 +173,7 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today.AddDays(-3), ActivatedDate = DateTime.Today.AddDays(-2), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
             new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today, StoryPoints = 2 }
         ];
+        type.GetField("_startDate", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(metrics, items.Min(i => i.ClosedDate));
         compute.Invoke(metrics, new object?[] { items });
 
         var series = (List<ApexSeries>)seriesField.GetValue(metrics)!;
@@ -192,6 +196,7 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today.AddDays(-2), ActivatedDate = DateTime.Today.AddDays(-1), ClosedDate = DateTime.Today.AddDays(-1), StoryPoints = 3 },
             new() { CreatedDate = DateTime.Today.AddDays(-1), ActivatedDate = DateTime.Today, ClosedDate = DateTime.Today, StoryPoints = 2 }
         ];
+        type.GetField("_startDate", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(metrics, items.Min(i => i.ClosedDate));
         compute.Invoke(metrics, new object?[] { items });
 
         var series = (List<ApexSeries>)seriesField.GetValue(metrics)!;

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
@@ -22,7 +22,7 @@
     <value>Idioma</value>
   </data>
   <data name="English" xml:space="preserve">
-    <value>Inglés</value>
+    <value>Inglés (Reino Unido)</value>
   </data>
   <data name="Spanish" xml:space="preserve">
     <value>Español</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
@@ -12,7 +12,7 @@
             <MudTextField @bind-Value="_organization" Label='@L["Organization"]' autocomplete="off" />
             <MudTextField @bind-Value="_token" Label='@L["PatToken"]' InputType="InputType.Password" autocomplete="off" />
             <MudSelect @bind-Value="_culture" Label='@L["Language"]'>
-                <MudSelectItem Value="@("en")">@L["English"]</MudSelectItem>
+                <MudSelectItem Value="@("en-GB")">@L["English"]</MudSelectItem>
                 <MudSelectItem Value="@("es")">@L["Spanish"]</MudSelectItem>
             </MudSelect>
         </MudStack>
@@ -27,7 +27,7 @@
     [CascadingParameter] IMudDialogInstance MudDialog { get; set; } = default!;
     private string _organization = string.Empty;
     private string _token = string.Empty;
-    private string _culture = "en";
+    private string _culture = "en-GB";
     
 
     protected override async Task OnInitializedAsync()
@@ -44,7 +44,7 @@
         }
         catch
         {
-            _culture = "en";
+            _culture = "en-GB";
         }
     }
 
@@ -60,7 +60,7 @@
         }
         catch
         {
-            await JSRuntime.InvokeVoidAsync("blazorCulture.set", "en");
+            await JSRuntime.InvokeVoidAsync("blazorCulture.set", "en-GB");
         }
         Snackbar.Add(L["SavedMessage"].Value, Severity.Success);
         MudDialog.Close(DialogResult.Ok(true));

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
@@ -22,7 +22,7 @@
     <value>Language</value>
   </data>
   <data name="English" xml:space="preserve">
-    <value>English</value>
+    <value>English (UK)</value>
   </data>
   <data name="Spanish" xml:space="preserve">
     <value>Spanish</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -484,11 +484,16 @@ else if (_periods.Any())
     private void ComputeBurnUp(List<StoryMetric> items)
     {
         _burnApex.Clear();
+        if (items.Count == 0)
+        {
+            _burnLabels = [];
+            return;
+        }
         var efficiency = _useSprintEfficiency && !string.IsNullOrWhiteSpace(_tag)
             ? ComputeOverallSprintEfficiency(items)
             : _efficiency;
 
-        var start = items.Min(i => i.ClosedDate).Date;
+        var start = (_startDate ?? items.Min(i => i.ClosedDate)).Date;
         var end = _endDate ?? DateTime.Today;
         var daysActual = (end - start).Days + 1;
         double[] daily = new double[daysActual];

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -29,7 +29,7 @@ builder.Services.AddScoped<ThemeSessionService>();
 
 var host = builder.Build();
 var js = host.Services.GetRequiredService<IJSRuntime>();
-string cultureName = "en";
+string cultureName = "en-GB";
 try
 {
     var stored = await js.InvokeAsync<string>("blazorCulture.get");
@@ -38,7 +38,7 @@ try
 }
 catch
 {
-    cultureName = "en";
+    cultureName = "en-GB";
 }
 
 CultureInfo culture;
@@ -48,7 +48,7 @@ try
 }
 catch (CultureNotFoundException)
 {
-    culture = new CultureInfo("en");
+    culture = new CultureInfo("en-GB");
 }
 CultureInfo.DefaultThreadCurrentCulture = culture;
 CultureInfo.DefaultThreadCurrentUICulture = culture;

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -28,7 +28,7 @@ public class DevOpsConfigService
     public string GlobalPatToken { get; private set; } = string.Empty;
     public string GlobalOrganization { get; private set; } = string.Empty;
     public bool GlobalDarkMode { get; private set; }
-    public string GlobalCulture { get; private set; } = "en";
+    public string GlobalCulture { get; private set; } = "en-GB";
 
     public DevOpsConfig Config => CurrentProject.Config;
 
@@ -45,7 +45,7 @@ public class DevOpsConfigService
         GlobalPatToken = await _localStorage.GetItemAsync<string>(GlobalPatKey) ?? string.Empty;
         GlobalOrganization = await _localStorage.GetItemAsync<string>(GlobalOrgKey) ?? string.Empty;
         GlobalDarkMode = await _localStorage.GetItemAsync<bool?>(GlobalDarkKey) ?? false;
-        GlobalCulture = await _localStorage.GetItemAsync<string>(GlobalCultureKey) ?? "en";
+        GlobalCulture = await _localStorage.GetItemAsync<string>(GlobalCultureKey) ?? "en-GB";
         var currentName = await _localStorage.GetItemAsync<string>(CurrentKey) ?? string.Empty;
         var projects = await _localStorage.GetItemAsync<List<DevOpsProject>>(StorageKey);
         if (projects != null && projects.Count > 0)
@@ -120,7 +120,7 @@ public class DevOpsConfigService
 
     public async Task SaveGlobalCultureAsync(string culture)
     {
-        culture = string.IsNullOrWhiteSpace(culture) ? "en" : culture;
+        culture = string.IsNullOrWhiteSpace(culture) ? "en-GB" : culture;
         GlobalCulture = culture;
         await _localStorage.SetItemAsync(GlobalCultureKey, GlobalCulture);
     }
@@ -245,7 +245,7 @@ public class DevOpsConfigService
         GlobalPatToken = string.Empty;
         GlobalOrganization = string.Empty;
         GlobalDarkMode = false;
-        GlobalCulture = "en";
+        GlobalCulture = "en-GB";
         await _localStorage.RemoveItemAsync(StorageKey);
         await _localStorage.RemoveItemAsync(LegacyStorageKey);
         await _localStorage.RemoveItemAsync(GlobalPatKey);
@@ -270,7 +270,7 @@ public class DevOpsConfigService
 
     public async Task RemoveGlobalCultureAsync()
     {
-        GlobalCulture = "en";
+        GlobalCulture = "en-GB";
         await _localStorage.RemoveItemAsync(GlobalCultureKey);
     }
 


### PR DESCRIPTION
## Summary
- default to British culture and update language selector
- apply start date to burn up calculations
- keep tests in sync with new behaviour

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6862b0ccbea883289a7c40b107145f9e