### PR TITLE
Add tag editing and work item creation to requirements planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -1,0 +1,102 @@
+@using Microsoft.AspNetCore.Components
+@using MudBlazor
+@using DevOpsAssistant.Utils
+
+<MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass(Type)}")" draggable="@Draggable" @ondragstart="DragStart" @ondrop="Drop" @ondragover:preventDefault>
+    <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+        <MudText Typo="@HeaderTypo">@Type</MudText>
+        @if (OnDelete.HasDelegate)
+        {
+            <MudTooltip Text="@DeleteTooltip">
+                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="OnDelete" />
+            </MudTooltip>
+        }
+    </MudStack>
+    @if (Preview)
+    {
+        <MudText Typo="Typo.subtitle2">Description</MudText>
+        <div class="preview-box">@((MarkupString)Description)</div>
+        @if (AcceptanceCriteria != null)
+        {
+            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
+            <div class="preview-box">@((MarkupString)AcceptanceCriteria)</div>
+        }
+        <MudText Typo="Typo.subtitle2">Tags</MudText>
+        <div>@string.Join(", ", Tags)</div>
+    }
+    else
+    {
+        <MudTextField @bind-Value="Title" Label="Title" />
+        <MudTextField @bind-Value="Description" Label="Description" Lines="3" />
+        @if (AcceptanceCriteria != null)
+        {
+            <MudTextField @bind-Value="AcceptanceCriteria" Label="Acceptance Criteria" Lines="3" />
+        }
+        <MudStack Spacing="1">
+            <MudChipSet T="string">
+                @foreach (var t in Tags)
+                {
+                    if (IsProtected(t))
+                    {
+                        <MudChip Value="@t">@t</MudChip>
+                    }
+                    else
+                    {
+                        <MudChip Value="@t" OnClose="(MudChip<string> _) => RemoveTag(t)">@t</MudChip>
+                    }
+                }
+            </MudChipSet>
+            <MudStack Row="true" Spacing="1" AlignItems="AlignItems.End">
+                <MudTextField T="string" @bind-Value="_newTag" Label="Tag" />
+                <MudButton Variant="Variant.Text" OnClick="AddTag" Disabled="string.IsNullOrWhiteSpace(_newTag)">Add</MudButton>
+            </MudStack>
+        </MudStack>
+    }
+</MudPaper>
+
+@code {
+    [Parameter] public string Type { get; set; } = string.Empty;
+    [Parameter] public bool Preview { get; set; }
+    [Parameter] public bool Draggable { get; set; }
+    [Parameter] public EventCallback DragStart { get; set; }
+    [Parameter] public EventCallback Drop { get; set; }
+    [Parameter] public EventCallback OnDelete { get; set; }
+    [Parameter] public string DeleteTooltip { get; set; } = "Delete";
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> TitleChanged { get; set; }
+    [Parameter] public string Description { get; set; } = string.Empty;
+    [Parameter] public EventCallback<string> DescriptionChanged { get; set; }
+    [Parameter] public string? AcceptanceCriteria { get; set; }
+    [Parameter] public EventCallback<string?> AcceptanceCriteriaChanged { get; set; }
+    [Parameter] public List<string> Tags { get; set; } = new();
+    [Parameter] public EventCallback<List<string>> TagsChanged { get; set; }
+
+    private string _newTag = string.Empty;
+
+    private Typo HeaderTypo => Type switch
+    {
+        "Epic" => Typo.h6,
+        "Feature" => Typo.subtitle1,
+        _ => Typo.subtitle2
+    };
+
+    private void AddTag()
+    {
+        if (!string.IsNullOrWhiteSpace(_newTag))
+        {
+            Tags.Add(_newTag.Trim());
+            _newTag = string.Empty;
+            TagsChanged.InvokeAsync(Tags);
+        }
+    }
+
+    private bool IsProtected(string tag) => string.Equals(tag, "AI Generated", StringComparison.OrdinalIgnoreCase);
+
+    private void RemoveTag(string tag)
+    {
+        if (IsProtected(tag))
+            return;
+        Tags.Remove(tag);
+        TagsChanged.InvokeAsync(Tags);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -95,105 +95,63 @@
 
                 @foreach (var story in _plan.Stories)
                 {
-                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("User Story")}")"
-                              draggable="true"
-                              @ondragstart="() => OnDragStart(story)"
-                              @ondrop="() => OnDropOnStoryList(story)"
-                              @ondragover:preventDefault>
-                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                            <MudText Typo="Typo.subtitle2">Story</MudText>
-                            <MudTooltip Text='@L["DeleteTooltip"]'>
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveStory(story)" />
-                            </MudTooltip>
-                        </MudStack>
-                        @if (_previewHtml)
-                        {
-                            <MudText Typo="Typo.subtitle2">Description</MudText>
-                            <div class="preview-box">@((MarkupString)story.Description)</div>
-                            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
-                            <div class="preview-box">@((MarkupString)story.AcceptanceCriteria)</div>
-                            <MudText Typo="Typo.subtitle2">Tags</MudText>
-                            <div>@string.Join(", ", story.Tags)</div>
-                        }
-                        else
-                        {
-                            <MudTextField @bind-Value="story.Title" Label="Title" />
-                            <MudTextField @bind-Value="story.Description" Label="Description" Lines="3" />
-                            <MudTextField @bind-Value="story.AcceptanceCriteria" Label="Acceptance Criteria" Lines="3" />
-                            <MudTextField @bind-Value="story.TagString" Label="Tags" />
-                        }
-                    </MudPaper>
+                    <PlanItemEditor Type="User Story"
+                                    Draggable="true"
+                                    Preview="_previewHtml"
+                                    DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
+                                    Drop="EventCallback.Factory.Create(this, () => OnDropOnStoryList(story))"
+                                    OnDelete="EventCallback.Factory.Create(this, () => RemoveStory(story))"
+                                    @bind-Title="story.Title"
+                                    @bind-Description="story.Description"
+                                    @bind-AcceptanceCriteria="story.AcceptanceCriteria"
+                                    @bind-Tags="story.Tags" />
                 }
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddStory">Add Story</MudButton>
             }
             else
             {
                 @foreach (var epic in _plan.Epics)
                 {
-                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("Epic")}")"
-                              draggable="true"
-                              @ondragstart="() => OnDragStart(epic)"
-                              @ondrop="() => OnDropOnPlan(epic)"
-                              @ondragover:preventDefault>
-                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                            <MudText Typo="Typo.h6">Epic</MudText>
-                            <MudTooltip Text='@L["DeleteTooltip"]'>
-                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveEpic(epic)" />
-                            </MudTooltip>
-                        </MudStack>
-                        <MudTextField @bind-Value="epic.Title" Label="Title" />
-                        <MudTextField @bind-Value="epic.Description" Label="Description" Lines="3" />
-
+                    <PlanItemEditor Type="Epic"
+                                    Draggable="true"
+                                    Preview="_previewHtml"
+                                    DragStart="EventCallback.Factory.Create(this, () => OnDragStart(epic))"
+                                    Drop="EventCallback.Factory.Create(this, () => OnDropOnPlan(epic))"
+                                    OnDelete="EventCallback.Factory.Create(this, () => RemoveEpic(epic))"
+                                    @bind-Title="epic.Title"
+                                    @bind-Description="epic.Description"
+                                    @bind-Tags="epic.Tags" >
                         @foreach (var feature in epic.Features)
                         {
-                            <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("Feature")}")"
-                                      draggable="true"
-                                      @ondragstart="() => OnDragStart(feature)"
-                                      @ondrop="() => OnDropOnEpic(epic)"
-                                      @ondragover:preventDefault>
-                                <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                    <MudText Typo="Typo.subtitle1">Feature</MudText>
-                                    <MudTooltip Text='@L["DeleteTooltip"]'>
-                                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveFeature(feature)" />
-                                    </MudTooltip>
-                                </MudStack>
-                                <MudTextField @bind-Value="feature.Title" Label="Title" />
-                                <MudTextField @bind-Value="feature.Description" Label="Description" Lines="3" />
-
+                            <PlanItemEditor Type="Feature"
+                                            Draggable="true"
+                                            Preview="_previewHtml"
+                                            DragStart="EventCallback.Factory.Create(this, () => OnDragStart(feature))"
+                                            Drop="EventCallback.Factory.Create(this, () => OnDropOnEpic(epic))"
+                                            OnDelete="EventCallback.Factory.Create(this, () => RemoveFeature(feature))"
+                                            @bind-Title="feature.Title"
+                                            @bind-Description="feature.Description"
+                                            @bind-Tags="feature.Tags" >
                                 @foreach (var story in feature.Stories)
                                 {
-                                    <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass("User Story")}")"
-                                              draggable="true"
-                                              @ondragstart="() => OnDragStart(story)"
-                                              @ondrop="() => OnDropOnFeature(feature)"
-                                              @ondragover:preventDefault>
-                                        <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
-                                            <MudText Typo="Typo.subtitle2">Story</MudText>
-                                            <MudTooltip Text='@L["DeleteTooltip"]'>
-                                                <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small" OnClick="() => RemoveStory(story)" />
-                                            </MudTooltip>
-                                        </MudStack>
-                                        @if (_previewHtml)
-                                        {
-                                            <MudText Typo="Typo.subtitle2">Description</MudText>
-                                            <div class="preview-box">@((MarkupString)story.Description)</div>
-                                            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
-                                            <div class="preview-box">@((MarkupString)story.AcceptanceCriteria)</div>
-                                            <MudText Typo="Typo.subtitle2">Tags</MudText>
-                                            <div>@string.Join(", ", story.Tags)</div>
-                                        }
-                                        else
-                                        {
-                                            <MudTextField @bind-Value="story.Title" Label="Title" />
-                                            <MudTextField @bind-Value="story.Description" Label="Description" Lines="3" />
-                                            <MudTextField @bind-Value="story.AcceptanceCriteria" Label="Acceptance Criteria" Lines="3" />
-                                            <MudTextField @bind-Value="story.TagString" Label="Tags" />
-                                        }
-                                    </MudPaper>
+                                    <PlanItemEditor Type="User Story"
+                                                    Draggable="true"
+                                                    Preview="_previewHtml"
+                                                    DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
+                                                    Drop="EventCallback.Factory.Create(this, () => OnDropOnFeature(feature))"
+                                                    OnDelete="EventCallback.Factory.Create(this, () => RemoveStory(story))"
+                                                    @bind-Title="story.Title"
+                                                    @bind-Description="story.Description"
+                                                    @bind-AcceptanceCriteria="story.AcceptanceCriteria"
+                                                    @bind-Tags="story.Tags" />
                                 }
-                            </MudPaper>
+                                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddStory(feature)">Add Story</MudButton>
+                            </PlanItemEditor>
                         }
-                    </MudPaper>
+                        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddFeature(epic)">Add Feature</MudButton>
+                    </PlanItemEditor>
                 }
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddEpic">Add Epic</MudButton>
             }
 
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
@@ -561,8 +519,10 @@ Define what success looks like — business or system-level outcomes.
             story.TagString = string.Join(", ", story.Tags);
         foreach (var epic in plan.Epics)
         {
+            epic.TagString = string.Join(", ", epic.Tags);
             foreach (var feature in epic.Features)
             {
+                feature.TagString = string.Join(", ", feature.Tags);
                 foreach (var story in feature.Stories)
                     story.TagString = string.Join(", ", story.Tags);
             }
@@ -598,11 +558,13 @@ Define what success looks like — business or system-level outcomes.
             {
                 foreach (var epic in _plan.Epics)
                 {
-                    epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog, null, null, ["AI Generated"]);
+                    var epicTags = epic.Tags.Concat(["AI Generated"]).ToArray();
+                    epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog, null, null, epicTags);
                     _createdItems.Add(epic.Id);
                     foreach (var feature in epic.Features)
                     {
-                        feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id, null, ["AI Generated"]);
+                        var featureTags = feature.Tags.Concat(["AI Generated"]).ToArray();
+                        feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id, null, featureTags);
                         _createdItems.Add(feature.Id);
                         foreach (var story in feature.Stories)
                         {
@@ -803,6 +765,26 @@ Define what success looks like — business or system-level outcomes.
                     return;
     }
 
+    private void AddEpic()
+    {
+        _plan?.Epics.Add(new Epic());
+    }
+
+    private void AddFeature(Epic epic)
+    {
+        epic.Features.Add(new Feature());
+    }
+
+    private void AddStory(Feature feature)
+    {
+        feature.Stories.Add(new Story());
+    }
+
+    private void AddStory()
+    {
+        _plan?.Stories.Add(new Story());
+    }
+
     private class Plan
     {
         public List<Epic> Epics { get; set; } = new();
@@ -814,6 +796,16 @@ Define what success looks like — business or system-level outcomes.
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
+        public List<string> Tags { get; set; } = new();
+
+        [JsonIgnore]
+        public string TagString
+        {
+            get => string.Join(", ", Tags);
+            set => Tags = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(t => t.Trim())
+                                .ToList();
+        }
         public List<Feature> Features { get; set; } = new();
     }
 
@@ -822,6 +814,16 @@ Define what success looks like — business or system-level outcomes.
         public int Id { get; set; }
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
+        public List<string> Tags { get; set; } = new();
+
+        [JsonIgnore]
+        public string TagString
+        {
+            get => string.Join(", ", Tags);
+            set => Tags = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                                .Select(t => t.Trim())
+                                .ToList();
+        }
         public List<Story> Stories { get; set; } = new();
     }
 


### PR DESCRIPTION
## Summary
- add `PlanItemEditor` component for editing epics, features and stories
- support adding new epics, features and stories in `RequirementsPlanner`
- allow managing tags with chip UI and preserve non-removable `AI Generated` tag
- include tags for epics and features when creating work items

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6865809897788328975553d66e315201