### PR TITLE
Switch to async markdown read

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using DevOpsAssistant.Utils;
 using Pkg = DocumentFormat.OpenXml.Packaging;
 using W = DocumentFormat.OpenXml.Wordprocessing;
@@ -17,18 +18,18 @@ namespace DevOpsAssistant.Tests.Utils;
 public class DocumentHelpersTests
 {
     [Fact]
-    public void ExtractText_Returns_Content_For_Markdown()
+    public async Task ExtractText_Returns_Content_For_Markdown()
     {
         var text = "# Heading\nContent";
         using var stream = new MemoryStream(Encoding.UTF8.GetBytes(text));
 
-        var result = DocumentHelpers.ExtractText(stream, "test.md");
+        var result = await DocumentHelpers.ExtractTextAsync(stream, "test.md");
 
         Assert.Equal(text, result);
     }
 
     [Fact]
-    public void ExtractText_Returns_Content_For_Docx()
+    public async Task ExtractText_Returns_Content_For_Docx()
     {
         using var ms = new MemoryStream();
         using (var doc = Pkg.WordprocessingDocument.Create(ms, WordprocessingDocumentType.Document))
@@ -39,13 +40,13 @@ public class DocumentHelpersTests
         }
         ms.Position = 0;
 
-        var result = DocumentHelpers.ExtractText(ms, "file.docx");
+        var result = await DocumentHelpers.ExtractTextAsync(ms, "file.docx");
 
         Assert.Contains("Docx Text", result);
     }
 
     [Fact]
-    public void ExtractText_Returns_Content_For_Pptx()
+    public async Task ExtractText_Returns_Content_For_Pptx()
     {
         using var ms = new MemoryStream();
         using (var doc = Pkg.PresentationDocument.Create(ms, PresentationDocumentType.Presentation))
@@ -69,13 +70,13 @@ public class DocumentHelpersTests
         }
         ms.Position = 0;
 
-        var result = DocumentHelpers.ExtractText(ms, "file.pptx");
+        var result = await DocumentHelpers.ExtractTextAsync(ms, "file.pptx");
 
         Assert.Contains("Slide Text", result);
     }
 
     [Fact]
-    public void ExtractText_Returns_Content_For_Pdf()
+    public async Task ExtractText_Returns_Content_For_Pdf()
     {
         var builder = new PdfDocumentBuilder();
         var page = builder.AddPage(PageSize.A4);
@@ -84,7 +85,7 @@ public class DocumentHelpersTests
         var bytes = builder.Build();
         using var ms = new MemoryStream(bytes);
 
-        var result = DocumentHelpers.ExtractText(ms, "file.pdf");
+        var result = await DocumentHelpers.ExtractTextAsync(ms, "file.pdf");
 
         Assert.Contains("Pdf Text", result);
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -270,7 +270,7 @@
                     if (_file != null)
                     {
                         using var stream = _file.OpenReadStream(MaxFileSize);
-                        var text = DocumentHelpers.ExtractText(stream, _file.Name);
+                        var text = await DocumentHelpers.ExtractTextAsync(stream, _file.Name);
                         pages.Add((_file.Name, text));
                     }
                     break;
@@ -399,7 +399,7 @@
                 if (_promptFile != null)
                 {
                     using var stream = _promptFile.OpenReadStream(MaxFileSize);
-                    var text = DocumentHelpers.ExtractText(stream, _promptFile.Name);
+                    var text = await DocumentHelpers.ExtractTextAsync(stream, _promptFile.Name);
                     pages.Add((_promptFile.Name, text));
                 }
                 break;

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
@@ -117,7 +117,7 @@ else if (_promptParts != null)
                     if (_file != null)
                     {
                         using var stream = _file.OpenReadStream(MaxFileSize);
-                        var text = DocumentHelpers.ExtractText(stream, _file.Name);
+                        var text = await DocumentHelpers.ExtractTextAsync(stream, _file.Name);
                         pages.Add((_file.Name, text));
                     }
                     break;

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/DocumentHelpers.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/DocumentHelpers.cs
@@ -1,11 +1,12 @@
 using DocumentFormat.OpenXml.Packaging;
+using System.Threading.Tasks;
 using UglyToad.PdfPig;
 
 namespace DevOpsAssistant.Utils;
 
 public static class DocumentHelpers
 {
-    public static string ExtractText(Stream stream, string fileName)
+    public static async Task<string> ExtractTextAsync(Stream stream, string fileName)
     {
         var ext = Path.GetExtension(fileName).ToLowerInvariant();
         return ext switch
@@ -13,7 +14,7 @@ public static class DocumentHelpers
             ".pdf" => ExtractPdf(stream),
             ".docx" => ExtractDocx(stream),
             ".pptx" => ExtractPptx(stream),
-            ".md" => ExtractMarkdown(stream),
+            ".md" => await ExtractMarkdownAsync(stream),
             _ => string.Empty
         };
     }
@@ -45,9 +46,9 @@ public static class DocumentHelpers
             .Select(t => t.Text));
     }
 
-    private static string ExtractMarkdown(Stream stream)
+    private static async Task<string> ExtractMarkdownAsync(Stream stream)
     {
         using var reader = new StreamReader(stream);
-        return reader.ReadToEnd();
+        return await reader.ReadToEndAsync();
     }
 }


### PR DESCRIPTION
## Summary
- read markdown using `StreamReader.ReadToEndAsync`
- update callers to await the async helper
- adjust document helper tests for async

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_6868fcbb7f4c8328aae673fa8bda6446