### PR TITLE
Show AI tag in imported items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -440,7 +440,10 @@
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             _plan = JsonSerializer.Deserialize<Plan>(json, options);
             if (_plan != null)
+            {
+                AddAiGeneratedTags(_plan);
                 SetTagStrings(_plan);
+            }
             _error = null;
             _ = _stepper?.NextStepAsync();
         }
@@ -474,6 +477,28 @@
                     story.TagString = string.Join(", ", story.Tags);
             }
         }
+    }
+
+    private static void AddAiGeneratedTags(Plan plan)
+    {
+        foreach (var story in plan.Stories)
+            AddTagIfMissing(story.Tags);
+        foreach (var epic in plan.Epics)
+        {
+            AddTagIfMissing(epic.Tags);
+            foreach (var feature in epic.Features)
+            {
+                AddTagIfMissing(feature.Tags);
+                foreach (var story in feature.Stories)
+                    AddTagIfMissing(story.Tags);
+            }
+        }
+    }
+
+    private static void AddTagIfMissing(ICollection<string> tags)
+    {
+        if (!tags.Any(t => string.Equals(t, AppConstants.AiGeneratedTag, StringComparison.OrdinalIgnoreCase)))
+            tags.Add(AppConstants.AiGeneratedTag);
     }
 
     private async Task CreateItems()


### PR DESCRIPTION
## Summary
- add AI generated tag when importing work items
- protect AI tag from deletion in editor tests
- test import adds AI tag

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6867dec0d5bc8328aca47a70ff20e1af