### PR TITLE
Improve hierarchy fetch concurrency

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ConcurrencyTrackingHandler.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/ConcurrencyTrackingHandler.cs
@@ -1,0 +1,33 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DevOpsAssistant.Tests.Utils;
+
+public class ConcurrencyTrackingHandler : HttpMessageHandler
+{
+    private readonly Func<HttpRequestMessage, Task<HttpResponseMessage>> _handler;
+    private int _current;
+
+    public int MaxConcurrency { get; private set; }
+
+    public ConcurrencyTrackingHandler(Func<HttpRequestMessage, Task<HttpResponseMessage>> handler)
+    {
+        _handler = handler;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var count = Interlocked.Increment(ref _current);
+        if (count > MaxConcurrency)
+            MaxConcurrency = count;
+        try
+        {
+            return await _handler(request);
+        }
+        finally
+        {
+            Interlocked.Decrement(ref _current);
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -576,26 +576,61 @@ public class DevOpsApiService
         var idsToFetch = new HashSet<int>(rootIds);
         var fetched = new HashSet<int>();
         var items = new Dictionary<int, WorkItem>();
+        var lockObj = new object();
+        var tasks = new List<Task>();
+        using var sem = new SemaphoreSlim(4);
+
+        async Task ProcessBatch(int[] batch)
+        {
+            try
+            {
+                var idList = string.Join(',', batch);
+                var result = await GetJsonAsync<WorkItemsResult>($"{baseUri}/workitems?ids={idList}&$expand=relations&api-version={ApiVersion}");
+                if (result?.Value == null) return;
+                lock (lockObj)
+                {
+                    foreach (var w in result.Value)
+                    {
+                        if (items.TryAdd(w.Id, w) && w.Relations != null)
+                        {
+                            foreach (var rel in w.Relations.Where(r => r.Rel == "System.LinkTypes.Hierarchy-Forward"))
+                                if (int.TryParse(rel.Url.Split('/').Last(), out var childId))
+                                    idsToFetch.Add(childId);
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                sem.Release();
+            }
+        }
 
         while (true)
         {
-            var batch = idsToFetch.Except(fetched).Take(200).ToArray();
+            int[] batch;
+            lock (lockObj)
+            {
+                batch = idsToFetch.Except(fetched).Take(200).ToArray();
+                fetched.UnionWith(batch);
+            }
+
             if (batch.Length == 0)
-                break;
-            fetched.UnionWith(batch);
-            var idList = string.Join(',', batch);
-            var result = await GetJsonAsync<WorkItemsResult>($"{baseUri}/workitems?ids={idList}&$expand=relations&api-version={ApiVersion}");
-            if (result?.Value == null) continue;
-            foreach (var w in result.Value)
-                if (items.TryAdd(w.Id, w))
-                {
-                    if (w.Relations == null) continue;
-                    foreach (var rel in w.Relations.Where(r => r.Rel == "System.LinkTypes.Hierarchy-Forward"))
-                        if (int.TryParse(rel.Url.Split('/').Last(), out var childId))
-                            idsToFetch.Add(childId);
-                }
+            {
+                if (tasks.Count == 0)
+                    break;
+                var completed = await Task.WhenAny(tasks);
+                tasks.Remove(completed);
+                await completed;
+                continue;
+            }
+
+            await sem.WaitAsync();
+            var t = ProcessBatch(batch);
+            tasks.Add(t);
         }
 
+        await Task.WhenAll(tasks);
         return items;
     }
 


### PR DESCRIPTION
## Summary
- fetch work item hierarchy in concurrent batches
- add concurrency tracking handler for tests
- verify hierarchy built correctly when fetching concurrently

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6868fcb00bc483288908e3878cd21240