### PR TITLE
Fix preview styling

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -19,11 +19,15 @@
     @if (Preview)
     {
         <MudText Typo="Typo.subtitle2">Description</MudText>
-        <div class="preview-box">@((MarkupString)Description)</div>
+        <MudPaper Class="preview-box mud-typography-body1" Elevation="0">
+            @((MarkupString)Description)
+        </MudPaper>
         @if (AcceptanceCriteria != null)
         {
             <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
-            <div class="preview-box">@((MarkupString)AcceptanceCriteria)</div>
+            <MudPaper Class="preview-box mud-typography-body1" Elevation="0">
+                @((MarkupString)AcceptanceCriteria)
+            </MudPaper>
         }
         <MudText Typo="Typo.subtitle2">Tags</MudText>
         <div>@string.Join(", ", Tags)</div>

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -209,5 +209,10 @@ body {
 .cursor-pointer { cursor: pointer; }
 .drag-handle { cursor: move; }
 .no-link-style { color: inherit; text-decoration: none; }
-.preview-box { margin-bottom: 0.5rem; border: 1px solid #ccc; padding: 4px; }
+.preview-box {
+    margin-bottom: 0.5rem;
+    padding: 4px;
+    background-color: var(--mud-palette-surface, #fff);
+    border-radius: var(--mud-default-borderradius, 4px);
+}
 


### PR DESCRIPTION
## Summary
- render preview text in MudPaper instead of a div
- refine preview-box CSS

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_6867d55aad388328bfc5d8e450a44293