### PR TITLE
Improve standards tooltips

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectSettingsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectSettingsPageTests.cs
@@ -1,0 +1,30 @@
+using Bunit;
+using DevOpsAssistant.Pages;
+using DevOpsAssistant.Services.Models;
+using DevOpsAssistant.Tests.Utils;
+using DevOpsAssistant.Services;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DevOpsAssistant.Tests.Pages;
+
+public class ProjectSettingsPageTests : ComponentTestBase
+{
+    [Fact]
+    public async Task Disabled_Standard_Tooltip_Lists_Incompatibilities()
+    {
+        var config = SetupServices();
+        await config.AddProjectAsync("Demo");
+        await config.SaveCurrentAsync("Demo", new DevOpsConfig());
+
+        var cut = RenderComponent<ProjectSettings>(p => p.Add(c => c.ProjectName, "Demo"));
+        var selectedField = cut.Instance.GetType().GetField("_selectedStandards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        selectedField.SetValue(cut.Instance, new System.Collections.Generic.HashSet<string> { "ScrumUserStory" });
+        var method = cut.Instance.GetType().GetMethod("GetStandardTooltip", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        var option = DevOpsAssistant.Services.Models.StandardsCatalog.Options.First(o => o.Id == "JobStory");
+        var text = (string)method.Invoke(cut.Instance, [option])!;
+
+        Assert.Contains("Incompatible", text);
+        Assert.Contains("Scrum User Story", text);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -144,4 +144,10 @@
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
   </data>
+  <data name="StandardsHeader" xml:space="preserve">
+    <value>Estándares de elementos de trabajo</value>
+  </data>
+  <data name="IncompatibleWith" xml:space="preserve">
+    <value>Incompatible con {0}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -86,12 +86,13 @@
                         <MudSelectItem Value="OutputFormat.Html">HTML</MudSelectItem>
                         <MudSelectItem Value="OutputFormat.Inline">Inline</MudSelectItem>
                     </MudSelect>
+                    <MudText Typo="Typo.h6">@L["StandardsHeader"]</MudText>
                     <MudTabs @bind-ActivePanelIndex="_standardsTab">
                         <MudTabPanel Text='@L["RequirementsDocumentationGroup"]'>
                             <MudStack Spacing="1">
                                 @foreach (var opt in StandardOptions.Where(o => o.Group == "requirements_documentation"))
                                 {
-                                    <MudTooltip Text="@opt.Description">
+                                    <MudTooltip Text="@GetStandardTooltip(opt)">
                                         <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
                                     </MudTooltip>
                                 }
@@ -101,7 +102,7 @@
                             <MudStack Spacing="1">
                                 @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_description"))
                                 {
-                                    <MudTooltip Text="@opt.Description">
+                                    <MudTooltip Text="@GetStandardTooltip(opt)">
                                         <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
                                     </MudTooltip>
                                 }
@@ -111,7 +112,7 @@
                             <MudStack Spacing="1">
                                 @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_acceptance_criteria"))
                                 {
-                                    <MudTooltip Text="@opt.Description">
+                                    <MudTooltip Text="@GetStandardTooltip(opt)">
                                         <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
                                     </MudTooltip>
                                 }
@@ -121,7 +122,7 @@
                             <MudStack Spacing="1">
                                 @foreach (var opt in StandardOptions.Where(o => o.Group == "user_story_quality"))
                                 {
-                                    <MudTooltip Text="@opt.Description">
+                                    <MudTooltip Text="@GetStandardTooltip(opt)">
                                         <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
                                     </MudTooltip>
                                 }
@@ -131,7 +132,7 @@
                             <MudStack Spacing="1">
                                 @foreach (var opt in StandardOptions.Where(o => o.Group == "bug_reporting"))
                                 {
-                                    <MudTooltip Text="@opt.Description">
+                                    <MudTooltip Text="@GetStandardTooltip(opt)">
                                         <MudCheckBox T="bool" Value="IsStandardSelected(opt)" ValueChanged="v => OnStandardChanged(opt, v)" Disabled="IsStandardDisabled(opt)" Color="Color.Primary" Label="@opt.Name" />
                                     </MudTooltip>
                                 }
@@ -532,6 +533,19 @@
         if (!StandardsCatalog.Incompatibilities.TryGetValue(option.Id, out var inc))
             return false;
         return inc.Any(i => _selectedStandards.Contains(i));
+    }
+
+    private string GetStandardTooltip(StandardOption option)
+    {
+        var text = option.Description;
+        if (IsStandardDisabled(option) && StandardsCatalog.Incompatibilities.TryGetValue(option.Id, out var inc))
+        {
+            var names = inc.Where(i => _selectedStandards.Contains(i))
+                .Select(StandardsCatalog.GetName);
+            if (names.Any())
+                text += " " + string.Format(L["IncompatibleWith"].Value, string.Join(", ", names));
+        }
+        return text;
     }
 
     private void OnStandardChanged(StandardOption option, bool value)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -144,4 +144,10 @@
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
   </data>
+  <data name="StandardsHeader" xml:space="preserve">
+    <value>Work Item Standards</value>
+  </data>
+  <data name="IncompatibleWith" xml:space="preserve">
+    <value>Incompatible with {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- add header for standards section
- show incompatible standard names in tooltips
- localize new strings
- test tooltip helper

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6866ed791f348328bd4ed7f615e088ec