### PR TITLE
Refactor prompt data generation

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/MetricsPageTests.cs
@@ -66,8 +66,10 @@ public class MetricsPageTests : ComponentTestBase
             AvgWip = 1.5,
             SprintEfficiency = 80.0
         };
+        var method = typeof(Metrics).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var json = (string)method.Invoke(null, new object?[] { new[] { period } })!;
         var svc = new PromptService();
-        var prompt = svc.BuildMetricsPrompt(new[] { period }, OutputFormat.Markdown);
+        var prompt = svc.BuildMetricsPrompt(json, OutputFormat.Markdown);
 
         Assert.Contains("Agile Delivery Metrics Report Template", prompt);
         Assert.Contains("\"end\":\"2024-01-01\"", prompt);

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/ReleaseNotesPageTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Threading;
 using System.Linq;
 using System.Collections.Generic;
+using System.Reflection;
 using Bunit;
 using DevOpsAssistant.Pages;
 using DevOpsAssistant.Services;
@@ -27,8 +28,11 @@ public class ReleaseNotesPageTests : ComponentTestBase
             }
         };
 
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cfg = new DevOpsConfig();
+        var json = (string)method.Invoke(null, new object?[] { details, cfg })!;
         var svc = new PromptService();
-        var result = svc.BuildReleaseNotesPrompt(details, new DevOpsConfig());
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.Contains("\"AcceptanceCriteria\": \"criteria\"", result);
     }
@@ -44,8 +48,11 @@ public class ReleaseNotesPageTests : ComponentTestBase
             }
         };
 
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cfg = new DevOpsConfig();
+        var json = (string)method.Invoke(null, new object?[] { details, cfg })!;
         var svc = new PromptService();
-        var result = svc.BuildReleaseNotesPrompt(details, new DevOpsConfig());
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.Contains("Bugs are also in scope", result);
     }
@@ -53,8 +60,11 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Includes_NoBranding_Note()
     {
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cfg = new DevOpsConfig();
+        var json = (string)method.Invoke(null, new object?[] { new List<StoryHierarchyDetails>(), cfg })!;
         var svc = new PromptService();
-        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), new DevOpsConfig());
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.Contains("No branding is required.", result);
     }
@@ -78,8 +88,10 @@ public class ReleaseNotesPageTests : ComponentTestBase
                 Bug = new BugRules { IncludeReproSteps = false }
             }
         };
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var json = (string)method.Invoke(null, new object?[] { details, cfg })!;
         var svc = new PromptService();
-        var result = svc.BuildReleaseNotesPrompt(details, cfg);
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.DoesNotContain("ReproSteps", result);
     }
@@ -103,8 +115,10 @@ public class ReleaseNotesPageTests : ComponentTestBase
                 Bug = new BugRules { IncludeSystemInfo = false }
             }
         };
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var json = (string)method.Invoke(null, new object?[] { details, cfg })!;
         var svc = new PromptService();
-        var result = svc.BuildReleaseNotesPrompt(details, cfg);
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.DoesNotContain("SystemInfo", result);
     }
@@ -112,10 +126,11 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Inline_Format_Does_Not_Request_Conversion()
     {
-        var svc = new PromptService();
         var cfg = new DevOpsConfig { OutputFormat = OutputFormat.Inline };
-
-        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), cfg);
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var json = (string)method.Invoke(null, new object?[] { new List<StoryHierarchyDetails>(), cfg })!;
+        var svc = new PromptService();
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.DoesNotContain("convert the content", result);
         Assert.Contains("Reply inline", result);
@@ -124,9 +139,12 @@ public class ReleaseNotesPageTests : ComponentTestBase
     [Fact]
     public void BuildPrompt_Includes_Templates()
     {
+        var method = typeof(ReleaseNotes).GetMethod("BuildPromptData", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var cfg = new DevOpsConfig();
+        var json = (string)method.Invoke(null, new object?[] { new List<StoryHierarchyDetails>(), cfg })!;
         var svc = new PromptService();
 
-        var result = svc.BuildReleaseNotesPrompt(new List<StoryHierarchyDetails>(), new DevOpsConfig());
+        var result = svc.BuildReleaseNotesPrompt(json, cfg);
 
         Assert.Contains("# Release Notes", result);
         Assert.Contains("# Change Control Ticket", result);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -720,6 +720,32 @@ else if (_periods.Any())
         return sb.ToString();
     }
 
+    private static string BuildPromptData(IEnumerable<PeriodMetrics> periods)
+    {
+        var list = periods.ToList();
+        var metrics = list.Select(p => new
+        {
+            end = p.End.ToString("yyyy-MM-dd"),
+            leadTime = p.AvgLeadTime,
+            cycleTime = p.AvgCycleTime,
+            throughput = p.Throughput,
+            velocity = p.Velocity,
+            avgWip = p.AvgWip,
+            sprintEfficiency = p.SprintEfficiency
+        });
+        var summary = new
+        {
+            avgLeadTime = list.Any() ? list.Average(p => (decimal)p.AvgLeadTime) : 0,
+            avgCycleTime = list.Any() ? list.Average(p => (decimal)p.AvgCycleTime) : 0,
+            avgThroughput = list.Any() ? list.Average(p => p.Throughput) : 0,
+            avgVelocity = list.Any() ? list.Average(p => (decimal)p.Velocity) : 0,
+            avgWip = list.Any() ? list.Average(p => (decimal)p.AvgWip) : 0,
+            avgSprintEfficiency = list.Any() ? list.Average(p => (decimal)p.SprintEfficiency) : 0
+        };
+        var payload = new { metrics, summary };
+        return JsonSerializer.Serialize(payload);
+    }
+
     private void ToggleBurnChartControls()
     {
         _showBurnChartControls = !_showBurnChartControls;
@@ -736,7 +762,8 @@ else if (_periods.Any())
     private async Task CopyPrompt()
     {
         if (_periods.Count == 0) return;
-        var prompt = PromptService.BuildMetricsPrompt(_periods, ConfigService.Config.OutputFormat);
+        var json = BuildPromptData(_periods);
+        var prompt = PromptService.BuildMetricsPrompt(json, ConfigService.Config.OutputFormat);
         await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -95,7 +95,8 @@ else if (_promptParts != null)
         {
             var ids = _selectedItems.Select(s => s.Id);
             var details = await ApiService.GetStoryHierarchyDetailsAsync(ids);
-            _prompt = PromptService.BuildReleaseNotesPrompt(details, ConfigService.Config);
+            var json = BuildPromptData(details, ConfigService.Config);
+            _prompt = PromptService.BuildReleaseNotesPrompt(json, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             _error = null;
@@ -143,6 +144,26 @@ else if (_promptParts != null)
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
+    }
+
+    private static string BuildPromptData(IEnumerable<StoryHierarchyDetails> details, DevOpsConfig config)
+    {
+        var hierarchy = details.Select(d => new
+        {
+            Epic = d.Epic == null ? null : new { d.Epic.Id, d.Epic.Title, Description = TextHelpers.Sanitize(d.EpicDescription) },
+            Feature = d.Feature == null ? null : new { d.Feature.Id, d.Feature.Title, Description = TextHelpers.Sanitize(d.FeatureDescription) },
+            Item = new
+            {
+                d.Story.Id,
+                d.Story.Title,
+                d.Story.WorkItemType,
+                Description = TextHelpers.Sanitize(d.Description),
+                ReproSteps = config.Rules.Bug.IncludeReproSteps ? TextHelpers.Sanitize(d.ReproSteps) : null,
+                SystemInfo = config.Rules.Bug.IncludeSystemInfo ? TextHelpers.Sanitize(d.SystemInfo) : null,
+                AcceptanceCriteria = TextHelpers.Sanitize(d.AcceptanceCriteria)
+            }
+        });
+        return JsonSerializer.Serialize(hierarchy, new JsonSerializerOptions { WriteIndented = true, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
     }
 
 

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -1,6 +1,7 @@
 @page "/projects/{ProjectName}/work-item-quality"
 @using System.Text
 @using System.Text.Json
+@using System.Linq
 @using DevOpsAssistant.Services
 @using DevOpsAssistant.Services.Models
 @using DevOpsAssistant.Utils
@@ -84,7 +85,8 @@ else if (_promptParts != null)
         try
         {
             var details = await ApiService.GetStoryHierarchyDetailsAsync(_selectedItems.Select(i => i.Id));
-            _prompt = PromptService.BuildWorkItemQualityPrompt(details, ConfigService.Config);
+            var json = BuildPromptData(details);
+            _prompt = PromptService.BuildWorkItemQualityPrompt(json, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
             _error = null;
@@ -131,6 +133,22 @@ else if (_promptParts != null)
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
+    }
+
+    private static string BuildPromptData(IEnumerable<StoryHierarchyDetails> details)
+    {
+        var items = details.Select(d => new
+        {
+            Epic = d.Epic == null ? null : new { d.Epic.Title, Description = TextHelpers.Sanitize(d.EpicDescription) },
+            Feature = d.Feature == null ? null : new { d.Feature.Title, Description = TextHelpers.Sanitize(d.FeatureDescription) },
+            Story = d.Story.WorkItemType.Equals("User Story", StringComparison.OrdinalIgnoreCase)
+                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description) }
+                : null,
+            Bug = d.Story.WorkItemType.Equals("Bug", StringComparison.OrdinalIgnoreCase)
+                ? new { d.Story.Id, d.Story.Title, Description = TextHelpers.Sanitize(d.Description), ReproSteps = TextHelpers.Sanitize(d.ReproSteps), SystemInfo = TextHelpers.Sanitize(d.SystemInfo) }
+                : null
+        });
+        return JsonSerializer.Serialize(items, new JsonSerializerOptions { WriteIndented = true });
     }
 
 


### PR DESCRIPTION
## Summary
- move metrics, release notes and work item data building into pages
- adjust PromptService to accept pre-built JSON
- update unit tests for new workflow

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6868f9430b2c8328b0ce121edd167e02