### PR TITLE
Externalize prompt additions

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -755,9 +755,9 @@ else if (_periods.Any())
         sb.AppendLine(GeneratedPrompts.Metrics_MainPrompt.Value);
         sb.AppendLine();
         if (format == OutputFormat.Inline)
-            sb.AppendLine("Reply inline with the final report.");
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_MetricsInlinePrompt.Value);
         else
-            sb.AppendLine($"Once you summarize the metrics, convert the output to {format} format and include it.");
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_MetricsConvertPrompt.Value, format));
         sb.AppendLine();
         sb.AppendLine($"Data: {json}");
         sb.AppendLine();

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -208,9 +208,9 @@ else if (_promptParts != null)
         }
 
         if (config.OutputFormat == OutputFormat.Inline)
-            sb.AppendLine("Reply inline with the final notes.");
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_ReleaseNotesInlinePrompt.Value);
         else
-            sb.AppendLine($"After generating the notes, convert the content to {config.OutputFormat} format and include that version.");
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_ReleaseNotesConvertPrompt.Value, config.OutputFormat));
         sb.AppendLine();
         sb.AppendLine("Work items:");
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -200,9 +200,9 @@ else if (_promptParts != null)
             sb.AppendLine(config.StoryQualityPrompt.Trim());
         }
         if (config.OutputFormat == OutputFormat.Inline)
-            sb.AppendLine("Reply inline with the analysis results.");
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_WorkItemAnalysisInlinePrompt.Value);
         else
-            sb.AppendLine($"After completing the analysis, convert the output to {config.OutputFormat} format and include that version.");
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_WorkItemAnalysisConvertPrompt.Value, config.OutputFormat));
         sb.AppendLine();
         sb.AppendLine("Work items:");
         sb.AppendLine(json);

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/FormatInstructions.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/FormatInstructions.txt
@@ -1,0 +1,12 @@
+==== FormatInstructions_MetricsInline ====
+Reply inline with the final report.
+==== FormatInstructions_MetricsConvert ====
+Once you summarize the metrics, convert the output to {0} format and include it.
+==== FormatInstructions_ReleaseNotesInline ====
+Reply inline with the final notes.
+==== FormatInstructions_ReleaseNotesConvert ====
+After generating the notes, convert the content to {0} format and include that version.
+==== FormatInstructions_WorkItemAnalysisInline ====
+Reply inline with the analysis results.
+==== FormatInstructions_WorkItemAnalysisConvert ====
+After completing the analysis, convert the output to {0} format and include that version.

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/StandardDescriptions.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/StandardDescriptions.txt
@@ -1,0 +1,28 @@
+==== Standard_ISO29148 ====
+Formal SRS requirements standard including characteristics like complete, unambiguous, verifiable.
+==== Standard_Volere ====
+Practical requirements template with detailed sections for functional, non-functional, constraints, priorities.
+==== Standard_BABOK ====
+Guide for good practices in writing requirements including clarity, conciseness, and testability.
+==== Standard_ISO25010 ====
+Defines software quality attributes (for non-functional requirements).
+==== Standard_ScrumUserStory ====
+Use "As a [role] I want [goal] so that [benefit]" format.
+==== Standard_JobStory ====
+Use "When [situation] I want to [motivation] so I can [expected outcome]" format.
+==== Standard_Gherkin ====
+Write acceptance criteria in Given-When-Then format for automation.
+==== Standard_BulletPoints ====
+Write acceptance criteria as plain bullet points.
+==== Standard_SAFeStyle ====
+Write clear, unambiguous, testable acceptance criteria in any structured format (often bullet or Gherkin).
+==== Standard_INVEST ====
+Ensure story is Independent, Negotiable, Valuable, Estimable, Small, Testable.
+==== Standard_SAFe ====
+Ensure story has clear description, AC, estimate, and alignment to feature/epic.
+==== Standard_AgileAlliance ====
+Ensure story focuses on business value, small enough for iteration, clear goal.
+==== Standard_AzureDevOpsBug ====
+Include title, repro steps, expected result, actual result, severity, environment.
+==== Standard_ISTQBDefect ====
+Include ID, title, description, steps to reproduce, expected vs actual, severity, priority, status, environment.

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StandardsCatalog.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StandardsCatalog.cs
@@ -1,3 +1,5 @@
+using GeneratedPrompts;
+
 namespace DevOpsAssistant.Services.Models;
 
 public record StandardOption(string Group, string Id, string Name, string Description);
@@ -6,24 +8,24 @@ public static class StandardsCatalog
 {
     public static readonly StandardOption[] Options =
     [
-        new("requirements_documentation", "ISO29148", "ISO/IEC/IEEE 29148:2018", "Formal SRS requirements standard including characteristics like complete, unambiguous, verifiable."),
-        new("requirements_documentation", "Volere", "Volere Template", "Practical requirements template with detailed sections for functional, non-functional, constraints, priorities."),
-        new("requirements_documentation", "BABOK", "BABOK (Business Analysis Body of Knowledge)", "Guide for good practices in writing requirements including clarity, conciseness, and testability."),
-        new("requirements_documentation", "ISO25010", "ISO/IEC 25010", "Defines software quality attributes (for non-functional requirements)."),
+        new("requirements_documentation", "ISO29148", "ISO/IEC/IEEE 29148:2018", GeneratedPrompts.Standard_ISO29148Prompt.Value),
+        new("requirements_documentation", "Volere", "Volere Template", GeneratedPrompts.Standard_VolerePrompt.Value),
+        new("requirements_documentation", "BABOK", "BABOK (Business Analysis Body of Knowledge)", GeneratedPrompts.Standard_BABOKPrompt.Value),
+        new("requirements_documentation", "ISO25010", "ISO/IEC 25010", GeneratedPrompts.Standard_ISO25010Prompt.Value),
 
-        new("user_story_description", "ScrumUserStory", "Scrum User Story", "Use \"As a [role] I want [goal] so that [benefit]\" format."),
-        new("user_story_description", "JobStory", "Job Story", "Use \"When [situation] I want to [motivation] so I can [expected outcome]\" format."),
+        new("user_story_description", "ScrumUserStory", "Scrum User Story", GeneratedPrompts.Standard_ScrumUserStoryPrompt.Value),
+        new("user_story_description", "JobStory", "Job Story", GeneratedPrompts.Standard_JobStoryPrompt.Value),
 
-        new("user_story_acceptance_criteria", "Gherkin", "Gherkin / BDD", "Write acceptance criteria in Given-When-Then format for automation."),
-        new("user_story_acceptance_criteria", "BulletPoints", "Bullet Points", "Write acceptance criteria as plain bullet points."),
-        new("user_story_acceptance_criteria", "SAFeStyle", "SAFe Style", "Write clear, unambiguous, testable acceptance criteria in any structured format (often bullet or Gherkin)."),
+        new("user_story_acceptance_criteria", "Gherkin", "Gherkin / BDD", GeneratedPrompts.Standard_GherkinPrompt.Value),
+        new("user_story_acceptance_criteria", "BulletPoints", "Bullet Points", GeneratedPrompts.Standard_BulletPointsPrompt.Value),
+        new("user_story_acceptance_criteria", "SAFeStyle", "SAFe Style", GeneratedPrompts.Standard_SAFeStylePrompt.Value),
 
-        new("user_story_quality", "INVEST", "INVEST", "Ensure story is Independent, Negotiable, Valuable, Estimable, Small, Testable."),
-        new("user_story_quality", "SAFe", "SAFe", "Ensure story has clear description, AC, estimate, and alignment to feature/epic."),
-        new("user_story_quality", "AgileAlliance", "Agile Alliance", "Ensure story focuses on business value, small enough for iteration, clear goal."),
+        new("user_story_quality", "INVEST", "INVEST", GeneratedPrompts.Standard_INVESTPrompt.Value),
+        new("user_story_quality", "SAFe", "SAFe", GeneratedPrompts.Standard_SAFePrompt.Value),
+        new("user_story_quality", "AgileAlliance", "Agile Alliance", GeneratedPrompts.Standard_AgileAlliancePrompt.Value),
 
-        new("bug_reporting", "AzureDevOpsBug", "Azure DevOps Bug", "Include title, repro steps, expected result, actual result, severity, environment."),
-        new("bug_reporting", "ISTQBDefect", "ISTQB Defect Report", "Include ID, title, description, steps to reproduce, expected vs actual, severity, priority, status, environment.")
+        new("bug_reporting", "AzureDevOpsBug", "Azure DevOps Bug", GeneratedPrompts.Standard_AzureDevOpsBugPrompt.Value),
+        new("bug_reporting", "ISTQBDefect", "ISTQB Defect Report", GeneratedPrompts.Standard_ISTQBDefectPrompt.Value)
     ];
 
     public static readonly Dictionary<string, string[]> Incompatibilities = new()


### PR DESCRIPTION
## Summary
- pull format instructions into a new `FormatInstructions.txt`
- capture descriptions for all standards in `StandardDescriptions.txt`
- reference generated text when building prompts
- use generated descriptions inside `StandardsCatalog`

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_6866f4d1c8dc832894660337d7dea397