### PR TITLE
Add project colour override

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/HomePageTests.cs
@@ -15,7 +15,7 @@ public class HomePageTests : ComponentTestBase
     {
         var config = SetupServices();
         await config.AddProjectAsync("Demo");
-        await config.SaveCurrentAsync("Demo", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        await config.SaveCurrentAsync("Demo", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" }, "");
         var cut = RenderComponent<Home>(p => p.Add(c => c.ProjectName, config.CurrentProject.Name));
 
         Assert.Contains("DevOpsAssistant provides", cut.Markup);
@@ -26,7 +26,7 @@ public class HomePageTests : ComponentTestBase
     {
         var config = SetupServices();
         await config.AddProjectAsync("Demo");
-        await config.SaveCurrentAsync("Demo", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        await config.SaveCurrentAsync("Demo", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" }, "");
 
         var nav = Services.GetRequiredService<NavigationManager>() as FakeNavigationManager;
         RenderComponent<Home>();

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectSettingsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ProjectSettingsPageTests.cs
@@ -15,7 +15,7 @@ public class ProjectSettingsPageTests : ComponentTestBase
     {
         var config = SetupServices();
         await config.AddProjectAsync("Demo");
-        await config.SaveCurrentAsync("Demo", new DevOpsConfig());
+        await config.SaveCurrentAsync("Demo", new DevOpsConfig(), "");
 
         var cut = RenderComponent<ProjectSettings>(p => p.Add(c => c.ProjectName, "Demo"));
         var selectedField = cut.Instance.GetType().GetField("_selectedStandards", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -229,7 +229,7 @@ public class DevOpsConfigServiceTests
         await service.SelectProjectAsync("one");
 
         var cfg = new DevOpsConfig { Organization = "Org" };
-        await service.UpdateProjectAsync("two", "two", cfg);
+        await service.UpdateProjectAsync("two", "two", cfg, "");
 
         Assert.Equal("one", service.CurrentProject.Name);
         var other = service.Projects.First(p => p.Name == "two");
@@ -258,7 +258,7 @@ public class DevOpsConfigServiceTests
         await service.AddProjectAsync("two");
         await service.SelectProjectAsync("one");
 
-        var result = await service.SaveCurrentAsync("two", new DevOpsConfig());
+        var result = await service.SaveCurrentAsync("two", new DevOpsConfig(), "");
 
         Assert.False(result);
         Assert.Equal("one", service.CurrentProject.Name);
@@ -272,7 +272,7 @@ public class DevOpsConfigServiceTests
         await service.AddProjectAsync("one");
         await service.AddProjectAsync("two");
 
-        var result = await service.UpdateProjectAsync("two", "one", new DevOpsConfig());
+        var result = await service.UpdateProjectAsync("two", "one", new DevOpsConfig(), "");
 
         Assert.False(result);
     }
@@ -330,7 +330,7 @@ public class DevOpsConfigServiceTests
             Organization = "Org",
             Project = "Proj",
             PatToken = "token"
-        });
+        }, "");
 
         Assert.True(raised);
     }
@@ -341,7 +341,7 @@ public class DevOpsConfigServiceTests
         var storage = new FakeLocalStorageService();
         var service = new DevOpsConfigService(storage);
         await service.AddProjectAsync("one");
-        await service.SaveCurrentAsync("one", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" });
+        await service.SaveCurrentAsync("one", new DevOpsConfig { Organization = "Org", Project = "Proj", PatToken = "token" }, "");
         bool raised = false;
         service.ProjectChanged += () => raised = true;
 
@@ -350,7 +350,7 @@ public class DevOpsConfigServiceTests
             Organization = "Org2",
             Project = "Proj2",
             PatToken = "token2"
-        });
+        }, "");
 
         Assert.False(raised);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -90,7 +90,9 @@
     private string _selectedProject = string.Empty;
     private bool _initialized;
     private bool _isDarkMode;
-    private MudTheme CurrentTheme => ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme;
+    private MudTheme CurrentTheme
+        => (ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme)
+            .WithPrimaryColor(ConfigService.CurrentProject.Color);
     
     private void HandleProjectChanged()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -54,7 +54,9 @@
 
 @code {
     private bool _isDarkMode;
-    private MudTheme CurrentTheme => ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme;
+    private MudTheme CurrentTheme
+        => (ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme)
+            .WithPrimaryColor(ConfigService.CurrentProject.Color);
 
     protected override void OnInitialized()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -141,6 +141,9 @@
   <data name="PromptsCopied" xml:space="preserve">
     <value>Prompts copiados al portapapeles</value>
   </data>
+  <data name="ProjectColor" xml:space="preserve">
+    <value>Color del proyecto</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -49,6 +49,7 @@
                         }
                     }
                     <MudTextField @bind-Value="_model.MainBranch" Label='@L["MainBranch"]'/>
+                    <MudTextField T="string" Value="_color" ValueChanged="OnColorChanged" InputType="InputType.Color" Label='@L["ProjectColor"]' />
                     <MudStack Row="true" Spacing="1">
                         <MudButton OnClick="SaveGeneral" Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanSave">@L["Save"]</MudButton>
                         <MudButton OnClick="Delete" Variant="Variant.Filled" Color="Color.Error">@L["DeleteProject"]</MudButton>
@@ -195,6 +196,7 @@
     private bool _overridePat;
     private bool _useOrgAsGlobal;
     private bool _useAsGlobal;
+    private string _color = string.Empty;
     private bool _qualityDirty;
     private bool _promptsDirty;
     private bool _validationDirty;
@@ -252,6 +254,7 @@
                 }
             }
         };
+        _color = ConfigService.CurrentProject.Color;
         _overrideOrg = !string.IsNullOrWhiteSpace(_model.Organization) || string.IsNullOrWhiteSpace(ConfigService.GlobalOrganization);
         _overridePat = !string.IsNullOrWhiteSpace(_model.PatToken) || string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken);
         _useOrgAsGlobal = string.IsNullOrWhiteSpace(ConfigService.GlobalOrganization);
@@ -284,7 +287,7 @@
             Standards = _model.Standards,
             Rules = _model.Rules
         };
-        var saved = await ConfigService.SaveCurrentAsync(_model.Project, toSave);
+        var saved = await ConfigService.SaveCurrentAsync(_model.Project, toSave, _color);
         if (!saved)
         {
             _errors = [ L["DuplicateName"] ];
@@ -302,7 +305,7 @@
     {
         var cfg = ConfigService.Config;
         cfg.DefinitionOfReady = _model.DefinitionOfReady;
-        await ConfigService.SaveCurrentAsync(_model.Project, cfg);
+        await ConfigService.SaveCurrentAsync(_model.Project, cfg, _color);
         _qualityDirty = false;
         Snackbar.Add(string.Format(L["SectionSaved"].Value, L["StoryQualityTab"].Value, _model.Project), Severity.Success);
     }
@@ -319,7 +322,7 @@
         cfg.PromptCharacterLimit = _model.PromptCharacterLimit;
         cfg.OutputFormat = _model.OutputFormat;
         cfg.Standards = _model.Standards;
-        await ConfigService.SaveCurrentAsync(_model.Project, cfg);
+        await ConfigService.SaveCurrentAsync(_model.Project, cfg, _color);
         _promptsDirty = false;
         Snackbar.Add(string.Format(L["SectionSaved"].Value, L["PromptsTab"].Value, _model.Project), Severity.Success);
     }
@@ -328,7 +331,7 @@
     {
         var vcfg = ConfigService.Config;
         vcfg.Rules = _model.Rules;
-        await ConfigService.SaveCurrentAsync(_model.Project, vcfg);
+        await ConfigService.SaveCurrentAsync(_model.Project, vcfg, _color);
         _validationDirty = false;
         Snackbar.Add(string.Format(L["SectionSaved"].Value, L["ValidationTab"].Value, _model.Project), Severity.Success);
     }
@@ -352,7 +355,7 @@
                 pcfg.PromptCharacterLimit = _model.PromptCharacterLimit;
                 pcfg.OutputFormat = _model.OutputFormat;
                 pcfg.Standards = _model.Standards;
-                await ConfigService.UpdateProjectAsync(p.Name, p.Name, pcfg);
+                await ConfigService.UpdateProjectAsync(p.Name, p.Name, pcfg, p.Color);
             }
             Snackbar.Add(string.Format(L["SectionSaved"].Value, L["PromptsTab"].Value, L["AllProjects"].Value), Severity.Success);
         }
@@ -394,7 +397,7 @@
             {
                 var vc = p.Config;
                 vc.Rules = _model.Rules;
-                await ConfigService.UpdateProjectAsync(p.Name, p.Name, vc);
+                await ConfigService.UpdateProjectAsync(p.Name, p.Name, vc, p.Color);
             }
             Snackbar.Add(string.Format(L["SectionSaved"].Value, L["ValidationTab"].Value, L["AllProjects"].Value), Severity.Success);
         }
@@ -464,6 +467,13 @@
     private Task OnUseAsGlobalChanged(bool value)
     {
         _useAsGlobal = value;
+        _generalDirty = true;
+        return Task.CompletedTask;
+    }
+
+    private Task OnColorChanged(string value)
+    {
+        _color = value;
         _generalDirty = true;
         return Task.CompletedTask;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -141,6 +141,9 @@
   <data name="PromptsCopied" xml:space="preserve">
     <value>Prompts copied to clipboard</value>
   </data>
+  <data name="ProjectColor" xml:space="preserve">
+    <value>Project Color</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -84,7 +84,7 @@ public class DevOpsConfigService
         await SaveProjectsAsync();
     }
 
-    public async Task<bool> SaveCurrentAsync(string name, DevOpsConfig config)
+    public async Task<bool> SaveCurrentAsync(string name, DevOpsConfig config, string color)
     {
         var wasValid = IsCurrentProjectValid;
         name = name.Trim();
@@ -94,6 +94,7 @@ public class DevOpsConfigService
 
         CurrentProject.Name = name;
         CurrentProject.Config = Normalize(config);
+        CurrentProject.Color = color.Trim();
         await SaveProjectsAsync();
         if (wasValid != IsCurrentProjectValid)
             OnProjectChanged();
@@ -125,7 +126,7 @@ public class DevOpsConfigService
         await _localStorage.SetItemAsync(GlobalCultureKey, GlobalCulture);
     }
 
-    public async Task<bool> UpdateProjectAsync(string existingName, string newName, DevOpsConfig config)
+    public async Task<bool> UpdateProjectAsync(string existingName, string newName, DevOpsConfig config, string color)
     {
         var proj = Projects.FirstOrDefault(p => p.Name == existingName);
         if (proj == null) return false;
@@ -135,6 +136,7 @@ public class DevOpsConfigService
             return false;
         proj.Name = newName;
         proj.Config = Normalize(config);
+        proj.Color = color.Trim();
         await SaveProjectsAsync();
         return true;
     }
@@ -147,7 +149,8 @@ public class DevOpsConfigService
         var project = new DevOpsProject
         {
             Name = name,
-            Config = source != null ? Clone(source.Config) : new DevOpsConfig()
+            Config = source != null ? Clone(source.Config) : new DevOpsConfig(),
+            Color = source?.Color ?? string.Empty
         };
         Projects.Add(Normalize(project));
         CurrentProject = project;
@@ -211,6 +214,7 @@ public class DevOpsConfigService
     {
         project.Name = project.Name.Trim();
         project.Config = Normalize(project.Config);
+        project.Color = project.Color.Trim();
         return project;
     }
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsProject.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsProject.cs
@@ -4,4 +4,5 @@ public class DevOpsProject
 {
     public string Name { get; set; } = string.Empty;
     public DevOpsConfig Config { get; set; } = new();
+    public string Color { get; set; } = string.Empty;
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/ThemeExtensions.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/ThemeExtensions.cs
@@ -1,0 +1,54 @@
+using MudBlazor;
+
+namespace DevOpsAssistant.Utils;
+
+public static class ThemeExtensions
+{
+    public static MudTheme WithPrimaryColor(this MudTheme theme, string color)
+    {
+        if (string.IsNullOrWhiteSpace(color))
+            return theme;
+
+        return new MudTheme
+        {
+            LayoutProperties = theme.LayoutProperties,
+            Typography = theme.Typography,
+            Shadows = theme.Shadows,
+            ZIndex = theme.ZIndex,
+            PaletteLight = new PaletteLight
+            {
+                Primary = color,
+                Secondary = theme.PaletteLight.Secondary,
+                Tertiary = theme.PaletteLight.Tertiary,
+                Background = theme.PaletteLight.Background,
+                Surface = theme.PaletteLight.Surface,
+                Info = theme.PaletteLight.Info,
+                Success = theme.PaletteLight.Success,
+                Warning = theme.PaletteLight.Warning,
+                Error = theme.PaletteLight.Error,
+                TextPrimary = theme.PaletteLight.TextPrimary,
+                TextSecondary = theme.PaletteLight.TextSecondary,
+                AppbarText = theme.PaletteLight.AppbarText
+            },
+            PaletteDark = new PaletteDark
+            {
+                Primary = color,
+                Secondary = theme.PaletteDark.Secondary,
+                Tertiary = theme.PaletteDark.Tertiary,
+                Background = theme.PaletteDark.Background,
+                Surface = theme.PaletteDark.Surface,
+                Info = theme.PaletteDark.Info,
+                Success = theme.PaletteDark.Success,
+                Warning = theme.PaletteDark.Warning,
+                Error = theme.PaletteDark.Error,
+                LinesDefault = theme.PaletteDark.LinesDefault,
+                AppbarBackground = theme.PaletteDark.AppbarBackground,
+                TextPrimary = theme.PaletteDark.TextPrimary,
+                TextSecondary = theme.PaletteDark.TextSecondary,
+                DrawerText = theme.PaletteDark.DrawerText,
+                DrawerIcon = theme.PaletteDark.DrawerIcon,
+                Dark = theme.PaletteDark.Dark
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- allow each project to store an optional colour
- override the theme's primary colour when a project is active
- update project settings page with colour picker field
- update tests for new service method signatures

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686782b5eb04832890ab228e0a9ef652