### PR TITLE
Add work item viewer page

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemViewerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemViewerPageTests.cs
@@ -1,0 +1,25 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Tests.Utils;
+using DevOpsAssistant.Services;
+using System.Threading.Tasks;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class WorkItemViewerPageTests : ComponentTestBase
+{
+    [Fact]
+    public async Task WorkItemViewer_Renders()
+    {
+        var config = SetupServices(includeApi: true);
+        await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+
+        var exception = Record.Exception(() => RenderWithProvider<TestPage>());
+        Assert.Null(exception);
+    }
+
+    private class TestPage : WorkItemViewer
+    {
+        protected override Task OnInitializedAsync() => Task.CompletedTask;
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -24,6 +24,9 @@
   <data name="BulkTag" xml:space="preserve">
     <value>Etiquetado masivo</value>
   </data>
+  <data name="WorkItemViewer" xml:space="preserve">
+    <value>Visor de elementos</value>
+  </data>
   <data name="WorkItemQuality" xml:space="preserve">
     <value>Calidad de elemento de trabajo</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -46,6 +46,7 @@
                         <MudNavLink Href="@($"projects/{_selectedProject}/epics-features")" Icon="@Icons.Material.Filled.List" Disabled="@IsProjectInvalid">@L["Epics"]</MudNavLink>
                         <MudNavLink Href="@($"projects/{_selectedProject}/validation")" Icon="@Icons.Material.Filled.Rule" Disabled="@IsProjectInvalid">@L["Validation"]</MudNavLink>
                         <MudNavLink Href="@($"projects/{_selectedProject}/bulk-tag")" Icon="@Icons.Material.Filled.Label" Disabled="@IsProjectInvalid">@L["BulkTag"]</MudNavLink>
+                        <MudNavLink Href="@($"projects/{_selectedProject}/work-item-viewer")" Icon="@Icons.Material.Filled.Visibility" Disabled="@IsProjectInvalid">@L["WorkItemViewer"]</MudNavLink>
                 </MudNavGroup>
                 <MudNavGroup Title="@L["AIHelpers"]" Expanded="true">
                         <MudNavLink Href="@($"projects/{_selectedProject}/work-item-quality")" Icon="@Icons.Material.Filled.Check" Disabled="@IsProjectInvalid">@L["WorkItemQuality"]</MudNavLink>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -24,6 +24,9 @@
   <data name="BulkTag" xml:space="preserve">
     <value>Bulk Tag</value>
   </data>
+  <data name="WorkItemViewer" xml:space="preserve">
+    <value>Work Item Viewer</value>
+  </data>
   <data name="WorkItemQuality" xml:space="preserve">
     <value>Work Item Quality</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.es.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SelectedItems" xml:space="preserve">
+    <value>Elementos seleccionados</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="StoryPointsLabel" xml:space="preserve">
+    <value>Puntos de historia</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relaciones</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
@@ -1,0 +1,197 @@
+@page "/projects/{ProjectName}/work-item-viewer"
+@using DevOpsAssistant.Services.Models
+@inject DevOpsApiService ApiService
+@inject PageStateService StateService
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<WorkItemViewer> L
+@inherits ProjectComponentBase
+
+<PageTitle>DevOpsAssistant - Work Item Viewer</PageTitle>
+
+@if (!string.IsNullOrWhiteSpace(_error))
+{
+    <MudAlert Severity="Severity.Error">@_error</MudAlert>
+}
+
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+
+<MudPaper Class="viewer-layout">
+    <div class="viewer-list">
+        <MudExpansionPanels>
+            <MudExpansionPanel Text="@L["SelectedItems"]" Expanded="@_listExpanded" ExpandedChanged="@(v => _listExpanded = v)">
+                <MudList T="WorkItemInfo" Dense="true">
+                    @foreach (var item in _selectedItems)
+                    {
+                        <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
+                            @item.Id - @item.Title
+                        </MudListItem>
+                    }
+                </MudList>
+            </MudExpansionPanel>
+        </MudExpansionPanels>
+    </div>
+    <div class="viewer-details">
+        @if (_loading)
+        {
+            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+        }
+        else if (_details != null)
+        {
+            <MudStack Spacing="2">
+                <MudText Typo="Typo.h5">@_details.Story.Title (@_details.Story.Id)</MudText>
+                <MudText Typo="Typo.subtitle2">@(_details.Story.WorkItemType) - @_details.Story.State</MudText>
+                <MudLink Href="@_details.Story.Url" Target="_blank">Open in DevOps</MudLink>
+                @if (!string.IsNullOrWhiteSpace(_details.Description))
+                {
+                    <MudText Typo="Typo.h6">Description</MudText>
+                    <MudPaper Class="pa-2" Style="overflow:auto">
+                        @((MarkupString)_details.Description)
+                    </MudPaper>
+                }
+                @if (!string.IsNullOrWhiteSpace(_details.AcceptanceCriteria))
+                {
+                    <MudText Typo="Typo.h6">Acceptance Criteria</MudText>
+                    <MudPaper Class="pa-2" Style="overflow:auto">
+                        @((MarkupString)_details.AcceptanceCriteria)
+                    </MudPaper>
+                }
+                @if (_details.StoryPoints > 0)
+                {
+                    <MudText Typo="Typo.h6">@L["StoryPointsLabel"]: @_details.StoryPoints</MudText>
+                }
+                @if (_details.Tags.Length > 0)
+                {
+                    <MudText Typo="Typo.h6">@L["TagsHeading"]</MudText>
+                    <MudChipSet T="string">
+                        @foreach (var t in _details.Tags)
+                        {
+                            <MudChip T="string">@t</MudChip>
+                        }
+                    </MudChipSet>
+                }
+                @if (!string.IsNullOrWhiteSpace(_details.ReproSteps))
+                {
+                    <MudText Typo="Typo.h6">Repro Steps</MudText>
+                    <MudPaper Class="pa-2" Style="overflow:auto">
+                        @((MarkupString)_details.ReproSteps)
+                    </MudPaper>
+                }
+                @if (!string.IsNullOrWhiteSpace(_details.SystemInfo))
+                {
+                    <MudText Typo="Typo.h6">System Info</MudText>
+                    <MudPaper Class="pa-2" Style="overflow:auto">
+                        @((MarkupString)_details.SystemInfo)
+                    </MudPaper>
+                }
+                @if (_details.Feature != null)
+                {
+                    <MudDivider Class="my-2" />
+                    <MudText Typo="Typo.subtitle1">Feature: @_details.Feature.Title (@_details.Feature.State)</MudText>
+                    @if (!string.IsNullOrWhiteSpace(_details.FeatureDescription))
+                    {
+                        <MudPaper Class="pa-2" Style="overflow:auto">
+                            @((MarkupString)_details.FeatureDescription)
+                        </MudPaper>
+                    }
+                }
+                @if (_details.Epic != null)
+                {
+                    <MudDivider Class="my-2" />
+                    <MudText Typo="Typo.subtitle1">Epic: @_details.Epic.Title (@_details.Epic.State)</MudText>
+                    @if (!string.IsNullOrWhiteSpace(_details.EpicDescription))
+                    {
+                        <MudPaper Class="pa-2" Style="overflow:auto">
+                            @((MarkupString)_details.EpicDescription)
+                        </MudPaper>
+                    }
+                }
+                @if (_details.Relations.Count > 0)
+                {
+                    <MudDivider Class="my-2" />
+                    <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
+                    <MudList T="WorkItemRelation">
+                        @foreach (var r in _details.Relations)
+                        {
+                            <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                        }
+                    </MudList>
+                }
+                @if (_details.Comments.Count > 0)
+                {
+                    <MudDivider Class="my-2" />
+                    <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
+                    <MudList T="string" Dense="true">
+                        @foreach (var c in _details.Comments)
+                        {
+                            <MudListItem T="string">@c</MudListItem>
+                        }
+                    </MudList>
+                }
+            </MudStack>
+        }
+        else
+        {
+            <MudText>Select an item to view details.</MudText>
+        }
+    </div>
+</MudPaper>
+
+@code {
+    [Parameter] public string ProjectName { get; set; } = string.Empty;
+
+    private readonly HashSet<WorkItemInfo> _selectedItems = [];
+    private bool _loading;
+    private bool _filtersExpanded = true;
+    private bool _listExpanded = true;
+    private StoryHierarchyDetails? _details;
+    private string? _error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await ConfigService.LoadAsync();
+        if (!string.IsNullOrWhiteSpace(ProjectName) && ConfigService.CurrentProject.Name != ProjectName)
+        {
+            await ConfigService.SelectProjectAsync(ProjectName);
+        }
+    }
+
+    private Task OnWorkItemsSelected(IReadOnlyCollection<WorkItemInfo> items)
+    {
+        _selectedItems.Clear();
+        foreach (var i in items)
+            _selectedItems.Add(i);
+        var first = _selectedItems.FirstOrDefault();
+        if (first != null)
+            _ = LoadDetails(first.Id);
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadDetails(int id)
+    {
+        _loading = true;
+        _details = null;
+        StateHasChanged();
+        try
+        {
+            var result = await ApiService.GetStoryHierarchyDetailsAsync(new[] { id });
+            _details = result.FirstOrDefault();
+            if (_details != null)
+                _details.Comments = await ApiService.GetCommentsAsync(id);
+            _error = null;
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _loading = false;
+        }
+        StateHasChanged();
+    }
+
+    protected override Task OnProjectChangedAsync()
+    {
+        return OnInitializedAsync();
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.resx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="SelectedItems" xml:space="preserve">
+    <value>Selected Items</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="StoryPointsLabel" xml:space="preserve">
+    <value>Story Points</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relationships</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryHierarchyDetails.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace DevOpsAssistant.Services.Models;
 
 public class StoryHierarchyDetails
@@ -11,4 +14,8 @@ public class StoryHierarchyDetails
     public WorkItemInfo? Epic { get; set; }
     public string FeatureDescription { get; set; } = string.Empty;
     public string EpicDescription { get; set; } = string.Empty;
+    public double StoryPoints { get; set; }
+    public string[] Tags { get; set; } = Array.Empty<string>();
+    public List<WorkItemRelation> Relations { get; set; } = [];
+    public List<string> Comments { get; set; } = [];
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemRelation.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/WorkItemRelation.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services.Models;
+
+public class WorkItemRelation
+{
+    public string Rel { get; set; } = string.Empty;
+    public int TargetId { get; set; }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -209,3 +209,21 @@ body {
 .cursor-pointer { cursor: pointer; }
 .no-link-style { color: inherit; text-decoration: none; }
 .preview-box { margin-bottom: 0.5rem; border: 1px solid #ccc; padding: 4px; }
+
+.viewer-layout {
+    display: flex;
+    height: 80vh;
+}
+
+.viewer-list {
+    resize: horizontal;
+    overflow: auto;
+    min-width: 200px;
+    max-width: 400px;
+    margin-right: 1rem;
+}
+
+.viewer-details {
+    flex: 1;
+    overflow: auto;
+}


### PR DESCRIPTION
## Summary
- add a Work Item Viewer page
- add navigation entry and localization
- include simple page rendering test
- style viewer layout
- show tags, story points, relationships and comments on Work Item Viewer
- expose comments API

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68658d5479688328875e061a52577376