### PR TITLE
Rename Bulk Tag menu item

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -26,7 +26,7 @@
     <MudText Typo="Typo.body2">@((MarkupString)L["ReleaseNotes"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Bulk Tag</MudText>
+    <MudText Typo="Typo.h6">Work Item Bulk Tag</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["BulkTag"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.es.resx
@@ -22,7 +22,7 @@
     <value>Validación de elementos de trabajo</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>Etiquetado masivo</value>
+    <value>Etiquetado masivo de elementos</value>
   </data>
   <data name="WorkItemViewer" xml:space="preserve">
     <value>Visor de elementos</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.resx
@@ -22,7 +22,7 @@
     <value>Work Item Validation</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>Bulk Tag</value>
+    <value>Work Item Bulk Tag</value>
   </data>
   <data name="WorkItemViewer" xml:space="preserve">
     <value>Work Item Viewer</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -6,7 +6,7 @@
 @inject IStringLocalizer<BulkTag> L
 @inherits ProjectComponentBase
 
-<PageTitle>DevOpsAssistant - Bulk Tag</PageTitle>
+<PageTitle>DevOpsAssistant - Work Item Bulk Tag</PageTitle>
 
 @if (!string.IsNullOrWhiteSpace(_error))
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -34,7 +34,7 @@
     <value>&lt;p&gt;Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.&lt;/p&gt;&lt;p&gt;Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.&lt;/p&gt;</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>&lt;p&gt;Elija varias historias, seleccione una o más etiquetas y aplíquelas de una vez.&lt;/p&gt;</value>
+    <value>&lt;p&gt;Elija varios elementos, seleccione una o más etiquetas y aplíquelas de una vez.&lt;/p&gt;</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Muestre gráficas de rendimiento, tiempo de entrega, tiempo de ciclo, velocidad, burn up y flujo para el backlog elegido.&lt;/p&gt;&lt;p&gt;El rendimiento cuenta los elementos cerrados en cada periodo. El tiempo de entrega es la diferencia entre la Fecha de creación y la Fecha de cierre. El tiempo de ciclo se calcula desde la Fecha de activación hasta el cierre. La velocidad suma los Puntos de Historia o la Estimación Original de las historias completadas. La gráfica burn up proyecta la finalización usando los puntos adicionales, la eficiencia y el rango de error, mientras que el flujo acumulado muestra backlog, trabajo en progreso y tareas terminadas día a día.&lt;/p&gt;&lt;p&gt;Utilice las gráficas para detectar tendencias y planificar iteraciones futuras.&lt;/p&gt;</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -34,7 +34,7 @@
     <value>&lt;p&gt;Select stories and build a prompt that summarizes them for release notes.&lt;/p&gt;&lt;p&gt;Prompts can be copied or downloaded, splitting into parts with arrows to navigate.&lt;/p&gt;</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>&lt;p&gt;Choose multiple stories, pick one or more tags, and apply them all at once.&lt;/p&gt;</value>
+    <value>&lt;p&gt;Choose multiple work items, pick one or more tags, and apply them all at once.&lt;/p&gt;</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Display throughput, lead time, cycle time, velocity, burn up and flow charts for the chosen backlog.&lt;/p&gt;&lt;p&gt;Throughput counts the work items closed in each period. Lead time is the number of days from Created Date to Closed Date. Cycle time measures Activated Date to Closed Date. Velocity sums Story Points or Original Estimate for completed stories. The burn up forecast uses additional points, efficiency and error range, while cumulative flow tracks backlog, work in progress and done items each day.&lt;/p&gt;&lt;p&gt;Use these charts to spot trends and plan future iterations.&lt;/p&gt;</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.es.resx
@@ -28,7 +28,7 @@
     <value>Notas de lanzamiento — genere un resumen para las historias completadas</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>Etiquetado masivo — agrega etiquetas a varias historias</value>
+    <value>Etiquetado masivo de elementos — agrega etiquetas a varios items</value>
   </data>
   <data name="Quality" xml:space="preserve">
     <value>Calidad de la historia — revise las historias para el cumplimiento de INVEST</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Home.resx
@@ -28,7 +28,7 @@
     <value>Release Notes — generate a summary prompt for completed stories</value>
   </data>
   <data name="BulkTag" xml:space="preserve">
-    <value>Bulk Tag — apply existing tags to multiple stories</value>
+    <value>Work Item Bulk Tag — apply existing tags to multiple items</value>
   </data>
   <data name="Quality" xml:space="preserve">
     <value>Story Quality — review stories for INVEST compliance</value>


### PR DESCRIPTION
## Summary
- rename `Bulk Tag` to `Work Item Bulk Tag`
- update Spanish translations
- adjust help content and page title

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686799277d3883289c2f391373d842b8