### PR TITLE
Refactor prompt building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Codex must be proficient in the following technologies and frameworks, which are
 - Use async/await for I/O operations.
 - Avoid Bootstrap. Prefer MudBlazor components and attributes for layout and spacing.
 - Avoid hardcoded strings in the UI – use localization resources.
+- Store all AI prompt text in the `Prompts` folder for the source generator; never hardcode prompts in C# code.
 - Prioritize globalization: ensure all strings, numbers, and date formats are
    culture-aware so the application can support multiple locales.
 

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Net;
 using System.Threading;
 using System.Linq;
@@ -28,8 +27,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
             }
         };
 
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, [details, new DevOpsConfig()])!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(details, new DevOpsConfig());
 
         Assert.Contains("\"AcceptanceCriteria\": \"criteria\"", result);
     }
@@ -45,8 +44,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
             }
         };
 
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, [details, new DevOpsConfig()])!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(details, new DevOpsConfig());
 
         Assert.Contains("Bugs are also in scope", result);
     }
@@ -54,8 +53,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Includes_NoBranding_Note()
     {
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, [new List<StoryHierarchyDetails>(), new DevOpsConfig()])!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), new DevOpsConfig());
 
         Assert.Contains("No branding is required.", result);
     }
@@ -79,8 +78,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
                 Bug = new BugRules { IncludeReproSteps = false }
             }
         };
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, [details, cfg])!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(details, cfg);
 
         Assert.DoesNotContain("ReproSteps", result);
     }
@@ -104,8 +103,8 @@ public class ReleaseNotesPageTests : ComponentTestBase
                 Bug = new BugRules { IncludeSystemInfo = false }
             }
         };
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, [details, cfg])!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(details, cfg);
 
         Assert.DoesNotContain("SystemInfo", result);
     }
@@ -113,10 +112,10 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Inline_Format_Does_Not_Request_Conversion()
     {
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var svc = new PromptService();
         var cfg = new DevOpsConfig { OutputFormat = OutputFormat.Inline };
 
-        var result = (string)method.Invoke(null, [new List<StoryHierarchyDetails>(), cfg])!;
+        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), cfg);
 
         Assert.DoesNotContain("convert the content", result);
         Assert.Contains("Reply inline", result);
@@ -125,9 +124,9 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Includes_Templates()
     {
-        var method = typeof(ReleaseNotes).GetMethod("BuildPrompt", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var svc = new PromptService();
 
-        var result = (string)method.Invoke(null, [new List<StoryHierarchyDetails>(), new DevOpsConfig()])!;
+        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), new DevOpsConfig());
 
         Assert.Contains("# Release Notes", result);
         Assert.Contains("# Change Control Ticket", result);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ComponentTestBase.cs
@@ -24,6 +24,7 @@ public abstract class ComponentTestBase : TestContext
         Services.AddSingleton(config);
         Services.AddSingleton(new PageStateService(storage, config));
         Services.AddSingleton(new ThemeSessionService(JSInterop.JSRuntime));
+        Services.AddSingleton<PromptService>();
         if (includeApi)
         {
             var deployment = new DeploymentConfigService(new HttpClient());

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -11,6 +11,8 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@inject PromptService PromptService
+@inject PromptService PromptService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Metrics> L
 @inject ISnackbar Snackbar
@@ -724,45 +726,6 @@ else if (_periods.Any())
         _showBurnChartControls = !_showBurnChartControls;
     }
 
-    private static string BuildPrompt(IEnumerable<PeriodMetrics> periods, OutputFormat format)
-    {
-        var list = periods.ToList();
-        var metrics = list.Select(p => new
-        {
-            end = p.End.ToString("yyyy-MM-dd"),
-            leadTime = p.AvgLeadTime,
-            cycleTime = p.AvgCycleTime,
-            throughput = p.Throughput,
-            velocity = p.Velocity,
-            avgWip = p.AvgWip,
-            sprintEfficiency = p.SprintEfficiency
-        });
-
-        var summary = new
-        {
-            avgLeadTime = list.Any() ? list.Average(p => p.AvgLeadTime) : 0,
-            avgCycleTime = list.Any() ? list.Average(p => p.AvgCycleTime) : 0,
-            avgThroughput = list.Any() ? list.Average(p => p.Throughput) : 0,
-            avgVelocity = list.Any() ? list.Average(p => p.Velocity) : 0,
-            avgWip = list.Any() ? list.Average(p => p.AvgWip) : 0,
-            avgSprintEfficiency = list.Any() ? list.Average(p => p.SprintEfficiency) : 0
-        };
-
-        var payload = new { metrics, summary };
-        var json = JsonSerializer.Serialize(payload);
-
-        var sb = new StringBuilder();
-        sb.AppendLine(GeneratedPrompts.Metrics_MainPrompt.Value);
-        sb.AppendLine();
-        if (format == OutputFormat.Inline)
-            sb.AppendLine(GeneratedPrompts.FormatInstructions_MetricsInlinePrompt.Value);
-        else
-            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_MetricsConvertPrompt.Value, format));
-        sb.AppendLine();
-        sb.AppendLine($"Data: {json}");
-        sb.AppendLine();
-        return sb.ToString();
-    }
 
     private async Task ExportCsv()
     {
@@ -774,7 +737,7 @@ else if (_periods.Any())
     private async Task CopyPrompt()
     {
         if (_periods.Count == 0) return;
-        var prompt = BuildPrompt(_periods, ConfigService.Config.OutputFormat);
+        var prompt = PromptService.BuildMetricsPrompt(_periods, ConfigService.Config.OutputFormat);
         await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }
@@ -861,18 +824,6 @@ else if (_periods.Any())
     }
 
 
-    private class PeriodMetrics
-    {
-        public string Name { get; set; } = string.Empty;
-        public DateTime Start { get; set; }
-        public DateTime End { get; set; }
-        public double AvgLeadTime { get; set; }
-        public double AvgCycleTime { get; set; }
-        public int Throughput { get; set; }
-        public double Velocity { get; set; }
-        public double AvgWip { get; set; }
-        public double SprintEfficiency { get; set; }
-    }
 
     private class PageState
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -9,6 +9,7 @@
 @using GeneratedPrompts
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
+@inject PromptService PromptService
 @inherits ProjectComponentBase
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
@@ -94,7 +95,7 @@ else if (_promptParts != null)
         {
             var ids = _selectedItems.Select(s => s.Id);
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
-            _prompt = BuildPrompt(details, ConfigService.Config);
+            _prompt = PromptService.BuildReleaseNotesPrompt(details, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             _error = null;
@@ -155,69 +156,6 @@ else if (_promptParts != null)
     }
 
 
-    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
-    {
-        var hierarchy = details.Select(d => new
-        {
-            Epic = d.Epic == null
-                ? null
-                : new
-                {
-                    d.Epic.Id,
-                    d.Epic.Title,
-                    Description = TextHelpers.Sanitize(d.EpicDescription)
-                },
-            Feature = d.Feature == null
-                ? null
-                : new
-                {
-                    d.Feature.Id,
-                    d.Feature.Title,
-                    Description = TextHelpers.Sanitize(d.FeatureDescription)
-                },
-            Item = new
-            {
-                d.Story.Id,
-                d.Story.Title,
-                d.Story.WorkItemType,
-                Description = TextHelpers.Sanitize(d.Description),
-                ReproSteps = config.Rules.Bug.IncludeReproSteps ? TextHelpers.Sanitize(d.ReproSteps) : null,
-                SystemInfo = config.Rules.Bug.IncludeSystemInfo ? TextHelpers.Sanitize(d.SystemInfo) : null,
-                AcceptanceCriteria = TextHelpers.Sanitize(d.AcceptanceCriteria)
-            }
-        });
-
-        var json = JsonSerializer.Serialize(
-            hierarchy,
-            new JsonSerializerOptions
-            {
-                WriteIndented = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-            });
-
-        var sb = new StringBuilder();
-
-        if (string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt) ||
-            config.ReleaseNotesPromptMode == PromptMode.Append)
-        {
-            sb.AppendLine(GeneratedPrompts.ReleaseNotes_MainPrompt.Value);
-        }
-        if (!string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt))
-        {
-            sb.AppendLine(config.ReleaseNotesPrompt.Trim());
-        }
-
-        if (config.OutputFormat == OutputFormat.Inline)
-            sb.AppendLine(GeneratedPrompts.FormatInstructions_ReleaseNotesInlinePrompt.Value);
-        else
-            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_ReleaseNotesConvertPrompt.Value, config.OutputFormat));
-        sb.AppendLine();
-        sb.AppendLine("Work items:");
-
-        sb.AppendLine(json);
-        sb.AppendLine();
-        return sb.ToString();
-    }
 
     protected override Task OnProjectChangedAsync()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -11,6 +11,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject PageStateService StateService
+@inject PromptService PromptService
 @inherits ProjectComponentBase
 @inject ISnackbar Snackbar
 @using Microsoft.Extensions.Localization
@@ -288,7 +289,7 @@
                     }
                     break;
             }
-            _prompt = BuildPrompt(pages, _storiesOnly, _clarify, ConfigService.Config);
+            _prompt = PromptService.BuildRequirementsPlannerPrompt(pages, _storiesOnly, _clarify, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             await StateService.SaveAsync(StateKey, new PageState
@@ -575,83 +576,6 @@
         return item;
     }
 
-        private static string BuildPrompt(IEnumerable<(string Name, string Text)> pages, bool storiesOnly, bool clarify, DevOpsConfig config)
-    {
-        var sb = new System.Text.StringBuilder();
-        if (string.IsNullOrWhiteSpace(config.RequirementsPrompt) ||
-            config.RequirementsPromptMode == PromptMode.Append)
-        {
-            if (storiesOnly)
-            {
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_UserStoriesBlockPrompt.Value);
-            }
-            else
-            {
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsBlockPrompt.Value);
-            }
-            if (config.Standards.UserStoryDescription.Contains("ScrumUserStory"))
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_ScrumPrompt.Value);
-            else if (config.Standards.UserStoryDescription.Contains("JobStory"))
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_JobPrompt.Value);
-            else
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_GenericPrompt.Value);
-            if (config.Standards.UserStoryAcceptanceCriteria.Contains("Gherkin"))
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_GherkinPrompt.Value);
-            else if (config.Standards.UserStoryAcceptanceCriteria.Contains("BulletPoints"))
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_BulletPointsPrompt.Value);
-            else if (config.Standards.UserStoryAcceptanceCriteria.Contains("SAFeStyle"))
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_SAFeStylePrompt.Value);
-            sb.AppendLine(GeneratedPrompts.RequirementsPlanner_TagsAndHtmlAdvicePrompt.Value);
-            sb.AppendLine($"Work item granularity level {config.WorkItemGranularity}/10: 1 = large complex items, 10 = smallest sensible tasks.");
-
-            if (config.Standards.UserStoryQuality.Count > 0)
-            {
-                sb.AppendLine();
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_StoryQualityStandardsIntroPrompt.Value);
-                foreach (var s in config.Standards.UserStoryQuality)
-                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
-            }
-
-            if (config.Standards.RequirementsDocumentation.Count > 0)
-            {
-                sb.AppendLine();
-                sb.AppendLine(GeneratedPrompts.RequirementsDocumentationStandardsIntroPrompt.Value);
-                foreach (var s in config.Standards.RequirementsDocumentation)
-                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
-            }
-
-            if (storiesOnly)
-            {
-                sb.AppendLine();
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_StoriesOnlyBlockPrompt.Value);
-            }
-            else
-            {
-                sb.AppendLine();
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsJsonBlockPrompt.Value);
-            }
-
-            if (clarify)
-            {
-                sb.AppendLine();
-                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_ClarifyBlockPrompt.Value);
-            }
-        }
-        if (!string.IsNullOrWhiteSpace(config.RequirementsPrompt))
-        {
-            sb.AppendLine(config.RequirementsPrompt.Trim());
-        }
-        sb.AppendLine();
-        sb.AppendLine(GeneratedPrompts.RequirementsPlanner_DocumentIntroPrompt.Value);
-        foreach (var page in pages)
-        {
-            sb.AppendLine($"## {page.Name}");
-            sb.AppendLine(page.Text);
-            sb.AppendLine();
-        }
-        sb.AppendLine();
-        return sb.ToString();
-    }
 
     private async Task<IEnumerable<WorkItemInfo>> SearchFeatures(string value, CancellationToken _)
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
@@ -7,6 +7,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject PromptService PromptService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<RequirementsQuality> L
 @inherits ProjectComponentBase
@@ -135,7 +136,7 @@ else if (_promptParts != null)
                     }
                     break;
             }
-            _prompt = BuildPrompt(pages, ConfigService.Config);
+            _prompt = PromptService.BuildRequirementsQualityPrompt(pages, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             _error = null;
@@ -192,27 +193,6 @@ else if (_promptParts != null)
         return item;
     }
 
-    private static string BuildPrompt(IEnumerable<(string Name, string Text)> pages, DevOpsConfig config)
-    {
-        var sb = new StringBuilder();
-        sb.AppendLine(GeneratedPrompts.RequirementsQuality_MainPrompt.Value);
-        if (config.Standards.RequirementsDocumentation.Count > 0)
-        {
-            sb.AppendLine();
-            sb.AppendLine(GeneratedPrompts.RequirementsDocumentationStandardsIntroPrompt.Value);
-            foreach (var s in config.Standards.RequirementsDocumentation)
-                sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
-        }
-        sb.AppendLine();
-        sb.AppendLine("Document:");
-        foreach (var page in pages)
-        {
-            sb.AppendLine($"## {page.Name}");
-            sb.AppendLine(page.Text);
-            sb.AppendLine();
-        }
-        return sb.ToString();
-    }
 
     protected override Task OnProjectChangedAsync()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -8,6 +8,7 @@
 @inject DevOpsApiService ApiService
 @inject IJSRuntime JS
 @inject ISnackbar Snackbar
+@inject PromptService PromptService
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<WorkItemQuality> L
 @inherits ProjectComponentBase
@@ -83,7 +84,7 @@ else if (_promptParts != null)
         try
         {
             var details = await ApiService.GetStoryHierarchyDetailsAsync(_selectedItems.Select(i => i.Id));
-            _prompt = BuildPrompt(details, ConfigService.Config);
+            _prompt = PromptService.BuildWorkItemQualityPrompt(details, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             _error = null;
@@ -141,74 +142,6 @@ else if (_promptParts != null)
         return Task.CompletedTask;
     }
 
-    private static string BuildPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
-    {
-        var items = details.Select(d => new
-        {
-            Epic = d.Epic == null
-                ? null
-                : new
-                {
-                    d.Epic.Title,
-                    Description = TextHelpers.Sanitize(d.EpicDescription)
-                },
-            Feature = d.Feature == null
-                ? null
-                : new
-                {
-                    d.Feature.Title,
-                    Description = TextHelpers.Sanitize(d.FeatureDescription)
-                },
-            Story = d.Story.WorkItemType.Equals("User Story", StringComparison.OrdinalIgnoreCase)
-                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description) }
-                : null,
-            Bug = d.Story.WorkItemType.Equals("Bug", StringComparison.OrdinalIgnoreCase)
-                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description), ReproSteps = TextHelpers.Sanitize(d.ReproSteps), SystemInfo = TextHelpers.Sanitize(d.SystemInfo) }
-                : null
-        });
-        var json = JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });
-        var sb = new StringBuilder();
-        if (string.IsNullOrWhiteSpace(config.StoryQualityPrompt) ||
-            config.StoryQualityPromptMode == PromptMode.Append)
-        {
-            sb.AppendLine("You are an expert Agile coach reviewing user stories and bugs for quality.");
-            sb.AppendLine();
-            if (config.Standards.UserStoryQuality.Count > 0)
-            {
-                sb.AppendLine(GeneratedPrompts.WorkItemQuality_StoryQualityStandardsIntroPrompt.Value);
-                foreach (var s in config.Standards.UserStoryQuality)
-                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
-                sb.AppendLine();
-            }
-            sb.AppendLine(GeneratedPrompts.WorkItemQuality_MainPrompt.Value);
-            sb.AppendLine("For bugs, check that the reproduction steps and system information are clear and complete.");
-        if (config.Standards.BugReporting.Count > 0)
-        {
-            sb.AppendLine(GeneratedPrompts.WorkItemQuality_BugReportingStandardsIntroPrompt.Value);
-            foreach (var s in config.Standards.BugReporting)
-                sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
-        }
-        if (!string.IsNullOrWhiteSpace(config.DefinitionOfReady))
-        {
-            sb.AppendLine();
-            sb.AppendLine(GeneratedPrompts.WorkItemQuality_DefinitionOfReadyIntroPrompt.Value);
-            sb.AppendLine(config.DefinitionOfReady);
-        }
-        }
-        if (!string.IsNullOrWhiteSpace(config.StoryQualityPrompt))
-        {
-            sb.AppendLine(config.StoryQualityPrompt.Trim());
-        }
-        if (config.OutputFormat == OutputFormat.Inline)
-            sb.AppendLine(GeneratedPrompts.FormatInstructions_WorkItemAnalysisInlinePrompt.Value);
-        else
-            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_WorkItemAnalysisConvertPrompt.Value, config.OutputFormat));
-        sb.AppendLine();
-        sb.AppendLine("Work items:");
-        sb.AppendLine(json);
-        sb.AppendLine();
-        return sb.ToString();
-    }
 
 
     protected override Task OnProjectChangedAsync()

--- a/src/DevOpsAssistant/DevOpsAssistant/Program.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<VersionService>();
 builder.Services.AddScoped<DeploymentConfigService>();
 builder.Services.AddLocalization();
 builder.Services.AddScoped<ThemeSessionService>();
+builder.Services.AddScoped<PromptService>();
 
 var host = builder.Build();
 var js = host.Services.GetRequiredService<IJSRuntime>();

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
@@ -75,3 +75,5 @@ You will use the following **markdown report template** to structure your output
 _Compiled by:_ **Agile Coach Persona**  
 _Report Date:_ **{{today}}**
 ```
+==== Metrics_DataIntro ====
+Data: {0}

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
@@ -110,3 +110,5 @@ Change control template:
 *Include any other relevant information for stakeholders, approvers, or implementers.*  
 [Other notes.]
 ```
+==== ReleaseNotes_WorkItemsIntro ====
+Work items:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
@@ -81,6 +81,8 @@ Each story must include:
 ==== RequirementsPlanner_TagsAndHtmlAdvice ====
 - A "tags" array for engineering triage (e.g., ["frontend", "backend", "integration", "performance", "security", "accessibility", "needs-design"])
 Use HTML formatting in descriptions and acceptance criteria only when it improves readability, such as for bulleted lists. Avoid unnecessary tags like wrapping everything in <p> elements.
+==== RequirementsPlanner_WorkItemGranularity ====
+Work item granularity level {0}/10: 1 = large complex items, 10 = smallest sensible tasks.
 ==== RequirementsPlanner_StoriesOnlyBlock ====
 Stories Only:
 Do not generate epics or features. Only return an array of user stories in this format:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
@@ -1,3 +1,5 @@
 ==== RequirementsQuality_Main ====
 You are an expert requirements analyst reviewing the following document.
 Assess whether the requirements are clear, complete, and testable. Identify ambiguities, missing information, or conflicts and provide improvement suggestions.
+==== RequirementsQuality_DocumentIntro ====
+Document:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
@@ -83,3 +83,5 @@ Ensure bug reports follow these standards:
 Also confirm each story meets this Definition of Ready:
 ==== WorkItemQuality_StoryQualityStandardsIntro ====
 Apply these story quality standards:
+==== WorkItemQuality_WorkItemsIntro ====
+Work items:

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PeriodMetrics.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PeriodMetrics.cs
@@ -1,0 +1,14 @@
+namespace DevOpsAssistant.Services.Models;
+
+public class PeriodMetrics
+{
+    public string Name { get; set; } = string.Empty;
+    public DateTime Start { get; set; }
+    public DateTime End { get; set; }
+    public double AvgLeadTime { get; set; }
+    public double AvgCycleTime { get; set; }
+    public int Throughput { get; set; }
+    public double Velocity { get; set; }
+    public double AvgWip { get; set; }
+    public double SprintEfficiency { get; set; }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -1,0 +1,225 @@
+using System.Text;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GeneratedPrompts;
+using DevOpsAssistant.Services.Models;
+using DevOpsAssistant.Utils;
+using System.Collections.Generic;
+
+namespace DevOpsAssistant.Services;
+
+public class PromptService
+{
+    public string BuildMetricsPrompt(IEnumerable<PeriodMetrics> periods, OutputFormat format)
+    {
+        var list = periods.ToList();
+        var metrics = list.Select(p => new
+        {
+            end = p.End.ToString("yyyy-MM-dd"),
+            leadTime = p.AvgLeadTime,
+            cycleTime = p.AvgCycleTime,
+            throughput = p.Throughput,
+            velocity = p.Velocity,
+            avgWip = p.AvgWip,
+            sprintEfficiency = p.SprintEfficiency
+        });
+        var summary = new
+        {
+            avgLeadTime = list.Any() ? list.Average(p => (decimal)p.AvgLeadTime) : 0,
+            avgCycleTime = list.Any() ? list.Average(p => (decimal)p.AvgCycleTime) : 0,
+            avgThroughput = list.Any() ? list.Average(p => (int)p.Throughput) : 0,
+            avgVelocity = list.Any() ? list.Average(p => (decimal)p.Velocity) : 0,
+            avgWip = list.Any() ? list.Average(p => (decimal)p.AvgWip) : 0,
+            avgSprintEfficiency = list.Any() ? list.Average(p => (decimal)p.SprintEfficiency) : 0
+        };
+        var payload = new { metrics, summary };
+        var json = JsonSerializer.Serialize(payload);
+        var sb = new StringBuilder();
+        sb.AppendLine(GeneratedPrompts.Metrics_MainPrompt.Value);
+        sb.AppendLine();
+        if (format == OutputFormat.Inline)
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_MetricsInlinePrompt.Value);
+        else
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_MetricsConvertPrompt.Value, format));
+        sb.AppendLine();
+        sb.AppendLine(string.Format(GeneratedPrompts.Metrics_DataIntroPrompt.Value, json));
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    public string BuildReleaseNotesPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
+    {
+        var hierarchy = details.Select(d => new
+        {
+            Epic = d.Epic == null ? null : new { d.Epic.Id, d.Epic.Title, Description = TextHelpers.Sanitize(d.EpicDescription) },
+            Feature = d.Feature == null ? null : new { d.Feature.Id, d.Feature.Title, Description = TextHelpers.Sanitize(d.FeatureDescription) },
+            Item = new
+            {
+                d.Story.Id,
+                d.Story.Title,
+                d.Story.WorkItemType,
+                Description = TextHelpers.Sanitize(d.Description),
+                ReproSteps = config.Rules.Bug.IncludeReproSteps ? TextHelpers.Sanitize(d.ReproSteps) : null,
+                SystemInfo = config.Rules.Bug.IncludeSystemInfo ? TextHelpers.Sanitize(d.SystemInfo) : null,
+                AcceptanceCriteria = TextHelpers.Sanitize(d.AcceptanceCriteria)
+            }
+        });
+        var json = JsonSerializer.Serialize(hierarchy, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
+        var sb = new StringBuilder();
+        if (string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt) || config.ReleaseNotesPromptMode == PromptMode.Append)
+            sb.AppendLine(GeneratedPrompts.ReleaseNotes_MainPrompt.Value);
+        if (!string.IsNullOrWhiteSpace(config.ReleaseNotesPrompt))
+            sb.AppendLine(config.ReleaseNotesPrompt.Trim());
+        if (config.OutputFormat == OutputFormat.Inline)
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_ReleaseNotesInlinePrompt.Value);
+        else
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_ReleaseNotesConvertPrompt.Value, config.OutputFormat));
+        sb.AppendLine();
+        sb.AppendLine(GeneratedPrompts.ReleaseNotes_WorkItemsIntroPrompt.Value);
+        sb.AppendLine(json);
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    public string BuildRequirementsQualityPrompt(IEnumerable<(string Name, string Text)> pages, DevOpsConfig config)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(GeneratedPrompts.RequirementsQuality_MainPrompt.Value);
+        if (config.Standards.RequirementsDocumentation.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine(GeneratedPrompts.RequirementsDocumentationStandardsIntroPrompt.Value);
+            foreach (var s in config.Standards.RequirementsDocumentation)
+                sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
+        }
+        sb.AppendLine();
+        sb.AppendLine(GeneratedPrompts.RequirementsQuality_DocumentIntroPrompt.Value);
+        foreach (var page in pages)
+        {
+            sb.AppendLine($"## {page.Name}");
+            sb.AppendLine(page.Text);
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    public string BuildRequirementsPlannerPrompt(IEnumerable<(string Name, string Text)> pages, bool storiesOnly, bool clarify, DevOpsConfig config)
+    {
+        var sb = new StringBuilder();
+        if (string.IsNullOrWhiteSpace(config.RequirementsPrompt) || config.RequirementsPromptMode == PromptMode.Append)
+        {
+            if (storiesOnly)
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_UserStoriesBlockPrompt.Value);
+            else
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsBlockPrompt.Value);
+            if (config.Standards.UserStoryDescription.Contains("ScrumUserStory"))
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_ScrumPrompt.Value);
+            else if (config.Standards.UserStoryDescription.Contains("JobStory"))
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_JobPrompt.Value);
+            else
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_Description_GenericPrompt.Value);
+            if (config.Standards.UserStoryAcceptanceCriteria.Contains("Gherkin"))
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_GherkinPrompt.Value);
+            else if (config.Standards.UserStoryAcceptanceCriteria.Contains("BulletPoints"))
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_BulletPointsPrompt.Value);
+            else if (config.Standards.UserStoryAcceptanceCriteria.Contains("SAFeStyle"))
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_AcceptanceCriteria_SAFeStylePrompt.Value);
+            sb.AppendLine(GeneratedPrompts.RequirementsPlanner_TagsAndHtmlAdvicePrompt.Value);
+            sb.AppendLine(string.Format(GeneratedPrompts.RequirementsPlanner_WorkItemGranularityPrompt.Value, config.WorkItemGranularity));
+            if (config.Standards.UserStoryQuality.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_StoryQualityStandardsIntroPrompt.Value);
+                foreach (var s in config.Standards.UserStoryQuality)
+                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
+            }
+            if (config.Standards.RequirementsDocumentation.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.RequirementsDocumentationStandardsIntroPrompt.Value);
+                foreach (var s in config.Standards.RequirementsDocumentation)
+                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
+            }
+            if (storiesOnly)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_StoriesOnlyBlockPrompt.Value);
+            }
+            else
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_EpicsJsonBlockPrompt.Value);
+            }
+            if (clarify)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.RequirementsPlanner_ClarifyBlockPrompt.Value);
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(config.RequirementsPrompt))
+            sb.AppendLine(config.RequirementsPrompt.Trim());
+        sb.AppendLine();
+        sb.AppendLine(GeneratedPrompts.RequirementsPlanner_DocumentIntroPrompt.Value);
+        foreach (var page in pages)
+        {
+            sb.AppendLine($"## {page.Name}");
+            sb.AppendLine(page.Text);
+            sb.AppendLine();
+        }
+        sb.AppendLine();
+        return sb.ToString();
+    }
+
+    public string BuildWorkItemQualityPrompt(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
+    {
+        var items = details.Select(d => new
+        {
+            Epic = d.Epic == null ? null : new { d.Epic.Title, Description = TextHelpers.Sanitize(d.EpicDescription) },
+            Feature = d.Feature == null ? null : new { d.Feature.Title, Description = TextHelpers.Sanitize(d.FeatureDescription) },
+            Story = d.Story.WorkItemType.Equals("User Story", StringComparison.OrdinalIgnoreCase)
+                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description) }
+                : null,
+            Bug = d.Story.WorkItemType.Equals("Bug", StringComparison.OrdinalIgnoreCase)
+                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description), ReproSteps = TextHelpers.Sanitize(d.ReproSteps), SystemInfo = TextHelpers.Sanitize(d.SystemInfo) }
+                : null
+        });
+        var json = JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });
+        var sb = new StringBuilder();
+        if (string.IsNullOrWhiteSpace(config.StoryQualityPrompt) || config.StoryQualityPromptMode == PromptMode.Append)
+        {
+            sb.AppendLine(GeneratedPrompts.WorkItemQuality_MainPrompt.Value);
+            if (config.Standards.UserStoryQuality.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.WorkItemQuality_StoryQualityStandardsIntroPrompt.Value);
+                foreach (var s in config.Standards.UserStoryQuality)
+                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
+            }
+            if (config.Standards.BugReporting.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.WorkItemQuality_BugReportingStandardsIntroPrompt.Value);
+                foreach (var s in config.Standards.BugReporting)
+                    sb.AppendLine($"- {StandardsCatalog.GetName(s)}");
+            }
+            if (!string.IsNullOrWhiteSpace(config.DefinitionOfReady))
+            {
+                sb.AppendLine();
+                sb.AppendLine(GeneratedPrompts.WorkItemQuality_DefinitionOfReadyIntroPrompt.Value);
+                sb.AppendLine(config.DefinitionOfReady);
+            }
+        }
+        if (!string.IsNullOrWhiteSpace(config.StoryQualityPrompt))
+            sb.AppendLine(config.StoryQualityPrompt.Trim());
+        if (config.OutputFormat == OutputFormat.Inline)
+            sb.AppendLine(GeneratedPrompts.FormatInstructions_WorkItemAnalysisInlinePrompt.Value);
+        else
+            sb.AppendLine(string.Format(GeneratedPrompts.FormatInstructions_WorkItemAnalysisConvertPrompt.Value, config.OutputFormat));
+        sb.AppendLine();
+        sb.AppendLine(GeneratedPrompts.WorkItemQuality_WorkItemsIntroPrompt.Value);
+        sb.AppendLine(json);
+        sb.AppendLine();
+        return sb.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- move prompt assembly to `PromptService`
- add `PeriodMetrics` model
- pull hard-coded strings into prompt files
- register new service and update tests
- document prompt text rule in AGENTS.md

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_68682a2ebc5c8328b6b1c343f825bbc3