### PR TITLE
Add drag handles for requirement planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
@@ -17,4 +17,16 @@ public class PlanItemEditorTests : ComponentTestBase
 
         cut.Find("div.inner").MarkupMatches("<div class=\"inner\">content</div>");
     }
+
+    [Fact]
+    public void Shows_DragHandle_When_Draggable()
+    {
+        SetupServices();
+        var cut = RenderComponent<PlanItemEditor>(p => p
+            .Add(c => c.Type, "Epic")
+            .Add(c => c.Draggable, true)
+        );
+
+        Assert.NotNull(cut.Find(".drag-handle"));
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -2,8 +2,12 @@
 @using MudBlazor
 @using DevOpsAssistant.Utils
 
-<MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass(Type)}")" draggable="@Draggable" @ondragstart="DragStart" @ondrop="Drop" @ondragover:preventDefault>
+<MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass(Type)}")" @ondrop="OnDropInternal" @ondragover:preventDefault="Droppable">
     <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
+        @if (Draggable)
+        {
+            <MudIconButton Icon="@Icons.Material.Filled.DragIndicator" Class="drag-handle" draggable="true" @ondragstart="DragStart" Size="Size.Small" />
+        }
         <MudText Typo="@HeaderTypo">@Type</MudText>
         @if (OnDelete.HasDelegate)
         {
@@ -63,6 +67,7 @@
     [Parameter] public string Type { get; set; } = string.Empty;
     [Parameter] public bool Preview { get; set; }
     [Parameter] public bool Draggable { get; set; }
+    [Parameter] public bool Droppable { get; set; }
     [Parameter] public EventCallback DragStart { get; set; }
     [Parameter] public EventCallback Drop { get; set; }
     [Parameter] public EventCallback OnDelete { get; set; }
@@ -104,5 +109,12 @@
             return;
         Tags.Remove(tag);
         TagsChanged.InvokeAsync(Tags);
+    }
+
+    private Task OnDropInternal()
+    {
+        if (Droppable && Drop.HasDelegate)
+            return Drop.InvokeAsync();
+        return Task.CompletedTask;
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -97,6 +97,7 @@
                 {
                     <PlanItemEditor Type="User Story"
                                     Draggable="true"
+                                    Droppable="true"
                                     Preview="_previewHtml"
                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnStoryList(story))"
@@ -114,6 +115,7 @@
                 {
                     <PlanItemEditor Type="Epic"
                                     Draggable="true"
+                                    Droppable="true"
                                     Preview="_previewHtml"
                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(epic))"
                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnPlan(epic))"
@@ -125,6 +127,7 @@
                         {
                             <PlanItemEditor Type="Feature"
                                             Draggable="true"
+                                            Droppable="true"
                                             Preview="_previewHtml"
                                             DragStart="EventCallback.Factory.Create(this, () => OnDragStart(feature))"
                                             Drop="EventCallback.Factory.Create(this, () => OnDropOnEpic(epic))"
@@ -136,6 +139,7 @@
                                 {
                                     <PlanItemEditor Type="User Story"
                                                     Draggable="true"
+                                                    Droppable="true"
                                                     Preview="_previewHtml"
                                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
                                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnFeature(feature))"

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -207,6 +207,7 @@ body {
 .scroll-300 { max-height: 300px; overflow: auto; width: 100%; }
 .float-right { float: right; }
 .cursor-pointer { cursor: pointer; }
+.drag-handle { cursor: move; }
 .no-link-style { color: inherit; text-decoration: none; }
 .preview-box { margin-bottom: 0.5rem; border: 1px solid #ccc; padding: 4px; }
 


### PR DESCRIPTION
## Summary
- add drag handle to PlanItemEditor so users can move work items
- make droppable conditional
- update requirement planner markup to use new API
- style the drag handle
- test for drag handle rendering

## Testing
- `dotnet test DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6865a06fd02083288c1707a81eecde3c