### PR TITLE
Organize prompt settings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.UiTests/UiTests.cs
@@ -266,6 +266,23 @@ public class UiTests
     }
 
     [Fact]
+    public async Task ProjectSettings_Has_CopyPrompts_Button()
+    {
+        if (string.IsNullOrEmpty(_baseUrl))
+            return;
+
+        using var playwright = await Playwright.CreateAsync();
+        await using var browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+        var page = await browser.NewPageAsync();
+        await page.GotoAsync(_baseUrl);
+        await page.EvaluateAsync("localStorage.setItem('devops-config', JSON.stringify({ Organization: 'Org', Project: 'Proj', PatToken: 'Token' }))");
+        await page.ReloadAsync();
+        await page.GotoAsync(_baseUrl.TrimEnd('/') + "/projects/Proj/settings");
+        var button = await page.QuerySelectorAsync("text=Copy Prompts");
+        Assert.NotNull(button);
+    }
+
+    [Fact]
     public async Task Footer_Displays_Version()
     {
         if (string.IsNullOrEmpty(_baseUrl))

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -135,6 +135,12 @@
   <data name="ApplyToAll" xml:space="preserve">
     <value>Aplicar a todos los proyectos</value>
   </data>
+  <data name="CopyPrompts" xml:space="preserve">
+    <value>Copiar Prompts</value>
+  </data>
+  <data name="PromptsCopied" xml:space="preserve">
+    <value>Prompts copiados al portapapeles</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -7,6 +7,9 @@
 @inject ISnackbar Snackbar
 @inject IDialogService DialogService
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JS
+@using System.Text
+@using System.Text.RegularExpressions
 @using Microsoft.AspNetCore.Components.Routing
 
 <PageTitle>DevOpsAssistant - Settings</PageTitle>
@@ -83,47 +86,59 @@
                         <MudSelectItem Value="OutputFormat.Html">HTML</MudSelectItem>
                         <MudSelectItem Value="OutputFormat.Inline">Inline</MudSelectItem>
                     </MudSelect>
-                    <MudStack Spacing="1">
-                        <MudText Typo="Typo.h6">@L["RequirementsDocumentationGroup"]</MudText>
-                        @foreach (var opt in StandardOptions.Where(o => o.Group == "requirements_documentation"))
-                        {
-                            <MudTooltip Text="@opt.Description">
-                                <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
-                            </MudTooltip>
-                        }
-
-                        <MudText Typo="Typo.h6">@L["UserStoryDescriptionGroup"]</MudText>
-                        @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_description"))
-                        {
-                            <MudTooltip Text="@opt.Description">
-                                <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
-                            </MudTooltip>
-                        }
-
-                        <MudText Typo="Typo.h6">@L["UserStoryAcceptanceCriteriaGroup"]</MudText>
-                        @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_acceptance_criteria"))
-                        {
-                            <MudTooltip Text="@opt.Description">
-                                <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
-                            </MudTooltip>
-                        }
-
-                        <MudText Typo="Typo.h6">@L["UserStoryQualityGroup"]</MudText>
-                        @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_quality"))
-                        {
-                            <MudTooltip Text="@opt.Description">
-                                <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
-                            </MudTooltip>
-                        }
-
-                        <MudText Typo="Typo.h6">@L["BugReportingGroup"]</MudText>
-                        @foreach (var opt in StandardOptions.Where(o => o.Group == "bug_reporting"))
-                        {
-                            <MudTooltip Text="@opt.Description">
-                                <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
-                            </MudTooltip>
-                        }
-                    </MudStack>
+                    <MudTabs @bind-ActivePanelIndex="_standardsTab">
+                        <MudTabPanel Text='@L["RequirementsDocumentationGroup"]'>
+                            <MudStack Spacing="1">
+                                @foreach (var opt in StandardOptions.Where(o => o.Group == "requirements_documentation"))
+                                {
+                                    <MudTooltip Text="@opt.Description">
+                                        <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
+                                    </MudTooltip>
+                                }
+                            </MudStack>
+                        </MudTabPanel>
+                        <MudTabPanel Text='@L["UserStoryDescriptionGroup"]'>
+                            <MudStack Spacing="1">
+                                @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_description"))
+                                {
+                                    <MudTooltip Text="@opt.Description">
+                                        <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
+                                    </MudTooltip>
+                                }
+                            </MudStack>
+                        </MudTabPanel>
+                        <MudTabPanel Text='@L["UserStoryAcceptanceCriteriaGroup"]'>
+                            <MudStack Spacing="1">
+                                @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_acceptance_criteria"))
+                                {
+                                    <MudTooltip Text="@opt.Description">
+                                        <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
+                                    </MudTooltip>
+                                }
+                            </MudStack>
+                        </MudTabPanel>
+                        <MudTabPanel Text='@L["UserStoryQualityGroup"]'>
+                            <MudStack Spacing="1">
+                                @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_quality"))
+                                {
+                                    <MudTooltip Text="@opt.Description">
+                                        <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
+                                    </MudTooltip>
+                                }
+                            </MudStack>
+                        </MudTabPanel>
+                        <MudTabPanel Text='@L["BugReportingGroup"]'>
+                            <MudStack Spacing="1">
+                                @foreach (var opt in StandardOptions.Where(o => o.Group == "bug_reporting"))
+                                {
+                                    <MudTooltip Text="@opt.Description">
+                                        <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
+                                    </MudTooltip>
+                                }
+                            </MudStack>
+                        </MudTabPanel>
+                    </MudTabs>
+                    <MudButton OnClick="CopyAllPrompts" Variant="Variant.Outlined" Color="Color.Primary">@L["CopyPrompts"]</MudButton>
                     <MudButton OnClick="SavePrompts" Variant="Variant.Filled" Color="Color.Primary" Disabled="!_promptsDirty">@L["Save"]</MudButton>
                     <MudButton OnClick="ApplyPromptsToAll" Variant="Variant.Outlined" Color="Color.Primary">@L["ApplyToAll"]</MudButton>
                 </MudStack>
@@ -184,6 +199,7 @@
     private bool _validationDirty;
     private bool _generalDirty;
     private int _activeTab;
+    private int _standardsTab;
     private static readonly StandardOption[] StandardOptions = StandardsCatalog.Options;
     private HashSet<string> _selectedStandards = new();
 
@@ -339,6 +355,31 @@
             }
             Snackbar.Add(string.Format(L["SectionSaved"].Value, L["PromptsTab"].Value, L["AllProjects"].Value), Severity.Success);
         }
+    }
+
+    private async Task CopyAllPrompts()
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"### {L["StoryQualityPrompt"].Value}");
+        sb.AppendLine(WithDummyData(_model.StoryQualityPrompt));
+        sb.AppendLine("---");
+        sb.AppendLine($"### {L["ReleaseNotesPrompt"].Value}");
+        sb.AppendLine(WithDummyData(_model.ReleaseNotesPrompt));
+        sb.AppendLine("---");
+        sb.AppendLine($"### {L["RequirementsPrompt"].Value}");
+        sb.AppendLine(WithDummyData(_model.RequirementsPrompt));
+        await JS.InvokeVoidAsync("copyText", sb.ToString());
+        Snackbar.Add(L["PromptsCopied"].Value, Severity.Success);
+    }
+
+    private static readonly Regex Curly = new("\\{\\{.*?\\}}", RegexOptions.Compiled);
+    private static readonly Regex Brackets = new("\\[.*?\\]", RegexOptions.Compiled);
+
+    private static string WithDummyData(string text)
+    {
+        var result = Curly.Replace(text, "dummy");
+        result = Brackets.Replace(result, "sample");
+        return result;
     }
 
     private async Task ApplyValidationToAll()

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -135,6 +135,12 @@
   <data name="ApplyToAll" xml:space="preserve">
     <value>Apply to all projects</value>
   </data>
+  <data name="CopyPrompts" xml:space="preserve">
+    <value>Copy Prompts</value>
+  </data>
+  <data name="PromptsCopied" xml:space="preserve">
+    <value>Prompts copied to clipboard</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
   </data>


### PR DESCRIPTION
## Summary
- organize standards checkboxes into tabs
- add Copy Prompts button and dummy data helper
- localize new strings
- test for Copy Prompts button

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6866dcc244f88328b00fa5471b145386