### PR TITLE
Add paste text option

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.es.resx
@@ -12,7 +12,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="UseDocumentTooltip" xml:space="preserve">
-    <value>Cargue un documento en lugar de seleccionar páginas wiki</value>
+  <data name="SourceTooltip" xml:space="preserve">
+    <value>Elija de dónde proviene el contenido</value>
+  </data>
+  <data name="WikiLabel" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="DocumentLabel" xml:space="preserve">
+    <value>Cargar</value>
+  </data>
+  <data name="TextLabel" xml:space="preserve">
+    <value>Pegar</value>
+  </data>
+  <data name="TextPlaceholder" xml:space="preserve">
+    <value>Pega texto o Markdown</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
@@ -3,12 +3,20 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<WikiDocumentSelector> L
 
-<MudTooltip Text='@L["UseDocumentTooltip"]'>
-    <MudSwitch T="bool" @bind-Value="UseDocument" Color="Color.Primary" Label="Use Document" />
+<MudTooltip Text='@L["SourceTooltip"]'>
+    <MudRadioGroup T="DocumentSource" @bind-SelectedOption="Source" Row="true">
+        <MudRadio T="DocumentSource" Option="DocumentSource.Wiki">@L["WikiLabel"]</MudRadio>
+        <MudRadio T="DocumentSource" Option="DocumentSource.Document">@L["DocumentLabel"]</MudRadio>
+        <MudRadio T="DocumentSource" Option="DocumentSource.Text">@L["TextLabel"]</MudRadio>
+    </MudRadioGroup>
 </MudTooltip>
-@if (UseDocument)
+@if (Source == DocumentSource.Document)
 {
     <InputFile OnChange="OnFileSelected" accept=".pdf,.docx,.pptx,.md" />
+}
+else if (Source == DocumentSource.Text)
+{
+    <MudTextField T="string" @bind-Value="Text" Lines="4" Placeholder="@L["TextPlaceholder"]" />
 }
 else if (WikiItems != null)
 {
@@ -25,10 +33,12 @@ else if (WikiItems != null)
 }
 
 @code {
-    [Parameter] public bool UseDocument { get; set; }
-    [Parameter] public EventCallback<bool> UseDocumentChanged { get; set; }
+    [Parameter] public DocumentSource Source { get; set; }
+    [Parameter] public EventCallback<DocumentSource> SourceChanged { get; set; }
     [Parameter] public IBrowserFile? File { get; set; }
     [Parameter] public EventCallback<IBrowserFile?> FileChanged { get; set; }
+    [Parameter] public string? Text { get; set; }
+    [Parameter] public EventCallback<string?> TextChanged { get; set; }
     [Parameter] public List<TreeItemData<WikiPageNode>>? WikiItems { get; set; }
     [Parameter] public IReadOnlyCollection<WikiPageNode>? SelectedPages { get; set; }
     [Parameter] public EventCallback<IReadOnlyCollection<WikiPageNode>?> SelectedPagesChanged { get; set; }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.resx
@@ -12,7 +12,19 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="UseDocumentTooltip" xml:space="preserve">
-    <value>Upload a document instead of selecting wiki pages</value>
+  <data name="SourceTooltip" xml:space="preserve">
+    <value>Select where the document content comes from</value>
+  </data>
+  <data name="WikiLabel" xml:space="preserve">
+    <value>Wiki</value>
+  </data>
+  <data name="DocumentLabel" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="TextLabel" xml:space="preserve">
+    <value>Paste</value>
+  </data>
+  <data name="TextPlaceholder" xml:space="preserve">
+    <value>Paste text or Markdown</value>
   </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -22,10 +22,12 @@
     <MudExpansionPanel Text="@L["CopyPromptMessage"]">
         <MudStack Spacing="2">
             <MudButton Variant="Variant.Text" OnClick="CopyInitialPrompt">@L["CopyPromptLink"]</MudButton>
-            <WikiDocumentSelector UseDocument="@_promptUseDocument"
-                                   UseDocumentChanged="@(v => _promptUseDocument = v)"
+            <WikiDocumentSelector Source="@_promptSource"
+                                   SourceChanged="@(v => _promptSource = v)"
                                    File="@_promptFile"
                                    FileChanged="@(f => _promptFile = f)"
+                                   Text="@_promptText"
+                                   TextChanged="@(t => _promptText = t)"
                                    WikiItems="@_wikiItems"
                                    SelectedPages="@_promptSelectedPages"
                                    SelectedPagesChanged="@(p => _promptSelectedPages = p)" />
@@ -40,10 +42,12 @@
 <MudStepper @ref="_stepper" ActionContent="@(_ => (RenderFragment)(builder => { }) )">
     <MudStep Title="Select Requirements">
         <MudStack Spacing="2">
-            <WikiDocumentSelector UseDocument="@_useDocument"
-                                   UseDocumentChanged="@(v => _useDocument = v)"
+            <WikiDocumentSelector Source="@_source"
+                                   SourceChanged="@(v => _source = v)"
                                    File="@_file"
                                    FileChanged="@(f => _file = f)"
+                                   Text="@_text"
+                                   TextChanged="@(t => _text = t)"
                                    WikiItems="@_wikiItems"
                                    SelectedPages="@_selectedPages"
                                    SelectedPagesChanged="@(p => _selectedPages = p)" />
@@ -181,10 +185,12 @@
     private List<TreeItemData<WikiPageNode>>? _wikiItems;
     private IReadOnlyCollection<WikiPageNode>? _selectedPages;
     private IBrowserFile? _file;
-    private bool _useDocument;
+    private string _text = string.Empty;
+    private DocumentSource _source;
     private IReadOnlyCollection<WikiPageNode>? _promptSelectedPages;
     private IBrowserFile? _promptFile;
-    private bool _promptUseDocument;
+    private string _promptText = string.Empty;
+    private DocumentSource _promptSource;
     private string _wikiId = string.Empty;
     private string _prompt = string.Empty;
     private List<string>? _promptParts;
@@ -259,9 +265,12 @@ Define what success looks like — business or system-level outcomes.
 ## Notes
 - [Any background info, URLs, legacy behavior, etc.]
 ```";
-    private bool GenerateDisabled =>
-        _loading ||
-        (_useDocument ? _file == null : _selectedPages == null || _selectedPages.Count == 0);
+    private bool GenerateDisabled => _loading || _source switch
+        {
+            DocumentSource.Document => _file == null,
+            DocumentSource.Text => string.IsNullOrWhiteSpace(_text),
+            _ => _selectedPages == null || _selectedPages.Count == 0
+        };
 
     protected override async Task OnInitializedAsync()
     {
@@ -312,22 +321,30 @@ Define what success looks like — business or system-level outcomes.
         try
         {
             List<(string Name, string Text)> pages = [];
-            if (_useDocument)
+            switch (_source)
             {
-                if (_file != null)
-                {
-                    using var stream = _file.OpenReadStream(MaxFileSize);
-                    var text = DocumentHelpers.ExtractText(stream, _file.Name);
-                    pages.Add((_file.Name, text));
-                }
-            }
-            else if (_selectedPages != null)
-            {
-                foreach (var p in _selectedPages)
-                {
-                    var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
-                    pages.Add((p.Name, text));
-                }
+                case DocumentSource.Document:
+                    if (_file != null)
+                    {
+                        using var stream = _file.OpenReadStream(MaxFileSize);
+                        var text = DocumentHelpers.ExtractText(stream, _file.Name);
+                        pages.Add((_file.Name, text));
+                    }
+                    break;
+                case DocumentSource.Text:
+                    if (!string.IsNullOrWhiteSpace(_text))
+                        pages.Add(("Pasted", _text));
+                    break;
+                default:
+                    if (_selectedPages != null)
+                    {
+                        foreach (var p in _selectedPages)
+                        {
+                            var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
+                            pages.Add((p.Name, text));
+                        }
+                    }
+                    break;
             }
             _prompt = BuildPrompt(pages, _storiesOnly, _clarify, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
@@ -433,22 +450,30 @@ Define what success looks like — business or system-level outcomes.
     {
         var sb = new System.Text.StringBuilder(InitialPrompt);
         List<(string Name, string Text)> pages = [];
-        if (_promptUseDocument)
+        switch (_promptSource)
         {
-            if (_promptFile != null)
-            {
-                using var stream = _promptFile.OpenReadStream(MaxFileSize);
-                var text = DocumentHelpers.ExtractText(stream, _promptFile.Name);
-                pages.Add((_promptFile.Name, text));
-            }
-        }
-        else if (_promptSelectedPages != null)
-        {
-            foreach (var p in _promptSelectedPages)
-            {
-                var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
-                pages.Add((p.Name, text));
-            }
+            case DocumentSource.Document:
+                if (_promptFile != null)
+                {
+                    using var stream = _promptFile.OpenReadStream(MaxFileSize);
+                    var text = DocumentHelpers.ExtractText(stream, _promptFile.Name);
+                    pages.Add((_promptFile.Name, text));
+                }
+                break;
+            case DocumentSource.Text:
+                if (!string.IsNullOrWhiteSpace(_promptText))
+                    pages.Add(("Pasted", _promptText));
+                break;
+            default:
+                if (_promptSelectedPages != null)
+                {
+                    foreach (var p in _promptSelectedPages)
+                    {
+                        var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
+                        pages.Add((p.Name, text));
+                    }
+                }
+                break;
         }
         if (pages.Count > 0)
         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/DocumentSource.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/DocumentSource.cs
@@ -1,0 +1,8 @@
+namespace DevOpsAssistant.Services.Models;
+
+public enum DocumentSource
+{
+    Wiki,
+    Document,
+    Text
+}


### PR DESCRIPTION
## Summary
- add `DocumentSource` enum for wiki, document or text inputs
- update `WikiDocumentSelector` to allow pasting text
- localize new strings for the selector
- adjust `RequirementsPlanner` to use the new option

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6863d89bc664832888e023373d941f9a