### PR TITLE
Fix text input and clone wiki tree

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/WikiDocumentSelector.razor
@@ -18,7 +18,12 @@
 }
 else if (Source == DocumentSource.Text)
 {
-    <MudTextField T="string" @bind-Value="Text" Lines="4" Placeholder="@L["TextPlaceholder"]" Immediate="true" />
+    <MudTextField T="string"
+                  Value="@Text"
+                  ValueChanged="OnTextChanged"
+                  Lines="4"
+                  Placeholder="@L["TextPlaceholder"]"
+                  Immediate="true" />
 }
 else if (WikiItems != null)
 {
@@ -55,6 +60,12 @@ else if (WikiItems != null)
     {
         Source = source;
         return SourceChanged.InvokeAsync(Source);
+    }
+
+    private Task OnTextChanged(string? value)
+    {
+        Text = value;
+        return TextChanged.InvokeAsync(Text);
     }
 
     private Task OnSelectedPagesChanged(IReadOnlyCollection<WikiPageNode> pages)

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -29,7 +29,7 @@
                                    FileChanged="@(f => _promptFile = f)"
                                    Text="@_promptText"
                                    TextChanged="@(t => _promptText = t)"
-                                   WikiItems="@_wikiItems"
+                                   WikiItems="@_promptWikiItems"
                                    SelectedPages="@_promptSelectedPages"
                                    SelectedPagesChanged="@(p => _promptSelectedPages = p)" />
         </MudStack>
@@ -182,6 +182,7 @@
     [Parameter] public string ProjectName { get; set; } = string.Empty;
     private MudStepper? _stepper;
     private List<TreeItemData<WikiPageNode>>? _wikiItems;
+    private List<TreeItemData<WikiPageNode>>? _promptWikiItems;
     private IReadOnlyCollection<WikiPageNode>? _selectedPages;
     private IBrowserFile? _file;
     private string _text = string.Empty;
@@ -246,7 +247,10 @@
                     _wikiId = wikis[0].Id;
                 var root = await ApiService.GetWikiPageTreeAsync(_wikiId);
                 if (root != null)
+                {
                     _wikiItems = [BuildTreeItem(root)];
+                    _promptWikiItems = [BuildTreeItem(root)];
+                }
             }
 
             _error = null;


### PR DESCRIPTION
## Summary
- ensure WikiDocumentSelector propagates pasted text to the parent
- clone wiki tree for both selectors in RequirementsPlanner

## Testing
- `dotnet build --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6867b3589ec8832885bd916d86d0a165