### PR TITLE
Move RequirementsPlanner prompt text

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -560,27 +560,25 @@
         {
             if (storiesOnly)
             {
-                sb.AppendLine("You are a senior business analyst. Break down the following product requirement into User Stories.");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_UserStoriesBlockPrompt.Value);
             }
             else
             {
-                sb.AppendLine("You are a senior business analyst. Break down the following product requirement into Epics, Features, and User Stories.");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsBlockPrompt.Value);
             }
-            sb.AppendLine("Each story must include:");
             if (config.Standards.UserStoryDescription.Contains("ScrumUserStory"))
-                sb.AppendLine("- Description in 'As a <role>, I want <goal> so that <benefit>' format");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_ScrumPrompt.Value);
             else if (config.Standards.UserStoryDescription.Contains("JobStory"))
-                sb.AppendLine("- Description in 'When <situation> I want to <motivation> so I can <expected outcome>' format");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_JobPrompt.Value);
             else
-                sb.AppendLine("- A clear, user-centric title and description");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_GenericPrompt.Value);
             if (config.Standards.UserStoryAcceptanceCriteria.Contains("Gherkin"))
-                sb.AppendLine("- Acceptance criteria in Gherkin-style format using <pre><code class=\"language-gherkin\"></code></pre> (no markdown)");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_GherkinPrompt.Value);
             else if (config.Standards.UserStoryAcceptanceCriteria.Contains("BulletPoints"))
-                sb.AppendLine("- Acceptance criteria as bullet points");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_BulletPointsPrompt.Value);
             else if (config.Standards.UserStoryAcceptanceCriteria.Contains("SAFeStyle"))
-                sb.AppendLine("- Acceptance criteria that are clear, unambiguous and testable");
-            sb.AppendLine("- A \"tags\" array for engineering triage (e.g., [\"frontend\", \"backend\", \"integration\", \"performance\", \"security\", \"accessibility\", \"needs-design\"])");
-            sb.AppendLine("Use HTML formatting in descriptions and acceptance criteria only when it improves readability, such as for bulleted lists. Avoid unnecessary tags like wrapping everything in <p> elements.");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_SAFeStylePrompt.Value);
+            sb.AppendLine(GeneratedPrompts.RequirementsPlanner_TagsAndHtmlAdvicePrompt.Value);
 
             if (config.Standards.UserStoryQuality.Count > 0)
             {
@@ -601,30 +599,18 @@
             if (storiesOnly)
             {
                 sb.AppendLine();
-                sb.AppendLine("Stories Only:");
-                sb.AppendLine("Do not generate epics or features. Only return an array of user stories in this format:");
-                sb.AppendLine("{\"stories\":[{\"title\":\"\",\"description\":\"\",\"acceptanceCriteria\":\"\",\"tags\":[\"\"]}]}");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_StoriesOnlyBlockPrompt.Value);
             }
             else
             {
                 sb.AppendLine();
-                sb.AppendLine("Return strict JSON using this format:");
-                sb.AppendLine("{\"epics\":[{\"title\":\"\",\"description\":\"\",\"features\":[{\"title\":\"\",\"description\":\"\",\"stories\":[{\"title\":\"\",\"description\":\"\",\"acceptanceCriteria\":\"\",\"tags\":[\"\"]}]}]}]}");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsJsonBlockPrompt.Value);
             }
 
             if (clarify)
             {
                 sb.AppendLine();
-                sb.AppendLine("Clarify Requirements:");
-                sb.AppendLine("Before writing the output, review the requirement and ask for clarification if:");
-                sb.AppendLine("- Expected user behaviors or flows are ambiguous");
-                sb.AppendLine("- Access restrictions or permissions are not clearly defined");
-                sb.AppendLine("- Search or filtering functionality is mentioned without scope (e.g., partial matches, filtering fields)");
-                sb.AppendLine("- External system dependencies are implied but not detailed (e.g., email sending, file uploads, audit logging)");
-                sb.AppendLine("- Non-functional requirements are vague (e.g., \"must be fast\")");
-                sb.AppendLine("- It's unclear if optional elements (e.g., \"nice to have\" features) are in scope");
-                sb.AppendLine();
-                sb.AppendLine("If anything is unclear, ask precise, targeted clarification questions first, then proceed once answered.");
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_ClarifyBlockPrompt.Value);
             }
         }
         if (!string.IsNullOrWhiteSpace(config.RequirementsPrompt))

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
@@ -60,3 +60,42 @@ Document:
 The following document provides an overview of the current state of the application these requirements apply to.
 ==== RequirementsPlanner_StoryQualityStandardsIntro ====
 Ensure stories follow these quality standards:
+==== RequirementsPlanner_UserStoriesBlock ====
+You are a senior business analyst. Break down the following product requirement into User Stories.
+Each story must include:
+==== RequirementsPlanner_EpicsBlock ====
+You are a senior business analyst. Break down the following product requirement into Epics, Features, and User Stories.
+Each story must include:
+==== RequirementsPlanner_Description_Scrum ====
+- Description in 'As a <role>, I want <goal> so that <benefit>' format
+==== RequirementsPlanner_Description_Job ====
+- Description in 'When <situation> I want to <motivation> so I can <expected outcome>' format
+==== RequirementsPlanner_Description_Generic ====
+- A clear, user-centric title and description
+==== RequirementsPlanner_AcceptanceCriteria_Gherkin ====
+- Acceptance criteria in Gherkin-style format using <pre><code class="language-gherkin"></code></pre> (no markdown)
+==== RequirementsPlanner_AcceptanceCriteria_BulletPoints ====
+- Acceptance criteria as bullet points
+==== RequirementsPlanner_AcceptanceCriteria_SAFeStyle ====
+- Acceptance criteria that are clear, unambiguous and testable
+==== RequirementsPlanner_TagsAndHtmlAdvice ====
+- A "tags" array for engineering triage (e.g., ["frontend", "backend", "integration", "performance", "security", "accessibility", "needs-design"])
+Use HTML formatting in descriptions and acceptance criteria only when it improves readability, such as for bulleted lists. Avoid unnecessary tags like wrapping everything in <p> elements.
+==== RequirementsPlanner_StoriesOnlyBlock ====
+Stories Only:
+Do not generate epics or features. Only return an array of user stories in this format:
+{"stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""]}]}
+==== RequirementsPlanner_EpicsJsonBlock ====
+Return strict JSON using this format:
+{"epics":[{"title":"","description":"","features":[{"title":"","description":"","stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""]}]}]}]}
+==== RequirementsPlanner_ClarifyBlock ====
+Clarify Requirements:
+Before writing the output, review the requirement and ask for clarification if:
+- Expected user behaviors or flows are ambiguous
+- Access restrictions or permissions are not clearly defined
+- Search or filtering functionality is mentioned without scope (e.g., partial matches, filtering fields)
+- External system dependencies are implied but not detailed (e.g., email sending, file uploads, audit logging)
+- Non-functional requirements are vague (e.g., "must be fast")
+- It's unclear if optional elements (e.g., "nice to have" features) are in scope
+
+If anything is unclear, ask precise, targeted clarification questions first, then proceed once answered.


### PR DESCRIPTION
## Summary
- consolidate multiple requirements planner prompt fragments into larger sections
- reference the consolidated sections in RequirementsPlanner page

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_68678fb4d1988328b0c6fb5c2b081055