### PR TITLE
Improve work item viewer layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
@@ -8,31 +8,26 @@
         <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
         <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
 
-        <MudExpansionPanels>
-            @if (!string.IsNullOrWhiteSpace(Details.ReproSteps))
-            {
-                <MudExpansionPanel Text="@L["ReproStepsHeading"]">
-                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.ReproSteps)</MudPaper>
-                </MudExpansionPanel>
-            }
-            @if (!string.IsNullOrWhiteSpace(Details.SystemInfo))
-            {
-                <MudExpansionPanel Text="@L["SystemInfoHeading"]">
-                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.SystemInfo)</MudPaper>
-                </MudExpansionPanel>
-            }
-            @if (Details.Tags.Length > 0)
-            {
-                <MudExpansionPanel Text="@L["TagsHeading"]">
-                    <MudChipSet T="string">
-                        @foreach (var t in Details.Tags)
-                        {
-                            <MudChip T="string">@t</MudChip>
-                        }
-                    </MudChipSet>
-                </MudExpansionPanel>
-            }
-        </MudExpansionPanels>
+        @if (!string.IsNullOrWhiteSpace(Details.ReproSteps))
+        {
+            <MudText Typo="Typo.subtitle1">@L["ReproStepsHeading"]</MudText>
+            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.ReproSteps)</MudPaper>
+        }
+        @if (!string.IsNullOrWhiteSpace(Details.SystemInfo))
+        {
+            <MudText Typo="Typo.subtitle1">@L["SystemInfoHeading"]</MudText>
+            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.SystemInfo)</MudPaper>
+        }
+        @if (Details.Tags.Length > 0)
+        {
+            <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
+            <MudChipSet T="string">
+                @foreach (var t in Details.Tags)
+                {
+                    <MudChip T="string">@t</MudChip>
+                }
+            </MudChipSet>
+        }
 
         @if (Details.Feature != null)
         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
@@ -8,37 +8,31 @@
         <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
         <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
 
-        <MudExpansionPanels>
-            @if (!string.IsNullOrWhiteSpace(Details.Description))
-            {
-                <MudExpansionPanel Text="@L["DescriptionHeading"]">
-                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.Description)</MudPaper>
-                </MudExpansionPanel>
-            }
-            @if (!string.IsNullOrWhiteSpace(Details.AcceptanceCriteria))
-            {
-                <MudExpansionPanel Text="@L["AcceptanceCriteriaHeading"]">
-                    <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.AcceptanceCriteria)</MudPaper>
-                </MudExpansionPanel>
-            }
-            @if (Details.StoryPoints > 0)
-            {
-                <MudExpansionPanel Text="@L["StoryPointsHeading"]">
-                    <MudText>@Details.StoryPoints</MudText>
-                </MudExpansionPanel>
-            }
-            @if (Details.Tags.Length > 0)
-            {
-                <MudExpansionPanel Text="@L["TagsHeading"]">
-                    <MudChipSet T="string">
-                        @foreach (var t in Details.Tags)
-                        {
-                            <MudChip T="string">@t</MudChip>
-                        }
-                    </MudChipSet>
-                </MudExpansionPanel>
-            }
-        </MudExpansionPanels>
+        @if (!string.IsNullOrWhiteSpace(Details.Description))
+        {
+            <MudText Typo="Typo.subtitle1">@L["DescriptionHeading"]</MudText>
+            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.Description)</MudPaper>
+        }
+        @if (!string.IsNullOrWhiteSpace(Details.AcceptanceCriteria))
+        {
+            <MudText Typo="Typo.subtitle1">@L["AcceptanceCriteriaHeading"]</MudText>
+            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.AcceptanceCriteria)</MudPaper>
+        }
+        @if (Details.StoryPoints > 0)
+        {
+            <MudText Typo="Typo.subtitle1">@L["StoryPointsHeading"]</MudText>
+            <MudText>@Details.StoryPoints</MudText>
+        }
+        @if (Details.Tags.Length > 0)
+        {
+            <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
+            <MudChipSet T="string">
+                @foreach (var t in Details.Tags)
+                {
+                    <MudChip T="string">@t</MudChip>
+                }
+            </MudChipSet>
+        }
 
         @if (Details.Feature != null)
         {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
@@ -20,26 +20,22 @@
     <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ConfirmSelection" Disabled="@(!_pendingItems.Any())">@L["Confirm"]</MudButton>
 }
 
-<MudDrawerContainer Style="height:80vh;">
-<MudDrawer @bind-Open="_listOpen" Anchor="Anchor.Left" Variant="DrawerVariant.Responsive" Elevation="1" Style="width:300px;">
-        <MudStack Spacing="1" Class="pa-2">
-            <MudIconButton Icon="@(_listOpen ? Icons.Material.Filled.ChevronLeft : Icons.Material.Filled.ChevronRight)" OnClick="ToggleList" />
-            <MudExpansionPanels>
-                <MudExpansionPanel Text="@L["SelectedItems"]" Expanded="@_listExpanded" ExpandedChanged="@(v => _listExpanded = v)">
-                    <MudList T="WorkItemInfo" Dense="true">
-                        @foreach (var item in _selectedItems)
-                        {
-                            <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
-                                @item.Id - @item.Title
-                            </MudListItem>
-                        }
-                    </MudList>
-                </MudExpansionPanel>
-            </MudExpansionPanels>
-        </MudStack>
-    </MudDrawer>
-    <MudMainContent>
-        <div style="overflow:auto;height:80vh;">
+<MudGrid Class="mt-4">
+    <MudItem xs="12" md="4" lg="3">
+        <MudPaper Class="pa-2" Style="height:80vh; overflow:auto;">
+            <MudText Typo="Typo.h6">@L["SelectedItems"]</MudText>
+            <MudList T="WorkItemInfo" Dense="true">
+                @foreach (var item in _selectedItems)
+                {
+                    <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
+                        @item.Id - @item.Title
+                    </MudListItem>
+                }
+            </MudList>
+        </MudPaper>
+    </MudItem>
+    <MudItem xs="12" md="8" lg="9">
+        <MudPaper Class="pa-2" Style="height:80vh; overflow:auto;">
             @if (_loading)
             {
                 <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
@@ -59,9 +55,9 @@
             {
                 <MudText>Select an item to view details.</MudText>
             }
-        </div>
-    </MudMainContent>
-</MudDrawerContainer>
+        </MudPaper>
+    </MudItem>
+</MudGrid>
 
 @code {
     [Parameter] public string ProjectName { get; set; } = string.Empty;
@@ -70,8 +66,6 @@
     private IReadOnlyCollection<WorkItemInfo> _pendingItems = Array.Empty<WorkItemInfo>();
     private bool _loading;
     private bool _filtersExpanded = true;
-    private bool _listExpanded = true;
-    private bool _listOpen = true;
     private StoryHierarchyDetails? _details;
     private string? _error;
 
@@ -102,7 +96,6 @@
         return Task.CompletedTask;
     }
 
-    private void ToggleList() => _listOpen = !_listOpen;
 
     private async Task LoadDetails(int id)
     {


### PR DESCRIPTION
## Summary
- show selected work items in grid
- show details without collapsed panels

## Testing
- `dotnet restore src/DevOpsAssistant/DevOpsAssistant.sln --no-cache`
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686630e3dda08328bbf49dd96d35d272