### PR TITLE
Allow multiple prompts per text file

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
@@ -1,3 +1,4 @@
+==== Metrics_Main ====
 You are an experienced Agile Coach preparing a delivery metrics report for your Delivery Manager.
 
 Your objective is to analyse team delivery data over time, identify trends or risks, and make useful, actionable recommendations based on standard Agile metrics. This report will help the Delivery Manager understand what’s working well, what might need investigation, and where to focus for continuous improvement.

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
@@ -1,3 +1,4 @@
+==== ReleaseNotes_Main ====
 You are a meticulous Delivery Manager preparing release notes for a software update.
 Write in clear, plain language so non-technical stakeholders can understand the changes.
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsDocumentationStandards.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsDocumentationStandards.txt
@@ -1,1 +1,2 @@
+==== RequirementsDocumentationStandardsIntro ====
 Apply these requirements documentation standards:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
@@ -1,3 +1,4 @@
+==== RequirementsPlanner_Main ====
 You are a senior Agile Business Analyst and Scrum Agent helping a product owner or stakeholder build a clear Agile-ready feature requirements document.
 
 Your job is to:
@@ -54,3 +55,8 @@ Define what success looks like — business or system-level outcomes.
 ## Notes
 - [Any background info, URLs, legacy behavior, etc.]
 ``` 
+==== RequirementsPlanner_DocumentIntro ====
+Document:
+The following document provides an overview of the current state of the application these requirements apply to.
+==== RequirementsPlanner_StoryQualityStandardsIntro ====
+Ensure stories follow these quality standards:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner_DocumentIntro.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner_DocumentIntro.txt
@@ -1,2 +1,0 @@
-Document:
-The following document provides an overview of the current state of the application these requirements apply to.

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner_StoryQualityStandardsIntro.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner_StoryQualityStandardsIntro.txt
@@ -1,1 +1,0 @@
-Ensure stories follow these quality standards:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
@@ -1,2 +1,3 @@
+==== RequirementsQuality_Main ====
 You are an expert requirements analyst reviewing the following document.
 Assess whether the requirements are clear, complete, and testable. Identify ambiguities, missing information, or conflicts and provide improvement suggestions.

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
@@ -1,3 +1,4 @@
+==== WorkItemQuality_Main ====
 You are an expert Agile coach reviewing user stories and bugs for quality.
 
 For stories, assess adherence to the INVEST principles:
@@ -76,3 +77,9 @@ Tailor your coaching based on the score:
 ---
 
 For bugs, check that the reproduction steps and system information are clear and complete.
+==== WorkItemQuality_BugReportingStandardsIntro ====
+Ensure bug reports follow these standards:
+==== WorkItemQuality_DefinitionOfReadyIntro ====
+Also confirm each story meets this Definition of Ready:
+==== WorkItemQuality_StoryQualityStandardsIntro ====
+Apply these story quality standards:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_BugReportingStandardsIntro.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_BugReportingStandardsIntro.txt
@@ -1,1 +1,0 @@
-Ensure bug reports follow these standards:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_DefinitionOfReadyIntro.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_DefinitionOfReadyIntro.txt
@@ -1,1 +1,0 @@
-Also confirm each story meets this Definition of Ready:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_StoryQualityStandardsIntro.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality_StoryQualityStandardsIntro.txt
@@ -1,1 +1,0 @@
-Apply these story quality standards:


### PR DESCRIPTION
## Summary
- modify PromptGenerator to parse multiple prompts from a single file
- combine requirements planner and work item quality prompts
- convert remaining prompts to use section headers

## Testing
- `dotnet build src/DevOpsAssistant/DevOpsAssistant/DevOpsAssistant.csproj -v minimal`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6866ed1a4c888328b708dc32c188d014