### PR TITLE
Document DevOps API URL usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,9 @@ Codex must be proficient in the following technologies and frameworks, which are
 ### Common Pitfalls
 - Always bind MudCheckBox with `@bind-Value` instead of `@bind-Checked`.
 - Keep markup well-formed; mismatched tags cause build errors.
+- The Azure DevOps API requires a `$` in the work item creation path
+  (e.g., `/workitems/$Bug`). Do **not** remove this dollar sign when
+  constructing URLs.
 
 ## Final Checklist Before Completing Work
 


### PR DESCRIPTION
## Summary
- note that the `$` is required in the DevOps work item creation URL

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6868f9ec44d0832893a558039396e001