### PR TITLE
Render imported stories as HTML

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -16,33 +16,89 @@
             </MudTooltip>
         }
     </MudStack>
-    @if (Preview)
-    {
-        <MudText Typo="Typo.subtitle2">Description</MudText>
-        <MudPaper Class="preview-box mud-typography-body1" Elevation="0">
-            @((MarkupString)Description)
-        </MudPaper>
-        @if (AcceptanceCriteria != null)
+    <MudStack Spacing="1">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.subtitle2">Title</MudText>
+            @if (!_editTitle)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="BeginEditTitle" />
+            }
+            else
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Check" Size="Size.Small" OnClick="ConfirmTitle" />
+            }
+        </MudStack>
+        @if (_editTitle)
         {
-            <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
+            <MudTextField @bind-Value="_titleEdit" Label="Title" />
+        }
+        else
+        {
+            <div>@Title</div>
+        }
+
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.subtitle2">Description</MudText>
+            @if (!_editDescription)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="BeginEditDescription" />
+            }
+            else
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Check" Size="Size.Small" OnClick="ConfirmDescription" />
+            }
+        </MudStack>
+        @if (_editDescription)
+        {
+            <MudTextField @bind-Value="_descriptionEdit" Label="Description" Lines="3" />
+        }
+        else
+        {
             <MudPaper Class="preview-box mud-typography-body1" Elevation="0">
-                @((MarkupString)AcceptanceCriteria)
+                @((MarkupString)Description)
             </MudPaper>
         }
-        <MudText Typo="Typo.subtitle2">Tags</MudText>
-        <div>@string.Join(", ", Tags)</div>
-    }
-    else
-    {
-        <MudTextField @bind-Value="Title" Label="Title" />
-        <MudTextField @bind-Value="Description" Label="Description" Lines="3" />
+
         @if (AcceptanceCriteria != null)
         {
-            <MudTextField @bind-Value="AcceptanceCriteria" Label="Acceptance Criteria" Lines="3" />
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                <MudText Typo="Typo.subtitle2">Acceptance Criteria</MudText>
+                @if (!_editCriteria)
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="BeginEditCriteria" />
+                }
+                else
+                {
+                    <MudIconButton Icon="@Icons.Material.Filled.Check" Size="Size.Small" OnClick="ConfirmCriteria" />
+                }
+            </MudStack>
+            @if (_editCriteria)
+            {
+                <MudTextField @bind-Value="_criteriaEdit" Label="Acceptance Criteria" Lines="3" />
+            }
+            else
+            {
+                <MudPaper Class="preview-box mud-typography-body1" Elevation="0">
+                    @((MarkupString)AcceptanceCriteria)
+                </MudPaper>
+            }
         }
-        <MudStack Spacing="1">
+
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.subtitle2">Tags</MudText>
+            @if (!_editTags)
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Edit" Size="Size.Small" OnClick="BeginEditTags" />
+            }
+            else
+            {
+                <MudIconButton Icon="@Icons.Material.Filled.Check" Size="Size.Small" OnClick="ConfirmTags" />
+            }
+        </MudStack>
+        @if (_editTags)
+        {
             <MudChipSet T="string">
-                @foreach (var t in Tags)
+                @foreach (var t in _tagsEdit)
                 {
                     if (IsProtected(t))
                     {
@@ -58,8 +114,12 @@
                 <MudTextField T="string" @bind-Value="_newTag" Label="Tag" />
                 <MudButton Variant="Variant.Text" OnClick="AddTag" Disabled="string.IsNullOrWhiteSpace(_newTag)">Add</MudButton>
             </MudStack>
-        </MudStack>
-    }
+        }
+        else
+        {
+            <div>@string.Join(", ", Tags)</div>
+        }
+    </MudStack>
 
     @if (ChildContent != null)
     {
@@ -69,7 +129,6 @@
 
 @code {
     [Parameter] public string Type { get; set; } = string.Empty;
-    [Parameter] public bool Preview { get; set; }
     [Parameter] public bool Draggable { get; set; }
     [Parameter] public bool Droppable { get; set; }
     [Parameter] public EventCallback DragStart { get; set; }
@@ -87,6 +146,14 @@
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private string _newTag = string.Empty;
+    private bool _editTitle;
+    private bool _editDescription;
+    private bool _editCriteria;
+    private bool _editTags;
+    private string _titleEdit = string.Empty;
+    private string _descriptionEdit = string.Empty;
+    private string? _criteriaEdit;
+    private List<string> _tagsEdit = new();
 
     private Typo HeaderTypo => Type switch
     {
@@ -99,9 +166,8 @@
     {
         if (!string.IsNullOrWhiteSpace(_newTag))
         {
-            Tags.Add(_newTag.Trim());
+            _tagsEdit.Add(_newTag.Trim());
             _newTag = string.Empty;
-            TagsChanged.InvokeAsync(Tags);
         }
     }
 
@@ -111,8 +177,7 @@
     {
         if (IsProtected(tag))
             return;
-        Tags.Remove(tag);
-        TagsChanged.InvokeAsync(Tags);
+        _tagsEdit.Remove(tag);
     }
 
     private Task OnDropInternal()
@@ -120,5 +185,57 @@
         if (Droppable && Drop.HasDelegate)
             return Drop.InvokeAsync();
         return Task.CompletedTask;
+    }
+
+    private void BeginEditTitle()
+    {
+        _titleEdit = Title;
+        _editTitle = true;
+    }
+
+    private async Task ConfirmTitle()
+    {
+        _editTitle = false;
+        Title = _titleEdit;
+        await TitleChanged.InvokeAsync(Title);
+    }
+
+    private void BeginEditDescription()
+    {
+        _descriptionEdit = Description;
+        _editDescription = true;
+    }
+
+    private async Task ConfirmDescription()
+    {
+        _editDescription = false;
+        Description = _descriptionEdit;
+        await DescriptionChanged.InvokeAsync(Description);
+    }
+
+    private void BeginEditCriteria()
+    {
+        _criteriaEdit = AcceptanceCriteria;
+        _editCriteria = true;
+    }
+
+    private async Task ConfirmCriteria()
+    {
+        _editCriteria = false;
+        AcceptanceCriteria = _criteriaEdit;
+        await AcceptanceCriteriaChanged.InvokeAsync(AcceptanceCriteria);
+    }
+
+    private void BeginEditTags()
+    {
+        _tagsEdit = Tags.ToList();
+        _editTags = true;
+    }
+
+    private async Task ConfirmTags()
+    {
+        _editTags = false;
+        Tags = _tagsEdit;
+        await TagsChanged.InvokeAsync(Tags);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -28,7 +28,7 @@
     <value>&lt;p&gt;Genere un prompt detallado para revisar y calificar historias con INVEST y brindar coaching usando su Definición de Ready.&lt;/p&gt;&lt;p&gt;Los prompts largos se dividen en partes y puede cambiar entre ellas con las flechas.&lt;/p&gt;</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>&lt;p&gt;Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos.&lt;/p&gt;&lt;p&gt;Utilice HTML en las descripciones y criterios cuando ayude al formato. Active Vista previa HTML tras importar para verificar el marcado.&lt;/p&gt;</value>
+    <value>&lt;p&gt;Desglose páginas wiki o documentos cargados en un plan de épicas, características e historias y cree los elementos.&lt;/p&gt;&lt;p&gt;Utilice HTML en las descripciones y criterios cuando ayude al formato. El texto importado se muestra automáticamente para que pueda verificar el marcado.&lt;/p&gt;</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>&lt;p&gt;Seleccione historias y construya un prompt que las resuma para las notas de lanzamiento.&lt;/p&gt;&lt;p&gt;Puede copiar o descargar los prompts, que se dividen en partes navegables con flechas.&lt;/p&gt;</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -28,7 +28,7 @@
     <value>&lt;p&gt;Generate a detailed prompt to score stories against INVEST and provide coaching using your Definition of Ready.&lt;/p&gt;&lt;p&gt;Long prompts are split into parts—navigate between them with the arrows.&lt;/p&gt;</value>
   </data>
   <data name="RequirementsPlanner" xml:space="preserve">
-    <value>&lt;p&gt;Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items.&lt;/p&gt;&lt;p&gt;Use HTML in descriptions and acceptance criteria when it helps with lists or formatting, and toggle Preview HTML after importing to verify markup.&lt;/p&gt;</value>
+    <value>&lt;p&gt;Break wiki pages or uploaded documents into a plan of Epics, Features and Stories, then create work items.&lt;/p&gt;&lt;p&gt;Use HTML in descriptions and acceptance criteria when it helps with lists or formatting. Imported text is rendered automatically so you can verify markup.&lt;/p&gt;</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
     <value>&lt;p&gt;Select stories and build a prompt that summarizes them for release notes.&lt;/p&gt;&lt;p&gt;Prompts can be copied or downloaded, splitting into parts with arrows to navigate.&lt;/p&gt;</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -85,7 +85,6 @@
     <MudStep Title="Create Work Items" Disabled="@(_plan == null)">
         @if (_plan != null)
         {
-            <MudSwitch T="bool" @bind-Value="_previewHtml" Color="Color.Primary" Label="Preview HTML" />
             if (_storiesOnly)
             {
                 <MudAutocomplete T="WorkItemInfo"
@@ -99,7 +98,6 @@
                     <PlanItemEditor Type="User Story"
                                     Draggable="true"
                                     Droppable="true"
-                                    Preview="_previewHtml"
                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnStoryList(story))"
                                     OnDelete="EventCallback.Factory.Create(this, () => RemoveStory(story))"
@@ -117,7 +115,6 @@
                     <PlanItemEditor Type="Epic"
                                     Draggable="true"
                                     Droppable="true"
-                                    Preview="_previewHtml"
                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(epic))"
                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnPlan(epic))"
                                     OnDelete="EventCallback.Factory.Create(this, () => RemoveEpic(epic))"
@@ -129,7 +126,6 @@
                             <PlanItemEditor Type="Feature"
                                             Draggable="true"
                                             Droppable="true"
-                                            Preview="_previewHtml"
                                             DragStart="EventCallback.Factory.Create(this, () => OnDragStart(feature))"
                                             Drop="EventCallback.Factory.Create(this, () => OnDropOnEpic(epic))"
                                             OnDelete="EventCallback.Factory.Create(this, () => RemoveFeature(feature))"
@@ -141,7 +137,6 @@
                                     <PlanItemEditor Type="User Story"
                                                     Draggable="true"
                                                     Droppable="true"
-                                                    Preview="_previewHtml"
                                                     DragStart="EventCallback.Factory.Create(this, () => OnDragStart(story))"
                                                     Drop="EventCallback.Factory.Create(this, () => OnDropOnFeature(feature))"
                                                     OnDelete="EventCallback.Factory.Create(this, () => RemoveStory(story))"
@@ -202,7 +197,6 @@
     private string _backlog = string.Empty;
     private bool _storiesOnly;
     private bool _clarify;
-    private bool _previewHtml;
     private WorkItemInfo? _feature;
     private Plan? _plan;
     private readonly List<int> _createdItems = new();


### PR DESCRIPTION
## Summary
- display plan items in read-only mode with edit buttons
- remove the Preview HTML toggle from requirements planner
- update help text to mention automatic rendering

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6867d786031083289663834bc9aa9f7b