### PR TITLE
Add prompt override mode

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -21,6 +21,9 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = "SQ",
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
+            StoryQualityPromptMode = PromptMode.Append,
+            ReleaseNotesPromptMode = PromptMode.Append,
+            RequirementsPromptMode = PromptMode.Append,
             MainBranch = " main ",
             OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules
@@ -71,6 +74,9 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = "SQ",
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
+            StoryQualityPromptMode = PromptMode.Append,
+            ReleaseNotesPromptMode = PromptMode.Append,
+            RequirementsPromptMode = PromptMode.Append,
             OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules
             {
@@ -119,6 +125,9 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = " SQ ",
             ReleaseNotesPrompt = " RN ",
             RequirementsPrompt = " RP ",
+            StoryQualityPromptMode = PromptMode.Append,
+            ReleaseNotesPromptMode = PromptMode.Append,
+            RequirementsPromptMode = PromptMode.Append,
             OutputFormat = OutputFormat.Pdf,
             Rules = new ValidationRules()
         };

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -24,6 +24,12 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Prompt de Requerimientos</value>
   </data>
+  <data name="PromptReplace" xml:space="preserve">
+    <value>Reemplazar el prompt predeterminado</value>
+  </data>
+  <data name="PromptAppend" xml:space="preserve">
+    <value>Agregar al prompt predeterminado</value>
+  </data>
   <data name="PromptLimit" xml:space="preserve">
     <value>Límite de caracteres del prompt</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -61,8 +61,20 @@
             <MudTabPanel Text='@L["PromptsTab"]'>
                 <MudStack Spacing="2">
                     <MudTextField T="string" Value="_model.StoryQualityPrompt" ValueChanged="v => OnPromptsChanged(() => _model.StoryQualityPrompt = v)" Label='@L["StoryQualityPrompt"]' Lines="3"/>
+                    <MudRadioGroup T="PromptMode" Value="_model.StoryQualityPromptMode" ValueChanged="v => OnPromptsChanged(() => _model.StoryQualityPromptMode = v)">
+                        <MudRadio T="PromptMode" Value="PromptMode.Replace">@L["PromptReplace"]</MudRadio>
+                        <MudRadio T="PromptMode" Value="PromptMode.Append">@L["PromptAppend"]</MudRadio>
+                    </MudRadioGroup>
                     <MudTextField T="string" Value="_model.ReleaseNotesPrompt" ValueChanged="v => OnPromptsChanged(() => _model.ReleaseNotesPrompt = v)" Label='@L["ReleaseNotesPrompt"]' Lines="3"/>
+                    <MudRadioGroup T="PromptMode" Value="_model.ReleaseNotesPromptMode" ValueChanged="v => OnPromptsChanged(() => _model.ReleaseNotesPromptMode = v)">
+                        <MudRadio T="PromptMode" Value="PromptMode.Replace">@L["PromptReplace"]</MudRadio>
+                        <MudRadio T="PromptMode" Value="PromptMode.Append">@L["PromptAppend"]</MudRadio>
+                    </MudRadioGroup>
                     <MudTextField T="string" Value="_model.RequirementsPrompt" ValueChanged="v => OnPromptsChanged(() => _model.RequirementsPrompt = v)" Label='@L["RequirementsPrompt"]' Lines="3"/>
+                    <MudRadioGroup T="PromptMode" Value="_model.RequirementsPromptMode" ValueChanged="v => OnPromptsChanged(() => _model.RequirementsPromptMode = v)">
+                        <MudRadio T="PromptMode" Value="PromptMode.Replace">@L["PromptReplace"]</MudRadio>
+                        <MudRadio T="PromptMode" Value="PromptMode.Append">@L["PromptAppend"]</MudRadio>
+                    </MudRadioGroup>
                     <MudTextField T="int" Value="_model.PromptCharacterLimit" ValueChanged="OnPromptsLimitChanged" Label='@L["PromptLimit"]' InputType="InputType.Number" />
                     <MudSelect T="OutputFormat" Value="_model.OutputFormat" ValueChanged="OnOutputFormatChanged" Label='@L["OutputFormat"]'>
                         <MudSelectItem Value="OutputFormat.Markdown">Markdown</MudSelectItem>
@@ -150,6 +162,9 @@
             StoryQualityPrompt = cfg.StoryQualityPrompt,
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
+            StoryQualityPromptMode = cfg.StoryQualityPromptMode,
+            ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
+            RequirementsPromptMode = cfg.RequirementsPromptMode,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
             OutputFormat = cfg.OutputFormat,
             Rules = new ValidationRules
@@ -199,6 +214,9 @@
             StoryQualityPrompt = _model.StoryQualityPrompt,
             ReleaseNotesPrompt = _model.ReleaseNotesPrompt,
             RequirementsPrompt = _model.RequirementsPrompt,
+            StoryQualityPromptMode = _model.StoryQualityPromptMode,
+            ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode,
+            RequirementsPromptMode = _model.RequirementsPromptMode,
             PromptCharacterLimit = _model.PromptCharacterLimit,
             OutputFormat = _model.OutputFormat,
             Rules = _model.Rules
@@ -232,6 +250,9 @@
         cfg.StoryQualityPrompt = _model.StoryQualityPrompt;
         cfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
         cfg.RequirementsPrompt = _model.RequirementsPrompt;
+        cfg.StoryQualityPromptMode = _model.StoryQualityPromptMode;
+        cfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
+        cfg.RequirementsPromptMode = _model.RequirementsPromptMode;
         cfg.PromptCharacterLimit = _model.PromptCharacterLimit;
         cfg.OutputFormat = _model.OutputFormat;
         await ConfigService.SaveCurrentAsync(_model.Project, cfg);
@@ -261,6 +282,9 @@
                 pcfg.StoryQualityPrompt = _model.StoryQualityPrompt;
                 pcfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
                 pcfg.RequirementsPrompt = _model.RequirementsPrompt;
+                pcfg.StoryQualityPromptMode = _model.StoryQualityPromptMode;
+                pcfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
+                pcfg.RequirementsPromptMode = _model.RequirementsPromptMode;
                 pcfg.PromptCharacterLimit = _model.PromptCharacterLimit;
                 pcfg.OutputFormat = _model.OutputFormat;
                 await ConfigService.UpdateProjectAsync(p.Name, p.Name, pcfg);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -24,6 +24,12 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Requirements Prompt</value>
   </data>
+  <data name="PromptReplace" xml:space="preserve">
+    <value>Replace default prompt</value>
+  </data>
+  <data name="PromptAppend" xml:space="preserve">
+    <value>Add to default prompt</value>
+  </data>
   <data name="PromptLimit" xml:space="preserve">
     <value>Prompt Character Limit</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -196,7 +196,8 @@ else if (_promptParts != null)
 
         var sb = new StringBuilder();
 
-        if (string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt))
+        if (string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt) ||
+            config.ReleaseNotesPromptMode == PromptMode.Append)
         {
             sb.AppendLine("You are a meticulous Delivery Manager preparing release notes for a software update.");
             sb.AppendLine("Write in clear, plain language so non-technical stakeholders can understand the changes.");
@@ -310,7 +311,7 @@ else if (_promptParts != null)
             sb.AppendLine("[Other notes.]");
             sb.AppendLine("```");
         }
-        else
+        if (!string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt))
         {
             sb.AppendLine(config.ReleaseNotesPrompt.Trim());
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -606,7 +606,8 @@ Define what success looks like — business or system-level outcomes.
         private static string BuildPrompt(IEnumerable<(string Name, string Text)> pages, bool storiesOnly, bool clarify, DevOpsConfig config)
     {
         var sb = new System.Text.StringBuilder();
-        if (string.IsNullOrWhiteSpace(config.RequirementsPrompt))
+        if (string.IsNullOrWhiteSpace(config.RequirementsPrompt) ||
+            config.RequirementsPromptMode == PromptMode.Append)
         {
             if (storiesOnly)
             {
@@ -651,7 +652,7 @@ Define what success looks like — business or system-level outcomes.
                 sb.AppendLine("If anything is unclear, ask precise, targeted clarification questions first, then proceed once answered.");
             }
         }
-        else
+        if (!string.IsNullOrWhiteSpace(config.RequirementsPrompt))
         {
             sb.AppendLine(config.RequirementsPrompt.Trim());
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -167,7 +167,8 @@ else if (_promptParts != null)
         });
         var json = JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });
         var sb = new StringBuilder();
-        if (string.IsNullOrWhiteSpace(config.StoryQualityPrompt))
+        if (string.IsNullOrWhiteSpace(config.StoryQualityPrompt) ||
+            config.StoryQualityPromptMode == PromptMode.Append)
         {
             sb.AppendLine("You are an expert Agile coach reviewing user stories and bugs for quality.");
             sb.AppendLine();
@@ -254,7 +255,7 @@ else if (_promptParts != null)
             sb.AppendLine(config.DefinitionOfReady);
         }
         }
-        else
+        if (!string.IsNullOrWhiteSpace(config.StoryQualityPrompt))
         {
             sb.AppendLine(config.StoryQualityPrompt.Trim());
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -12,6 +12,9 @@ public class DevOpsConfig
     public string StoryQualityPrompt { get; set; } = string.Empty;
     public string ReleaseNotesPrompt { get; set; } = string.Empty;
     public string RequirementsPrompt { get; set; } = string.Empty;
+    public PromptMode StoryQualityPromptMode { get; set; }
+    public PromptMode ReleaseNotesPromptMode { get; set; }
+    public PromptMode RequirementsPromptMode { get; set; }
     public int PromptCharacterLimit { get; set; }
     public OutputFormat OutputFormat { get; set; }
     public ValidationRules Rules { get; set; } = new();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -197,6 +197,9 @@ public class DevOpsConfigService
             StoryQualityPrompt = config.StoryQualityPrompt.Trim(),
             ReleaseNotesPrompt = config.ReleaseNotesPrompt.Trim(),
             RequirementsPrompt = config.RequirementsPrompt.Trim(),
+            StoryQualityPromptMode = config.StoryQualityPromptMode,
+            ReleaseNotesPromptMode = config.ReleaseNotesPromptMode,
+            RequirementsPromptMode = config.RequirementsPromptMode,
             PromptCharacterLimit = config.PromptCharacterLimit,
             OutputFormat = config.OutputFormat,
             Rules = config.Rules
@@ -222,6 +225,9 @@ public class DevOpsConfigService
             StoryQualityPrompt = cfg.StoryQualityPrompt,
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
+            StoryQualityPromptMode = cfg.StoryQualityPromptMode,
+            ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
+            RequirementsPromptMode = cfg.RequirementsPromptMode,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
             OutputFormat = cfg.OutputFormat,
             Rules = cfg.Rules

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PromptMode.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PromptMode.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services.Models;
+
+public enum PromptMode
+{
+    Replace,
+    Append
+}


### PR DESCRIPTION
## Summary
- add `PromptMode` enum and new prompt mode fields to `DevOpsConfig`
- persist prompt mode in `DevOpsConfigService`
- expose prompt mode radio groups in project settings
- support append behavior in prompt builders
- update tests and resources

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68658806add483288a8a6de6da145f67