### PR TITLE
Remove output format prompt from requirements planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -667,10 +667,6 @@ Define what success looks like — business or system-level outcomes.
             sb.AppendLine();
         }
         sb.AppendLine();
-        if (config.OutputFormat == OutputFormat.Inline)
-            sb.AppendLine("Reply inline with the final requirements.");
-        else
-            sb.AppendLine($"Once finished, convert the entire output to {config.OutputFormat} format and provide that version.");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## Summary
- remove output format instructions from RequirementsPlanner prompt builder

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686557589be08328b4cb2274835385be