### PR TITLE
Use invariant culture for dates

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -2,6 +2,7 @@
 @using System.Text
 @using System.Text.Json
 @using System.Linq
+@using System.Globalization
 @using System.Resources
 @using GeneratedPrompts
 @using DevOpsAssistant.Services.Models
@@ -725,7 +726,7 @@ else if (_periods.Any())
         var list = periods.ToList();
         var metrics = list.Select(p => new
         {
-            end = p.End.ToString("yyyy-MM-dd"),
+            end = p.End.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
             leadTime = p.AvgLeadTime,
             cycleTime = p.AvgCycleTime,
             throughput = p.Throughput,

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Linq;
 using System.Text.Json;
+using System.Globalization;
 using System.Collections.Generic;
 using DevOpsAssistant.Services.Models;
 
@@ -999,7 +1000,7 @@ public class DevOpsApiService
     private static string BuildMetricsWiql(string areaPath, DateTime startDate)
     {
         areaPath = NormalizeAreaPath(areaPath);
-        var start = startDate.ToString("yyyy-MM-dd");
+        var start = startDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         return
             $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AreaPath] UNDER '{areaPath}' AND [System.WorkItemType] = 'User Story' AND ([Microsoft.VSTS.Common.ClosedDate] >= '{start}' OR [System.State] <> 'Closed') ORDER BY [Microsoft.VSTS.Common.ClosedDate]";
     }


### PR DESCRIPTION
## Summary
- import `System.Globalization`
- use `CultureInfo.InvariantCulture` when formatting dates

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6868fca232fc83289d3d1c1f59cfd580