### PR TITLE
Improve project color handling

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -61,6 +61,7 @@
     protected override void OnInitialized()
     {
         ThemeSession.ThemeChanged += OnThemeChanged;
+        ConfigService.ProjectChanged += OnProjectChanged;
     }
 
     protected override async Task OnInitializedAsync()
@@ -126,8 +127,14 @@
         InvokeAsync(StateHasChanged);
     }
 
+    private void OnProjectChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
     public void Dispose()
     {
         ThemeSession.ThemeChanged -= OnThemeChanged;
+        ConfigService.ProjectChanged -= OnProjectChanged;
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -144,6 +144,9 @@
   <data name="ProjectColor" xml:space="preserve">
     <value>Color del proyecto</value>
   </data>
+  <data name="ClearColor" xml:space="preserve">
+    <value>Borrar color</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Configuración del proyecto</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -49,7 +49,15 @@
                         }
                     }
                     <MudTextField @bind-Value="_model.MainBranch" Label='@L["MainBranch"]'/>
-                    <MudTextField T="string" Value="_color" ValueChanged="OnColorChanged" InputType="InputType.Color" Label='@L["ProjectColor"]' />
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                        <MudText Typo="Typo.body1">@L["ProjectColor"]</MudText>
+                        <MudTextField T="string" Value="_color" ValueChanged="OnColorChanged"
+                                     InputType="InputType.Color" Style="width:3rem;height:2rem;padding:0" />
+                        @if (!string.IsNullOrWhiteSpace(_color))
+                        {
+                            <MudIconButton Icon="@Icons.Material.Filled.Clear" OnClick="ClearColor" title='@L["ClearColor"]' Color="Color.Default" />
+                        }
+                    </MudStack>
                     <MudStack Row="true" Spacing="1">
                         <MudButton OnClick="SaveGeneral" Variant="Variant.Filled" Color="Color.Primary" Disabled="!CanSave">@L["Save"]</MudButton>
                         <MudButton OnClick="Delete" Variant="Variant.Filled" Color="Color.Error">@L["DeleteProject"]</MudButton>
@@ -474,6 +482,13 @@
     private Task OnColorChanged(string value)
     {
         _color = value;
+        _generalDirty = true;
+        return Task.CompletedTask;
+    }
+
+    private Task ClearColor()
+    {
+        _color = string.Empty;
         _generalDirty = true;
         return Task.CompletedTask;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -144,6 +144,9 @@
   <data name="ProjectColor" xml:space="preserve">
     <value>Project Color</value>
   </data>
+  <data name="ClearColor" xml:space="preserve">
+    <value>Clear Color</value>
+  </data>
   <data name="ProjectSettings" xml:space="preserve">
     <value>Project Settings</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -87,17 +87,25 @@ public class DevOpsConfigService
     public async Task<bool> SaveCurrentAsync(string name, DevOpsConfig config, string color)
     {
         var wasValid = IsCurrentProjectValid;
-        name = name.Trim();
-        if (!CurrentProject.Name.Equals(name, StringComparison.OrdinalIgnoreCase) &&
-            Projects.Any(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase)))
+        var trimmedName = name.Trim();
+        var trimmedColor = color.Trim();
+
+        if (!CurrentProject.Name.Equals(trimmedName, StringComparison.OrdinalIgnoreCase) &&
+            Projects.Any(p => p.Name.Equals(trimmedName, StringComparison.OrdinalIgnoreCase)))
             return false;
 
-        CurrentProject.Name = name;
+        var nameChanged = !CurrentProject.Name.Equals(trimmedName, StringComparison.OrdinalIgnoreCase);
+        var colorChanged = !CurrentProject.Color.Equals(trimmedColor, StringComparison.OrdinalIgnoreCase);
+
+        CurrentProject.Name = trimmedName;
         CurrentProject.Config = Normalize(config);
-        CurrentProject.Color = color.Trim();
+        CurrentProject.Color = trimmedColor;
+
         await SaveProjectsAsync();
-        if (wasValid != IsCurrentProjectValid)
+
+        if (wasValid != IsCurrentProjectValid || nameChanged || colorChanged)
             OnProjectChanged();
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- trigger UI update when project color or name changes
- adjust ProjectSettings UI to allow removing color
- connect SimpleLayout to project change event
- localize new `ClearColor` action

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6867987df6748328bff8ddd840352d85