### PR TITLE
Remove duplicate AI tag strings

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -101,7 +101,7 @@
         }
     }
 
-    private bool IsProtected(string tag) => string.Equals(tag, "AI Generated", StringComparison.OrdinalIgnoreCase);
+    private bool IsProtected(string tag) => string.Equals(tag, AppConstants.AiGeneratedTag, StringComparison.OrdinalIgnoreCase);
 
     private void RemoveTag(string tag)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -490,7 +490,7 @@
                 var parentId = _feature?.Id;
                 foreach (var story in _plan.Stories)
                 {
-                    var tags = story.Tags.Concat(["AI Generated"]).ToArray();
+                    var tags = story.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                     story.Id = await ApiService.CreateWorkItemAsync(
                         "User Story",
                         story.Title,
@@ -507,17 +507,17 @@
             {
                 foreach (var epic in _plan.Epics)
                 {
-                    var epicTags = epic.Tags.Concat(["AI Generated"]).ToArray();
+                    var epicTags = epic.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                     epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog, null, null, epicTags);
                     _createdItems.Add(epic.Id);
                     foreach (var feature in epic.Features)
                     {
-                        var featureTags = feature.Tags.Concat(["AI Generated"]).ToArray();
+                        var featureTags = feature.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                         feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id, null, featureTags);
                         _createdItems.Add(feature.Id);
                         foreach (var story in feature.Stories)
                         {
-                            var tags2 = story.Tags.Concat(["AI Generated"]).ToArray();
+                            var tags2 = story.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                             story.Id = await ApiService.CreateWorkItemAsync(
                                 "User Story",
                                 story.Title,

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/AppConstants.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/AppConstants.cs
@@ -1,0 +1,6 @@
+namespace DevOpsAssistant.Utils;
+
+public static class AppConstants
+{
+    public const string AiGeneratedTag = "AI Generated";
+}


### PR DESCRIPTION
## Summary
- extract `AiGeneratedTag` constant
- use constant in requirements planner and plan item editor

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6866fb7899a48328a16f11f1ba4523a0