### PR TITLE
Add work item color classes and tabbed templates

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.es.resx
@@ -36,4 +36,10 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relaciones</value>
   </data>
+  <data name="DetailsTab" xml:space="preserve">
+    <value>Detalles</value>
+  </data>
+  <data name="HierarchyTab" xml:space="preserve">
+    <value>Jerarquía</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.razor
@@ -1,74 +1,84 @@
 @using DevOpsAssistant.Services.Models
+@using DevOpsAssistant.Services
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<BugView> L
 
-<div class="work-item-view">
+<div class="@($"work-item-view {WorkItemHelpers.GetItemClass(Details.Story.WorkItemType)}")">
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@Details.Story.Title (@Details.Story.Id)</MudText>
         <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
         <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
-
-        @if (!string.IsNullOrWhiteSpace(Details.ReproSteps))
-        {
-            <MudText Typo="Typo.subtitle1">@L["ReproStepsHeading"]</MudText>
-            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.ReproSteps)</MudPaper>
-        }
-        @if (!string.IsNullOrWhiteSpace(Details.SystemInfo))
-        {
-            <MudText Typo="Typo.subtitle1">@L["SystemInfoHeading"]</MudText>
-            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.SystemInfo)</MudPaper>
-        }
-        @if (Details.Tags.Length > 0)
-        {
-            <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
-            <MudChipSet T="string">
-                @foreach (var t in Details.Tags)
-                {
-                    <MudChip T="string">@t</MudChip>
-                }
-            </MudChipSet>
-        }
-
-        @if (Details.Feature != null)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
-            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+        <MudTabs>
+            <MudTabPanel Text="@L["DetailsTab"]">
+                <MudStack Spacing="2">
+                    @if (!string.IsNullOrWhiteSpace(Details.ReproSteps))
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["ReproStepsHeading"]</MudText>
+                        <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.ReproSteps)</MudPaper>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(Details.SystemInfo))
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["SystemInfoHeading"]</MudText>
+                        <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.SystemInfo)</MudPaper>
+                    }
+                    @if (Details.Tags.Length > 0)
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
+                        <MudChipSet T="string">
+                            @foreach (var t in Details.Tags)
+                            {
+                                <MudChip T="string">@t</MudChip>
+                            }
+                        </MudChipSet>
+                    }
+                </MudStack>
+            </MudTabPanel>
+            @if (Details.Feature != null || Details.Epic != null)
             {
-                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+                <MudTabPanel Text="@L["HierarchyTab"]">
+                    <MudStack Spacing="2">
+                        @if (Details.Feature != null)
+                        {
+                            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
+                            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+                            {
+                                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+                            }
+                        }
+                        @if (Details.Epic != null)
+                        {
+                            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
+                            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+                            {
+                                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+                            }
+                        }
+                    </MudStack>
+                </MudTabPanel>
             }
-        }
-        @if (Details.Epic != null)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
-            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+            @if (Details.Relations.Count > 0)
             {
-                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+                <MudTabPanel Text="@L["RelationshipsHeading"]">
+                    <MudList T="WorkItemRelation">
+                        @foreach (var r in Details.Relations)
+                        {
+                            <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                        }
+                    </MudList>
+                </MudTabPanel>
             }
-        }
-        @if (Details.Relations.Count > 0)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
-            <MudList T="WorkItemRelation">
-                @foreach (var r in Details.Relations)
-                {
-                    <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
-                }
-            </MudList>
-        }
-        @if (Details.Comments.Count > 0)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
-            <MudList T="string" Dense="true">
-                @foreach (var c in Details.Comments)
-                {
-                    <MudListItem T="string">@c</MudListItem>
-                }
-            </MudList>
-        }
+            @if (Details.Comments.Count > 0)
+            {
+                <MudTabPanel Text="@L["CommentsHeading"]">
+                    <MudList T="string" Dense="true">
+                        @foreach (var c in Details.Comments)
+                        {
+                            <MudListItem T="string">@c</MudListItem>
+                        }
+                    </MudList>
+                </MudTabPanel>
+            }
+        </MudTabs>
     </MudStack>
 </div>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/BugView.resx
@@ -36,4 +36,10 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relationships</value>
   </data>
+  <data name="DetailsTab" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="HierarchyTab" xml:space="preserve">
+    <value>Hierarchy</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.es.resx
@@ -39,4 +39,10 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relaciones</value>
   </data>
+  <data name="DetailsTab" xml:space="preserve">
+    <value>Detalles</value>
+  </data>
+  <data name="HierarchyTab" xml:space="preserve">
+    <value>Jerarquía</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.razor
@@ -1,79 +1,89 @@
 @using DevOpsAssistant.Services.Models
+@using DevOpsAssistant.Services
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<StoryView> L
 
-<div class="work-item-view">
+<div class="@($"work-item-view {WorkItemHelpers.GetItemClass(Details.Story.WorkItemType)}")">
     <MudStack Spacing="2">
         <MudText Typo="Typo.h5">@Details.Story.Title (@Details.Story.Id)</MudText>
         <MudText Typo="Typo.subtitle2">@Details.Story.WorkItemType - @Details.Story.State</MudText>
         <MudLink Href="@Details.Story.Url" Target="_blank">@L["OpenLink"]</MudLink>
-
-        @if (!string.IsNullOrWhiteSpace(Details.Description))
-        {
-            <MudText Typo="Typo.subtitle1">@L["DescriptionHeading"]</MudText>
-            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.Description)</MudPaper>
-        }
-        @if (!string.IsNullOrWhiteSpace(Details.AcceptanceCriteria))
-        {
-            <MudText Typo="Typo.subtitle1">@L["AcceptanceCriteriaHeading"]</MudText>
-            <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.AcceptanceCriteria)</MudPaper>
-        }
-        @if (Details.StoryPoints > 0)
-        {
-            <MudText Typo="Typo.subtitle1">@L["StoryPointsHeading"]</MudText>
-            <MudText>@Details.StoryPoints</MudText>
-        }
-        @if (Details.Tags.Length > 0)
-        {
-            <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
-            <MudChipSet T="string">
-                @foreach (var t in Details.Tags)
-                {
-                    <MudChip T="string">@t</MudChip>
-                }
-            </MudChipSet>
-        }
-
-        @if (Details.Feature != null)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
-            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+        <MudTabs>
+            <MudTabPanel Text="@L["DetailsTab"]">
+                <MudStack Spacing="2">
+                    @if (!string.IsNullOrWhiteSpace(Details.Description))
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["DescriptionHeading"]</MudText>
+                        <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.Description)</MudPaper>
+                    }
+                    @if (!string.IsNullOrWhiteSpace(Details.AcceptanceCriteria))
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["AcceptanceCriteriaHeading"]</MudText>
+                        <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.AcceptanceCriteria)</MudPaper>
+                    }
+                    @if (Details.StoryPoints > 0)
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["StoryPointsHeading"]</MudText>
+                        <MudText>@Details.StoryPoints</MudText>
+                    }
+                    @if (Details.Tags.Length > 0)
+                    {
+                        <MudText Typo="Typo.subtitle1">@L["TagsHeading"]</MudText>
+                        <MudChipSet T="string">
+                            @foreach (var t in Details.Tags)
+                            {
+                                <MudChip T="string">@t</MudChip>
+                            }
+                        </MudChipSet>
+                    }
+                </MudStack>
+            </MudTabPanel>
+            @if (Details.Feature != null || Details.Epic != null)
             {
-                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+                <MudTabPanel Text="@L["HierarchyTab"]">
+                    <MudStack Spacing="2">
+                        @if (Details.Feature != null)
+                        {
+                            <MudText Typo="Typo.subtitle1">@L["FeatureHeading"]: @Details.Feature.Title (@Details.Feature.State)</MudText>
+                            @if (!string.IsNullOrWhiteSpace(Details.FeatureDescription))
+                            {
+                                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.FeatureDescription)</MudPaper>
+                            }
+                        }
+                        @if (Details.Epic != null)
+                        {
+                            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
+                            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+                            {
+                                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+                            }
+                        }
+                    </MudStack>
+                </MudTabPanel>
             }
-        }
-        @if (Details.Epic != null)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.subtitle1">@L["EpicHeading"]: @Details.Epic.Title (@Details.Epic.State)</MudText>
-            @if (!string.IsNullOrWhiteSpace(Details.EpicDescription))
+            @if (Details.Relations.Count > 0)
             {
-                <MudPaper Class="pa-2 scroll-300">@((MarkupString)Details.EpicDescription)</MudPaper>
+                <MudTabPanel Text="@L["RelationshipsHeading"]">
+                    <MudList T="WorkItemRelation">
+                        @foreach (var r in Details.Relations)
+                        {
+                            <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
+                        }
+                    </MudList>
+                </MudTabPanel>
             }
-        }
-        @if (Details.Relations.Count > 0)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.h6">@L["RelationshipsHeading"]</MudText>
-            <MudList T="WorkItemRelation">
-                @foreach (var r in Details.Relations)
-                {
-                    <MudListItem T="WorkItemRelation">@r.Rel - @r.TargetId</MudListItem>
-                }
-            </MudList>
-        }
-        @if (Details.Comments.Count > 0)
-        {
-            <MudDivider Class="my-2" />
-            <MudText Typo="Typo.h6">@L["CommentsHeading"]</MudText>
-            <MudList T="string" Dense="true">
-                @foreach (var c in Details.Comments)
-                {
-                    <MudListItem T="string">@c</MudListItem>
-                }
-            </MudList>
-        }
+            @if (Details.Comments.Count > 0)
+            {
+                <MudTabPanel Text="@L["CommentsHeading"]">
+                    <MudList T="string" Dense="true">
+                        @foreach (var c in Details.Comments)
+                        {
+                            <MudListItem T="string">@c</MudListItem>
+                        }
+                    </MudList>
+                </MudTabPanel>
+            }
+        </MudTabs>
     </MudStack>
 </div>
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WorkItems/StoryView.resx
@@ -39,4 +39,10 @@
   <data name="RelationshipsHeading" xml:space="preserve">
     <value>Relationships</value>
   </data>
+  <data name="DetailsTab" xml:space="preserve">
+    <value>Details</value>
+  </data>
+  <data name="HierarchyTab" xml:space="preserve">
+    <value>Hierarchy</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemViewer.razor
@@ -27,7 +27,9 @@
             <MudList T="WorkItemInfo" Dense="true">
                 @foreach (var item in _selectedItems)
                 {
-                    <MudListItem T="WorkItemInfo" Class="cursor-pointer" OnClick="() => LoadDetails(item.Id)">
+                    <MudListItem T="WorkItemInfo"
+                                 Class="@($"cursor-pointer {WorkItemHelpers.GetItemClass(item.WorkItemType)}")"
+                                 OnClick="() => LoadDetails(item.Id)">
                         @item.Id - @item.Title
                     </MudListItem>
                 }


### PR DESCRIPTION
## Summary
- show work item colours in viewer list
- use colour classes on full work item view
- switch story and bug views to use tabs
- localize new tab labels

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj`

------
https://chatgpt.com/codex/tasks/task_e_6866372dc9908328b97d5dca7339c62b