### PR TITLE
Add work item granularity option

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -25,6 +25,7 @@ public class DevOpsConfigServiceTests
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
             MainBranch = " main ",
+            WorkItemGranularity = 3,
             OutputFormat = OutputFormat.Pdf,
             Standards = new PromptStandards
             {
@@ -62,6 +63,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("RN", storedCfg.ReleaseNotesPrompt);
         Assert.Equal("RP", storedCfg.RequirementsPrompt);
         Assert.Equal("main", storedCfg.MainBranch);
+        Assert.Equal(3, storedCfg.WorkItemGranularity);
         Assert.Equal(OutputFormat.Pdf, storedCfg.OutputFormat);
         Assert.Contains("Gherkin", storedCfg.Standards.UserStoryAcceptanceCriteria);
         Assert.Contains("ScrumUserStory", storedCfg.Standards.UserStoryDescription);
@@ -84,6 +86,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPromptMode = PromptMode.Append,
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
+            WorkItemGranularity = 7,
             OutputFormat = OutputFormat.Pdf,
             Standards = new PromptStandards
             {
@@ -142,6 +145,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPromptMode = PromptMode.Append,
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
+            WorkItemGranularity = 5,
             OutputFormat = OutputFormat.Pdf,
             Standards = new PromptStandards
             {
@@ -164,6 +168,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
         Assert.Equal(OutputFormat.Pdf, service.Config.OutputFormat);
+        Assert.Equal(5, service.Config.WorkItemGranularity);
         Assert.Contains("Gherkin", service.Config.Standards.UserStoryAcceptanceCriteria);
         Assert.Empty(service.Config.Standards.UserStoryDescription);
         Assert.Equal("default", service.CurrentProject.Name);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -33,6 +33,9 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Límite de caracteres del prompt</value>
   </data>
+  <data name="WorkItemGranularity" xml:space="preserve">
+    <value>Granularidad de elementos de trabajo</value>
+  </data>
   <data name="OutputFormat" xml:space="preserve">
     <value>Formato de salida</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -87,6 +87,12 @@
                         <MudRadio T="PromptMode" Value="PromptMode.Replace">@L["PromptReplace"]</MudRadio>
                         <MudRadio T="PromptMode" Value="PromptMode.Append">@L["PromptAppend"]</MudRadio>
                     </MudRadioGroup>
+                    <MudText Typo="Typo.subtitle2">@L["WorkItemGranularity"]: @_model.WorkItemGranularity</MudText>
+                    <MudSlider T="int" Min="1" Max="10" Step="1"
+                               Value="_model.WorkItemGranularity"
+                               Immediate="true"
+                               ValueChanged="OnGranularityChanged"
+                               Color="Color.Primary" />
                     <MudTextField T="int" Value="_model.PromptCharacterLimit" ValueChanged="OnPromptsLimitChanged" Label='@L["PromptLimit"]' InputType="InputType.Number" />
                     <MudSelect T="OutputFormat" Value="_model.OutputFormat" ValueChanged="OnOutputFormatChanged" Label='@L["OutputFormat"]'>
                         <MudSelectItem Value="OutputFormat.Markdown">Markdown</MudSelectItem>
@@ -236,6 +242,7 @@
             ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
             RequirementsPromptMode = cfg.RequirementsPromptMode,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
+            WorkItemGranularity = cfg.WorkItemGranularity,
             OutputFormat = cfg.OutputFormat,
             Standards = cfg.Standards,
             Rules = new ValidationRules
@@ -291,6 +298,7 @@
             ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode,
             RequirementsPromptMode = _model.RequirementsPromptMode,
             PromptCharacterLimit = _model.PromptCharacterLimit,
+            WorkItemGranularity = _model.WorkItemGranularity,
             OutputFormat = _model.OutputFormat,
             Standards = _model.Standards,
             Rules = _model.Rules
@@ -328,6 +336,7 @@
         cfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
         cfg.RequirementsPromptMode = _model.RequirementsPromptMode;
         cfg.PromptCharacterLimit = _model.PromptCharacterLimit;
+        cfg.WorkItemGranularity = _model.WorkItemGranularity;
         cfg.OutputFormat = _model.OutputFormat;
         cfg.Standards = _model.Standards;
         await ConfigService.SaveCurrentAsync(_model.Project, cfg, _color);
@@ -361,6 +370,7 @@
                 pcfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
                 pcfg.RequirementsPromptMode = _model.RequirementsPromptMode;
                 pcfg.PromptCharacterLimit = _model.PromptCharacterLimit;
+                pcfg.WorkItemGranularity = _model.WorkItemGranularity;
                 pcfg.OutputFormat = _model.OutputFormat;
                 pcfg.Standards = _model.Standards;
                 await ConfigService.UpdateProjectAsync(p.Name, p.Name, pcfg, p.Color);
@@ -517,6 +527,13 @@
     private Task OnOutputFormatChanged(OutputFormat value)
     {
         _model.OutputFormat = value;
+        _promptsDirty = true;
+        return Task.CompletedTask;
+    }
+
+    private Task OnGranularityChanged(int value)
+    {
+        _model.WorkItemGranularity = value;
         _promptsDirty = true;
         return Task.CompletedTask;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -33,6 +33,9 @@
   <data name="PromptLimit" xml:space="preserve">
     <value>Prompt Character Limit</value>
   </data>
+  <data name="WorkItemGranularity" xml:space="preserve">
+    <value>Work Item Granularity</value>
+  </data>
   <data name="OutputFormat" xml:space="preserve">
     <value>Output Format</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -602,6 +602,7 @@
             else if (config.Standards.UserStoryAcceptanceCriteria.Contains("SAFeStyle"))
                 sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_SAFeStylePrompt.Value);
             sb.AppendLine(GeneratedPrompts.RequirementsPlanner_TagsAndHtmlAdvicePrompt.Value);
+            sb.AppendLine($"Work item granularity level {config.WorkItemGranularity}/10: 1 = large complex items, 10 = smallest sensible tasks.");
 
             if (config.Standards.UserStoryQuality.Count > 0)
             {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -16,6 +16,7 @@ public class DevOpsConfig
     public PromptMode ReleaseNotesPromptMode { get; set; }
     public PromptMode RequirementsPromptMode { get; set; }
     public int PromptCharacterLimit { get; set; }
+    public int WorkItemGranularity { get; set; } = 5;
     public OutputFormat OutputFormat { get; set; }
     public PromptStandards Standards { get; set; } = new();
     public ValidationRules Rules { get; set; } = new();

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -212,6 +212,7 @@ public class DevOpsConfigService
             ReleaseNotesPromptMode = config.ReleaseNotesPromptMode,
             RequirementsPromptMode = config.RequirementsPromptMode,
             PromptCharacterLimit = config.PromptCharacterLimit,
+            WorkItemGranularity = config.WorkItemGranularity,
             OutputFormat = config.OutputFormat,
             Standards = config.Standards,
             Rules = config.Rules
@@ -242,6 +243,7 @@ public class DevOpsConfigService
             ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
             RequirementsPromptMode = cfg.RequirementsPromptMode,
             PromptCharacterLimit = cfg.PromptCharacterLimit,
+            WorkItemGranularity = cfg.WorkItemGranularity,
             OutputFormat = cfg.OutputFormat,
             Standards = cfg.Standards,
             Rules = cfg.Rules


### PR DESCRIPTION
## Summary
- add work item granularity property to config
- save/load the property via DevOpsConfigService
- expose slider in project settings
- localize slider label
- add prompt text about granularity level
- test config persistence

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686826f845d0832884c99514d1d1c660