### PR TITLE
Apply analyzer suggestions

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/ChartDialogTests.cs
@@ -32,8 +32,8 @@ public class ChartDialogTests : ComponentTestBase
             .AddCascadingValue(fake)
             .Add(p => p.Title, "Test Chart")
             .Add(p => p.ChartType, ChartType.Line)
-            .Add(p => p.ChartSeries, new List<ChartSeries>())
-            .Add(p => p.XAxisLabels, Array.Empty<string>())
+            .Add(p => p.ChartSeries, [])
+            .Add(p => p.XAxisLabels, [])
             .Add(p => p.AxisChartOptions, new AxisChartOptions())
         );
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/GlobalOptionsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/GlobalOptionsDialogTests.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using System.Reflection;
 using Bunit;
 using DevOpsAssistant.Components;
 using DevOpsAssistant.Tests.Utils;
@@ -31,9 +32,9 @@ public class GlobalOptionsDialogTests : ComponentTestBase
         var fake = new FakeDialog();
         var cut = RenderComponent<GlobalOptionsDialog>(p => p.AddCascadingValue(fake));
 
-        var field = cut.Instance.GetType().GetField("_culture", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var field = cut.Instance.GetType().GetField("_culture", BindingFlags.NonPublic | BindingFlags.Instance)!;
         field.SetValue(cut.Instance, "es");
-        var method = cut.Instance.GetType().GetMethod("Save", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var method = cut.Instance.GetType().GetMethod("Save", BindingFlags.NonPublic | BindingFlags.Instance)!;
 
         await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, null)!);
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/WorkItemSelectorTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 using Bunit;
 using DevOpsAssistant.Components;
 using DevOpsAssistant.Services;
@@ -124,12 +125,12 @@ public class WorkItemSelectorTests : ComponentTestBase
             sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var cut = RenderWithProvider<WorkItemSelector>();
-        var field = cut.Instance.GetType().GetField("_tag", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var field = cut.Instance.GetType().GetField("_tag", BindingFlags.NonPublic | BindingFlags.Instance);
         field!.SetValue(cut.Instance, "UI");
-        var method = cut.Instance.GetType().GetMethod("LoadTag", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var method = cut.Instance.GetType().GetMethod("LoadTag", BindingFlags.NonPublic | BindingFlags.Instance);
         await cut.InvokeAsync(async () => await (Task)method!.Invoke(cut.Instance, null)!);
-        var setField = cut.Instance.GetType().GetField("_tagSelected", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var selected = (System.Collections.Generic.HashSet<DevOpsAssistant.Services.Models.WorkItemInfo>)setField!.GetValue(cut.Instance)!;
+        var setField = cut.Instance.GetType().GetField("_tagSelected", BindingFlags.NonPublic | BindingFlags.Instance);
+        var selected = (HashSet<WorkItemInfo>)setField!.GetValue(cut.Instance)!;
 
         Assert.Single(selected);
         Assert.Equal(5, selected.First().Id);
@@ -171,12 +172,12 @@ public class WorkItemSelectorTests : ComponentTestBase
             sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var cut = RenderWithProvider<WorkItemSelector>();
-        var queryField = cut.Instance.GetType().GetField("_query", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var queryField = cut.Instance.GetType().GetField("_query", BindingFlags.NonPublic | BindingFlags.Instance);
         queryField!.SetValue(cut.Instance, new QueryInfo { Id = "1", Name = "MyQuery", Path = "Shared Queries/MyQuery" });
-        var method = cut.Instance.GetType().GetMethod("LoadQuery", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var method = cut.Instance.GetType().GetMethod("LoadQuery", BindingFlags.NonPublic | BindingFlags.Instance);
         await cut.InvokeAsync(async () => await (Task)method!.Invoke(cut.Instance, null)!);
-        var setField = cut.Instance.GetType().GetField("_querySelected", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        var selected = (System.Collections.Generic.HashSet<WorkItemInfo>)setField!.GetValue(cut.Instance)!;
+        var setField = cut.Instance.GetType().GetField("_querySelected", BindingFlags.NonPublic | BindingFlags.Instance);
+        var selected = (HashSet<WorkItemInfo>)setField!.GetValue(cut.Instance)!;
 
         Assert.Single(selected);
         Assert.Equal(10, selected.First().Id);
@@ -211,7 +212,7 @@ public class WorkItemSelectorTests : ComponentTestBase
             sp.GetRequiredService<IStringLocalizer<DevOpsApiService>>()));
 
         var cut = RenderWithProvider<WorkItemSelector>();
-        var loadingField = cut.Instance.GetType().GetField("_loading", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var loadingField = cut.Instance.GetType().GetField("_loading", BindingFlags.NonPublic | BindingFlags.Instance);
         loadingField!.SetValue(cut.Instance, true);
         cut.Render();
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -5,6 +5,7 @@ using DevOpsAssistant.Tests.Utils;
 using System.Threading.Tasks;
 using System.Linq;
 using System.IO;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Components;
 using Bunit.TestDoubles;
@@ -55,7 +56,7 @@ public class MainLayoutTests : ComponentTestBase
         await config.SaveAsync(new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
 
         var cut = RenderComponent<MainLayout>();
-        var method = typeof(MainLayout).GetMethod("SignOut", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var method = typeof(MainLayout).GetMethod("SignOut", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var task = cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, null)!);
         var dialog = cut.WaitForElement("div.mud-dialog");
         dialog.GetElementsByTagName("button")[0].Click();
@@ -118,7 +119,7 @@ public class MainLayoutTests : ComponentTestBase
         await config.SelectProjectAsync("One");
         await config.SelectProjectAsync("One");
         var cut = RenderComponent<MainLayout>();
-        var method = typeof(MainLayout).GetMethod("ChangeProject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var method = typeof(MainLayout).GetMethod("ChangeProject", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var task = cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, ["Two"])!);
         var dialog = cut.WaitForElement("div.mud-dialog");
         dialog.GetElementsByTagName("button")[0].Click();
@@ -139,7 +140,7 @@ public class MainLayoutTests : ComponentTestBase
         nav!.NavigateTo("projects/new");
 
         var cut = RenderComponent<MainLayout>();
-        var method = typeof(MainLayout).GetMethod("ChangeProject", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var method = typeof(MainLayout).GetMethod("ChangeProject", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var task = cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, ["Two"])!);
         var dialog = cut.WaitForElement("div.mud-dialog");
         dialog.GetElementsByTagName("button")[0].Click();

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -291,9 +291,10 @@ public class MetricsPageTests : ComponentTestBase
             new() { CreatedDate = DateTime.Today, ActivatedDate = DateTime.Today, ClosedDate = DateTime.Today, Tags = ["Keep"] }
         ];
         var result = (IEnumerable<StoryMetric>)filter.Invoke(metrics, new object?[] { items })!;
+        var list = result.ToList();
 
-        Assert.Single(result);
-        Assert.Contains("Keep", result.First().Tags);
+        Assert.Single(list);
+        Assert.Contains("Keep", list[0].Tags);
     }
 
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
@@ -111,7 +111,7 @@ public class RequirementsPlannerPageTests : ComponentTestBase
         planField.SetValue(cut.Instance, plan);
 
         var remove = typeof(RequirementsPlanner).GetMethod("RemoveEpic", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        cut.InvokeAsync(() => remove.Invoke(cut.Instance, new[] { epic }));
+        cut.InvokeAsync(() => remove.Invoke(cut.Instance, [epic]));
 
         Assert.Empty((System.Collections.IList)epicsProp.GetValue(plan)!);
     }
@@ -144,8 +144,8 @@ public class RequirementsPlannerPageTests : ComponentTestBase
 
         var drag = typeof(RequirementsPlanner).GetMethod("OnDragStart", BindingFlags.NonPublic | BindingFlags.Instance)!;
         var drop = typeof(RequirementsPlanner).GetMethod("OnDropOnEpic", BindingFlags.NonPublic | BindingFlags.Instance)!;
-        cut.InvokeAsync(() => drag.Invoke(cut.Instance, new[] { feature }));
-        cut.InvokeAsync(() => drop.Invoke(cut.Instance, new[] { epic2 }));
+        cut.InvokeAsync(() => drag.Invoke(cut.Instance, [feature]));
+        cut.InvokeAsync(() => drop.Invoke(cut.Instance, [epic2]));
 
         Assert.Empty((System.Collections.IList)featuresProp.GetValue(epic1)!);
         Assert.Single((System.Collections.IList)featuresProp.GetValue(epic2)!);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/WorkItemsPageTests.cs
@@ -4,6 +4,7 @@ using DevOpsAssistant.Services;
 using DevOpsAssistant.Tests.Utils;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using DevOpsAssistant.Services.Models;
 
 namespace DevOpsAssistant.Tests.Pages;
@@ -83,11 +84,11 @@ public class WorkItemsPageTests : ComponentTestBase
                 StatusValid = false
             };
 
-            var backlogsField = typeof(WorkItems).GetField("_backlogs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var backlogsField = typeof(WorkItems).GetField("_backlogs", BindingFlags.NonPublic | BindingFlags.Instance)!;
             backlogsField.SetValue(this, new[] { "Area" });
-            var pathField = typeof(WorkItems).GetField("_path", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var pathField = typeof(WorkItems).GetField("_path", BindingFlags.NonPublic | BindingFlags.Instance)!;
             pathField.SetValue(this, "Area");
-            var rootsField = typeof(WorkItems).GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var rootsField = typeof(WorkItems).GetField("_roots", BindingFlags.NonPublic | BindingFlags.Instance)!;
             rootsField.SetValue(this, new List<WorkItemNode> { root });
 
             return Task.CompletedTask;
@@ -120,11 +121,11 @@ public class WorkItemsPageTests : ComponentTestBase
                 StatusValid = true
             };
 
-            var backlogsField = typeof(WorkItems).GetField("_backlogs", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var backlogsField = typeof(WorkItems).GetField("_backlogs", BindingFlags.NonPublic | BindingFlags.Instance)!;
             backlogsField.SetValue(this, new[] { "Area" });
-            var pathField = typeof(WorkItems).GetField("_path", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var pathField = typeof(WorkItems).GetField("_path", BindingFlags.NonPublic | BindingFlags.Instance)!;
             pathField.SetValue(this, "Area");
-            var rootsField = typeof(WorkItems).GetField("_roots", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var rootsField = typeof(WorkItems).GetField("_roots", BindingFlags.NonPublic | BindingFlags.Instance)!;
             rootsField.SetValue(this, new List<WorkItemNode> { epic1, epic2 });
 
             return Task.CompletedTask;
@@ -136,7 +137,7 @@ public class WorkItemsPageTests : ComponentTestBase
         protected override Task OnInitializedAsync()
         {
             base.OnInitializedAsync();
-            var field = typeof(WorkItems).GetField("_issuesOnly", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            var field = typeof(WorkItems).GetField("_issuesOnly", BindingFlags.NonPublic | BindingFlags.Instance)!;
             field.SetValue(this, false);
             return Task.CompletedTask;
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -58,7 +58,7 @@
     [Parameter] public string ProjectName { get; set; } = string.Empty;
 
     private readonly HashSet<WorkItemInfo> _selectedItems = [];
-    private HashSet<string> _selectedTags = new();
+    private readonly HashSet<string> _selectedTags = new();
     private string[] _tags = [];
     private string _tag = string.Empty;
     private bool _loading;

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -237,7 +237,7 @@ else if (_periods.Any())
     private VelocityMode _velocityMode = VelocityMode.StoryPoints;
     private DateTime? _startDate = DateTime.Today.AddDays(-84);
     private DateTime? _endDate = DateTime.Today;
-    private List<PeriodMetrics> _periods = new();
+    private readonly List<PeriodMetrics> _periods = new();
     private List<IterationInfo> _iterations = new();
     private List<StoryMetric> _items = new();
 
@@ -268,7 +268,7 @@ else if (_periods.Any())
     private List<ApexSeries> _burnApex = [];
     private List<ApexSeries> _flowApex = [];
     private ApexChartOptions<ChartPoint> _burnOptions = new();
-    private ApexChartOptions<ChartPoint> _flowOptions = new() { Chart = new Chart { Stacked = true } };
+    private readonly ApexChartOptions<ChartPoint> _flowOptions = new() { Chart = new Chart { Stacked = true } };
     private bool _leadCycleExpanded;
     private bool _barExpanded;
     private bool _wipExpanded;
@@ -726,7 +726,8 @@ else if (_periods.Any())
 
     private static string BuildPrompt(IEnumerable<PeriodMetrics> periods, OutputFormat format)
     {
-        var metrics = periods.Select(p => new
+        var list = periods.ToList();
+        var metrics = list.Select(p => new
         {
             end = p.End.ToString("yyyy-MM-dd"),
             leadTime = p.AvgLeadTime,
@@ -739,12 +740,12 @@ else if (_periods.Any())
 
         var summary = new
         {
-            avgLeadTime = periods.Any() ? periods.Average(p => p.AvgLeadTime) : 0,
-            avgCycleTime = periods.Any() ? periods.Average(p => p.AvgCycleTime) : 0,
-            avgThroughput = periods.Any() ? periods.Average(p => p.Throughput) : 0,
-            avgVelocity = periods.Any() ? periods.Average(p => p.Velocity) : 0,
-            avgWip = periods.Any() ? periods.Average(p => p.AvgWip) : 0,
-            avgSprintEfficiency = periods.Any() ? periods.Average(p => p.SprintEfficiency) : 0
+            avgLeadTime = list.Any() ? list.Average(p => p.AvgLeadTime) : 0,
+            avgCycleTime = list.Any() ? list.Average(p => p.AvgCycleTime) : 0,
+            avgThroughput = list.Any() ? list.Average(p => p.Throughput) : 0,
+            avgVelocity = list.Any() ? list.Average(p => p.Velocity) : 0,
+            avgWip = list.Any() ? list.Average(p => p.AvgWip) : 0,
+            avgSprintEfficiency = list.Any() ? list.Average(p => p.SprintEfficiency) : 0
         };
 
         var payload = new { metrics, summary };

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -790,7 +790,8 @@ public class DevOpsApiService
 
     public async Task<List<StoryHierarchyDetails>> GetStoryHierarchyDetailsAsync(IEnumerable<int> storyIds)
     {
-        var idsToFetch = new HashSet<int>(storyIds);
+        var idsList = storyIds.ToList();
+        var idsToFetch = new HashSet<int>(idsList);
         var fetched = new HashSet<int>();
         var items = new Dictionary<int, WorkItem>();
 
@@ -821,7 +822,7 @@ public class DevOpsApiService
         }
 
         List<StoryHierarchyDetails> list = [];
-        foreach (var id in storyIds)
+        foreach (var id in idsList)
         {
             if (!items.TryGetValue(id, out var story))
                 continue;


### PR DESCRIPTION
## Summary
- run JetBrains InspectCode and fix some findings
- remove redundant qualifiers in tests
- simplify collection creation
- avoid multiple enumeration in MetricsPageTests
- mark private fields readonly where possible

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6866e570ebc483288f0bd55384205971