### PR TITLE
Improve work item viewer

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.es.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="OpenLink" xml:space="preserve">
+    <value>Abrir en DevOps</value>
+  </data>
+  <data name="ReproStepsHeading" xml:space="preserve">
+    <value>Pasos de repro</value>
+  </data>
+  <data name="SystemInfoHeading" xml:space="preserve">
+    <value>Información del sistema</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="FeatureHeading" xml:space="preserve">
+    <value>Funcionalidad</value>
+  </data>
+  <data name="EpicHeading" xml:space="preserve">
+    <value>Épica</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relaciones</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
@@ -1,0 +1,82 @@
+@using DevOpsAssistant.Services.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<BugView> L
+
+<div class="work-item-view">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h5">@Details.Story.Title (@Details.Story.Id)</MudText>
+        <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
+        <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
+
+        <MudExpansionPanels>
+            @if (!string.IsNullOrWhiteSpace(Details.ReproSteps))
+            {
+                <MudExpansionPanel Text="@L["ReproStepsHeading"]">
+                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.ReproSteps)</MudPaper>
+                </MudExpansionPanel>
+            }
+            @if (!string.IsNullOrWhiteSpace(Details.SystemInfo))
+            {
+                <MudExpansionPanel Text="@L["SystemInfoHeading"]">
+                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.SystemInfo)</MudPaper>
+                </MudExpansionPanel>
+            }
+            @if (Details.Tags.Length > 0)
+            {
+                <MudExpansionPanel Text="@L["TagsHeading"]">
+                    <MudChipSet T="string">
+                        @foreach (var t in Details.Tags)
+                        {
+                            <MudChip T="string">@t</MudChip>
+                        }
+                    </MudChipSet>
+                </MudExpansionPanel>
+            }
+        </MudExpansionPanels>
+
+        @if (Details.Feature != null)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
+            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+            {
+                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+            }
+        }
+        @if (Details.Epic != null)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
+            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+            {
+                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+            }
+        }
+        @if (Details.Relations.Count > 0)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
+            <MudList T="WorkItemRelation">
+                @foreach (var r in Details.Relations)
+                {
+                    <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                }
+            </MudList>
+        }
+        @if (Details.Comments.Count > 0)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
+            <MudList T="string" Dense="true">
+                @foreach (var c in Details.Comments)
+                {
+                    <MudListItem T="string">@c</MudListItem>
+                }
+            </MudList>
+        }
+    </MudStack>
+</div>
+
+@code {
+    [Parameter] public StoryHierarchyDetails Details { get; set; } = new();
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.resx
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="OpenLink" xml:space="preserve">
+    <value>Open in DevOps</value>
+  </data>
+  <data name="ReproStepsHeading" xml:space="preserve">
+    <value>Repro Steps</value>
+  </data>
+  <data name="SystemInfoHeading" xml:space="preserve">
+    <value>System Info</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="FeatureHeading" xml:space="preserve">
+    <value>Feature</value>
+  </data>
+  <data name="EpicHeading" xml:space="preserve">
+    <value>Epic</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relationships</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.es.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="OpenLink" xml:space="preserve">
+    <value>Abrir en DevOps</value>
+  </data>
+  <data name="DescriptionHeading" xml:space="preserve">
+    <value>Descripción</value>
+  </data>
+  <data name="AcceptanceCriteriaHeading" xml:space="preserve">
+    <value>Criterios de aceptación</value>
+  </data>
+  <data name="StoryPointsHeading" xml:space="preserve">
+    <value>Puntos de historia</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Etiquetas</value>
+  </data>
+  <data name="FeatureHeading" xml:space="preserve">
+    <value>Funcionalidad</value>
+  </data>
+  <data name="EpicHeading" xml:space="preserve">
+    <value>Épica</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comentarios</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relaciones</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
@@ -1,0 +1,88 @@
+@using DevOpsAssistant.Services.Models
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<StoryView> L
+
+<div class="work-item-view">
+    <MudStack Spacing="2">
+        <MudText Typo="Typo.h5">@Details.Story.Title (@Details.Story.Id)</MudText>
+        <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
+        <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
+
+        <MudExpansionPanels>
+            @if (!string.IsNullOrWhiteSpace(Details.Description))
+            {
+                <MudExpansionPanel Text="@L["DescriptionHeading"]">
+                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.Description)</MudPaper>
+                </MudExpansionPanel>
+            }
+            @if (!string.IsNullOrWhiteSpace(Details.AcceptanceCriteria))
+            {
+                <MudExpansionPanel Text="@L["AcceptanceCriteriaHeading"]">
+                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.AcceptanceCriteria)</MudPaper>
+                </MudExpansionPanel>
+            }
+            @if (Details.StoryPoints > 0)
+            {
+                <MudExpansionPanel Text="@L["StoryPointsHeading"]">
+                    <MudText>@Details.StoryPoints</MudText>
+                </MudExpansionPanel>
+            }
+            @if (Details.Tags.Length > 0)
+            {
+                <MudExpansionPanel Text="@L["TagsHeading"]">
+                    <MudChipSet T="string">
+                        @foreach (var t in Details.Tags)
+                        {
+                            <MudChip T="string">@t</MudChip>
+                        }
+                    </MudChipSet>
+                </MudExpansionPanel>
+            }
+        </MudExpansionPanels>
+
+        @if (Details.Feature != null)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
+            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+            {
+                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+            }
+        }
+        @if (Details.Epic != null)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
+            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+            {
+                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+            }
+        }
+        @if (Details.Relations.Count > 0)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
+            <MudList T="WorkItemRelation">
+                @foreach (var r in Details.Relations)
+                {
+                    <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                }
+            </MudList>
+        }
+        @if (Details.Comments.Count > 0)
+        {
+            <MudDivider Class="my-2" />
+            <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
+            <MudList T="string" Dense="true">
+                @foreach (var c in Details.Comments)
+                {
+                    <MudListItem T="string">@c</MudListItem>
+                }
+            </MudList>
+        }
+    </MudStack>
+</div>
+
+@code {
+    [Parameter] public StoryHierarchyDetails Details { get; set; } = new();
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.resx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="OpenLink" xml:space="preserve">
+    <value>Open in DevOps</value>
+  </data>
+  <data name="DescriptionHeading" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="AcceptanceCriteriaHeading" xml:space="preserve">
+    <value>Acceptance Criteria</value>
+  </data>
+  <data name="StoryPointsHeading" xml:space="preserve">
+    <value>Story Points</value>
+  </data>
+  <data name="TagsHeading" xml:space="preserve">
+    <value>Tags</value>
+  </data>
+  <data name="FeatureHeading" xml:space="preserve">
+    <value>Feature</value>
+  </data>
+  <data name="EpicHeading" xml:space="preserve">
+    <value>Epic</value>
+  </data>
+  <data name="CommentsHeading" xml:space="preserve">
+    <value>Comments</value>
+  </data>
+  <data name="RelationshipsHeading" xml:space="preserve">
+    <value>Relationships</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.es.resx
@@ -27,4 +27,7 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relaciones</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirmar</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
@@ -1,5 +1,6 @@
 @page "/projects/{ProjectName}/work-item-viewer"
 @using DevOpsAssistant.Services.Models
+@using System.Linq
 @inject DevOpsApiService ApiService
 @inject PageStateService StateService
 @using Microsoft.Extensions.Localization
@@ -13,136 +14,64 @@
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
 }
 
-<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" />
+<WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnPendingItemsSelected" />
+@if (_filtersExpanded)
+{
+    <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmSelection" Disabled="@(!_pendingItems.Any())">@L["Confirm"]</MudButton>
+}
 
-<MudPaper Class="viewer-layout">
-    <div class="viewer-list">
-        <MudExpansionPanels>
-            <MudExpansionPanel Text="@L["SelectedItems"]" Expanded="@_listExpanded" ExpandedChanged="@(v => _listExpanded = v)">
-                <MudList T="WorkItemInfo" Dense="true">
-                    @foreach (var item in _selectedItems)
-                    {
-                        <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
-                            @item.Id - @item.Title
-                        </MudListItem>
-                    }
-                </MudList>
-            </MudExpansionPanel>
-        </MudExpansionPanels>
-    </div>
-    <div class="viewer-details">
-        @if (_loading)
-        {
-            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-        }
-        else if (_details != null)
-        {
-            <MudStack Spacing="2">
-                <MudText Typo="Typo.h5">@_details.Story.Title (@_details.Story.Id)</MudText>
-                <MudText Typo="Typo.subtitle2">@(_details.Story.WorkItemType) - @_details.Story.State</MudText>
-                <MudLink Href="@_details.Story.Url" Target="_blank">Open in DevOps</MudLink>
-                @if (!string.IsNullOrWhiteSpace(_details.Description))
-                {
-                    <MudText Typo="Typo.h6">Description</MudText>
-                    <MudPaper Class="pa-2" Style="overflow:auto">
-                        @((MarkupString)_details.Description)
-                    </MudPaper>
-                }
-                @if (!string.IsNullOrWhiteSpace(_details.AcceptanceCriteria))
-                {
-                    <MudText Typo="Typo.h6">Acceptance Criteria</MudText>
-                    <MudPaper Class="pa-2" Style="overflow:auto">
-                        @((MarkupString)_details.AcceptanceCriteria)
-                    </MudPaper>
-                }
-                @if (_details.StoryPoints > 0)
-                {
-                    <MudText Typo="Typo.h6">@L["StoryPointsLabel"]: @_details.StoryPoints</MudText>
-                }
-                @if (_details.Tags.Length > 0)
-                {
-                    <MudText Typo="Typo.h6">@L["TagsHeading"]</MudText>
-                    <MudChipSet T="string">
-                        @foreach (var t in _details.Tags)
+<MudDrawerContainer Style="height:80vh;">
+<MudDrawer @bind-Open="_listOpen" Anchor="Anchor.Left" Variant="DrawerVariant.Responsive" Elevation="1" Style="width:300px;">
+        <MudStack Spacing="1" Class="pa-2">
+            <MudIconButton Icon="@(_listOpen ? Icons.Material.Filled.ChevronLeft : Icons.Material.Filled.ChevronRight)" OnClick="ToggleList" />
+            <MudExpansionPanels>
+                <MudExpansionPanel Text="@L["SelectedItems"]" Expanded="@_listExpanded" ExpandedChanged="@(v => _listExpanded = v)">
+                    <MudList T="WorkItemInfo" Dense="true">
+                        @foreach (var item in _selectedItems)
                         {
-                            <MudChip T="string">@t</MudChip>
-                        }
-                    </MudChipSet>
-                }
-                @if (!string.IsNullOrWhiteSpace(_details.ReproSteps))
-                {
-                    <MudText Typo="Typo.h6">Repro Steps</MudText>
-                    <MudPaper Class="pa-2" Style="overflow:auto">
-                        @((MarkupString)_details.ReproSteps)
-                    </MudPaper>
-                }
-                @if (!string.IsNullOrWhiteSpace(_details.SystemInfo))
-                {
-                    <MudText Typo="Typo.h6">System Info</MudText>
-                    <MudPaper Class="pa-2" Style="overflow:auto">
-                        @((MarkupString)_details.SystemInfo)
-                    </MudPaper>
-                }
-                @if (_details.Feature != null)
-                {
-                    <MudDivider Class="my-2" />
-                    <MudText Typo="Typo.subtitle1">Feature: @_details.Feature.Title (@_details.Feature.State)</MudText>
-                    @if (!string.IsNullOrWhiteSpace(_details.FeatureDescription))
-                    {
-                        <MudPaper Class="pa-2" Style="overflow:auto">
-                            @((MarkupString)_details.FeatureDescription)
-                        </MudPaper>
-                    }
-                }
-                @if (_details.Epic != null)
-                {
-                    <MudDivider Class="my-2" />
-                    <MudText Typo="Typo.subtitle1">Epic: @_details.Epic.Title (@_details.Epic.State)</MudText>
-                    @if (!string.IsNullOrWhiteSpace(_details.EpicDescription))
-                    {
-                        <MudPaper Class="pa-2" Style="overflow:auto">
-                            @((MarkupString)_details.EpicDescription)
-                        </MudPaper>
-                    }
-                }
-                @if (_details.Relations.Count > 0)
-                {
-                    <MudDivider Class="my-2" />
-                    <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
-                    <MudList T="WorkItemRelation">
-                        @foreach (var r in _details.Relations)
-                        {
-                            <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                            <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
+                                @item.Id - @item.Title
+                            </MudListItem>
                         }
                     </MudList>
-                }
-                @if (_details.Comments.Count > 0)
+                </MudExpansionPanel>
+            </MudExpansionPanels>
+        </MudStack>
+    </MudDrawer>
+    <MudMainContent>
+        <div style="overflow:auto;height:80vh;">
+            @if (_loading)
+            {
+                <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+            }
+            else if (_details != null)
+            {
+                if (string.Equals(_details.Story.WorkItemType, "Bug", StringComparison.OrdinalIgnoreCase))
                 {
-                    <MudDivider Class="my-2" />
-                    <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
-                    <MudList T="string" Dense="true">
-                        @foreach (var c in _details.Comments)
-                        {
-                            <MudListItem T="string">@c</MudListItem>
-                        }
-                    </MudList>
+                    <BugView Details="_details" />
                 }
-            </MudStack>
-        }
-        else
-        {
-            <MudText>Select an item to view details.</MudText>
-        }
-    </div>
-</MudPaper>
+                else
+                {
+                    <StoryView Details="_details" />
+                }
+            }
+            else
+            {
+                <MudText>Select an item to view details.</MudText>
+            }
+        </div>
+    </MudMainContent>
+</MudDrawerContainer>
 
 @code {
     [Parameter] public string ProjectName { get; set; } = string.Empty;
 
     private readonly HashSet<WorkItemInfo> _selectedItems = [];
+    private IReadOnlyCollection<WorkItemInfo> _pendingItems = Array.Empty<WorkItemInfo>();
     private bool _loading;
     private bool _filtersExpanded = true;
     private bool _listExpanded = true;
+    private bool _listOpen = true;
     private StoryHierarchyDetails? _details;
     private string? _error;
 
@@ -155,16 +84,25 @@
         }
     }
 
-    private Task OnWorkItemsSelected(IReadOnlyCollection<WorkItemInfo> items)
+    private Task OnPendingItemsSelected(IReadOnlyCollection<WorkItemInfo> items)
+    {
+        _pendingItems = items;
+        return Task.CompletedTask;
+    }
+
+    private Task ConfirmSelection()
     {
         _selectedItems.Clear();
-        foreach (var i in items)
+        foreach (var i in _pendingItems)
             _selectedItems.Add(i);
         var first = _selectedItems.FirstOrDefault();
         if (first != null)
             _ = LoadDetails(first.Id);
+        _filtersExpanded = false;
         return Task.CompletedTask;
     }
+
+    private void ToggleList() => _listOpen = !_listOpen;
 
     private async Task LoadDetails(int id)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.resx
@@ -27,4 +27,7 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relationships</value>
   </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Confirm</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/_Imports.razor
@@ -10,5 +10,6 @@
 @using DevOpsAssistant.Layout
 @using DevOpsAssistant.Services
 @using DevOpsAssistant.Components
+@using DevOpsAssistant.Components.WorkItems
 @using MudBlazor
 @using DevOpsAssistant.Utils

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -210,20 +210,3 @@ body {
 .no-link-style { color: inherit; text-decoration: none; }
 .preview-box { margin-bottom: 0.5rem; border: 1px solid #ccc; padding: 4px; }
 
-.viewer-layout {
-    display: flex;
-    height: 80vh;
-}
-
-.viewer-list {
-    resize: horizontal;
-    overflow: auto;
-    min-width: 200px;
-    max-width: 400px;
-    margin-right: 1rem;
-}
-
-.viewer-details {
-    flex: 1;
-    overflow: auto;
-}


### PR DESCRIPTION
## Summary
- collapse work item list using `MudDrawer` instead of CSS
- retain Azure DevOps-style item details via `BugView` and `StoryView`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68659ea57f888328a5ce249c1054e015