### PR TITLE
Fix PlanItemEditor child content error

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
@@ -1,0 +1,20 @@
+using Bunit;
+using DevOpsAssistant.Components;
+using DevOpsAssistant.Tests.Utils;
+
+namespace DevOpsAssistant.Tests.Components;
+
+public class PlanItemEditorTests : ComponentTestBase
+{
+    [Fact]
+    public void Renders_ChildContent()
+    {
+        SetupServices();
+        var cut = RenderComponent<PlanItemEditor>(p => p
+            .Add(c => c.Type, "Epic")
+            .AddChildContent("<div class=\"inner\">content</div>")
+        );
+
+        cut.Find("div.inner").MarkupMatches("<div class=\"inner\">content</div>");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -52,6 +52,11 @@
             </MudStack>
         </MudStack>
     }
+
+    @if (ChildContent != null)
+    {
+        @ChildContent
+    }
 </MudPaper>
 
 @code {
@@ -70,6 +75,7 @@
     [Parameter] public EventCallback<string?> AcceptanceCriteriaChanged { get; set; }
     [Parameter] public List<string> Tags { get; set; } = new();
     [Parameter] public EventCallback<List<string>> TagsChanged { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private string _newTag = string.Empty;
 


### PR DESCRIPTION
## Summary
- allow nested markup in `PlanItemEditor`
- add unit test to verify child content is rendered

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686588fdecfc8328a1e6b6b0ed98c4bc