### PR TITLE
Localize prompt pages

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
@@ -24,4 +24,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Siguiente parte</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generar prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Parte {0}/{1}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -23,7 +23,7 @@
 }
 
 <WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
-<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading || !_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading || !_selectedItems.Any()" OnClick="Generate">@L["GeneratePrompt"]</MudButton>
 @if (_loading)
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true"/>
@@ -35,7 +35,7 @@ else if (_promptParts != null)
             <MudButton Variant="Variant.Text"
                        StartIcon="@Icons.Material.Filled.Download"
                        OnClick="DownloadPrompt">
-                Download
+                @L["Download"]
             </MudButton>
             <MudTextField T="string"
                           Text="@_promptParts[_partIndex]"
@@ -48,7 +48,7 @@ else if (_promptParts != null)
                                    Disabled="_partIndex == 0"
                                    OnClick="PrevPart" />
                 </MudTooltip>
-                <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                <MudText Typo="Typo.body2">@string.Format(L["PartFormat"], _partIndex + 1, _promptParts.Count)</MudText>
                 <MudTooltip Text='@L["NextPartTooltip"]'>
                     <MudIconButton Icon="@Icons.Material.Filled.ChevronRight"
                                    Disabled="_partIndex == _promptParts.Count - 1"
@@ -57,7 +57,7 @@ else if (_promptParts != null)
                 <MudButton Variant="Variant.Text"
                            StartIcon="@Icons.Material.Filled.ContentCopy"
                            OnClick="() => CopyPart(_promptParts[_partIndex])">
-                    Copy
+                    @L["Copy"]
                 </MudButton>
             </MudStack>
         </MudStack>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
@@ -24,4 +24,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Next part</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generate Prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Part {0}/{1}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.es.resx
@@ -51,4 +51,49 @@
   <data name="DeleteTooltip" xml:space="preserve">
     <value>Quitar elemento</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generar prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Parte {0}/{1}</value>
+  </data>
+  <data name="SelectRequirements" xml:space="preserve">
+    <value>Seleccionar requisitos</value>
+  </data>
+  <data name="ImportResponse" xml:space="preserve">
+    <value>Importar respuesta</value>
+  </data>
+  <data name="LLMResponse" xml:space="preserve">
+    <value>Respuesta del LLM</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>Importar</value>
+  </data>
+  <data name="CreateWorkItems" xml:space="preserve">
+    <value>Crear elementos de trabajo</value>
+  </data>
+  <data name="AddEpic" xml:space="preserve">
+    <value>Agregar épica</value>
+  </data>
+  <data name="AddFeature" xml:space="preserve">
+    <value>Agregar característica</value>
+  </data>
+  <data name="AddStory" xml:space="preserve">
+    <value>Agregar historia</value>
+  </data>
+  <data name="StoriesOnlyLabel" xml:space="preserve">
+    <value>Solo historias</value>
+  </data>
+  <data name="FeatureLabel" xml:space="preserve">
+    <value>Característica</value>
+  </data>
+  <data name="Backlog" xml:space="preserve">
+    <value>Backlog</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -42,7 +42,7 @@
 }
 
 <MudStepper @ref="_stepper" NonLinear="true">
-    <MudStep Title="Select Requirements" Skippable="true">
+    <MudStep Title="@L["SelectRequirements"]" Skippable="true">
         <MudStack Spacing="2">
             <WikiDocumentSelector Source="@_source"
                                    SourceChanged="@(v => _source = v)"
@@ -54,36 +54,36 @@
                                    SelectedPages="@_selectedPages"
                                    SelectedPagesChanged="@(p => _selectedPages = p)" />
             <MudTooltip Text='@L["StoriesOnlyTooltip"]'>
-                <MudSwitch T="bool" @bind-Value="_storiesOnly" Color="Color.Primary" Label="Stories Only" />
+            <MudSwitch T="bool" @bind-Value="_storiesOnly" Color="Color.Primary" Label="@L["StoriesOnlyLabel"]" />
             </MudTooltip>
             <MudTooltip Text='@L["ClarifyTooltip"]'>
                 <MudSwitch T="bool" @bind-Value="_clarify" Color="Color.Primary" Label='@L["ClarifyLabel"]' />
             </MudTooltip>
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@GenerateDisabled" OnClick="Generate">Generate Prompt</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@GenerateDisabled" OnClick="Generate">@L["GeneratePrompt"]</MudButton>
         </MudStack>
     </MudStep>
-    <MudStep Title="Import Response" Skippable="true">
+    <MudStep Title="@L["ImportResponse"]" Skippable="true">
         <MudStack Spacing="2">
             @if (_promptParts != null)
             {
-                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">@L["Download"]</MudButton>
                 <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" />
                 <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                     <MudTooltip Text='@L["PrevPartTooltip"]'>
                         <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="_partIndex == 0" OnClick="PrevPart" />
                     </MudTooltip>
-                    <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                    <MudText Typo="Typo.body2">@string.Format(L["PartFormat"], _partIndex + 1, _promptParts.Count)</MudText>
                     <MudTooltip Text='@L["NextPartTooltip"]'>
                         <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="_partIndex == _promptParts.Count - 1" OnClick="NextPart" />
                     </MudTooltip>
-                    <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">Copy</MudButton>
+                    <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">@L["Copy"]</MudButton>
                 </MudStack>
             }
-            <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="LLM Response" />
-            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">Import</MudButton>
+            <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="@L["LLMResponse"]" />
+            <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">@L["Import"]</MudButton>
         </MudStack>
     </MudStep>
-    <MudStep Title="Create Work Items" Disabled="@(_plan == null)">
+    <MudStep Title="@L["CreateWorkItems"]" Disabled="@(_plan == null)">
         @if (_plan != null)
         {
             if (_storiesOnly)
@@ -92,7 +92,7 @@
                                  @bind-Value="_feature"
                                  SearchFunc="SearchFeatures"
                                  ToStringFunc="@(f => f == null ? string.Empty : $"{f.Id} - {f.Title}")"
-                                 Label="Feature" />
+                                 Label="@L["FeatureLabel"]" />
 
                 @foreach (var story in _plan.Stories)
                 {
@@ -107,7 +107,7 @@
                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
                                     @bind-Tags="story.Tags" />
                 }
-                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddStory">Add Story</MudButton>
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddStory">@L["AddStory"]</MudButton>
             }
             else
             {
@@ -146,23 +146,23 @@
                                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
                                                     @bind-Tags="story.Tags" />
                                 }
-                                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddStory(feature)">Add Story</MudButton>
+                                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddStory(feature)">@L["AddStory"]</MudButton>
                             </PlanItemEditor>
                         }
-                        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddFeature(epic)">Add Feature</MudButton>
+                        <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddFeature(epic)">@L["AddFeature"]</MudButton>
                     </PlanItemEditor>
                 }
-                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddEpic">Add Epic</MudButton>
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddEpic">@L["AddEpic"]</MudButton>
             }
 
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
-                <MudSelect T="string" @bind-Value="_backlog" Label="Backlog">
+                <MudSelect T="string" @bind-Value="_backlog" Label="@L["Backlog"]">
                     @foreach (var b in _backlogs)
                     {
                         <MudSelectItem Value="@b">@b</MudSelectItem>
                     }
                 </MudSelect>
-                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">Create Work Items</MudButton>
+                <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">@L["CreateWorkItems"]</MudButton>
                 <MudButton Variant="Variant.Outlined" Color="Color.Error" Disabled="_loading || _createdItems.Count == 0" OnClick="UndoCreatedItems">@L["Undo"]</MudButton>
             </MudStack>
         }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.resx
@@ -51,4 +51,49 @@
   <data name="DeleteTooltip" xml:space="preserve">
     <value>Remove item</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generate Prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Part {0}/{1}</value>
+  </data>
+  <data name="SelectRequirements" xml:space="preserve">
+    <value>Select Requirements</value>
+  </data>
+  <data name="ImportResponse" xml:space="preserve">
+    <value>Import Response</value>
+  </data>
+  <data name="LLMResponse" xml:space="preserve">
+    <value>LLM Response</value>
+  </data>
+  <data name="Import" xml:space="preserve">
+    <value>Import</value>
+  </data>
+  <data name="CreateWorkItems" xml:space="preserve">
+    <value>Create Work Items</value>
+  </data>
+  <data name="AddEpic" xml:space="preserve">
+    <value>Add Epic</value>
+  </data>
+  <data name="AddFeature" xml:space="preserve">
+    <value>Add Feature</value>
+  </data>
+  <data name="AddStory" xml:space="preserve">
+    <value>Add Story</value>
+  </data>
+  <data name="StoriesOnlyLabel" xml:space="preserve">
+    <value>Stories Only</value>
+  </data>
+  <data name="FeatureLabel" xml:space="preserve">
+    <value>Feature</value>
+  </data>
+  <data name="Backlog" xml:space="preserve">
+    <value>Backlog</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.es.resx
@@ -21,4 +21,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Siguiente parte</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generar prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Parte {0}/{1}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
@@ -28,7 +28,7 @@
                        WikiItems="@_wikiItems"
                        SelectedPages="@_selectedPages"
                        SelectedPagesChanged="@(p => _selectedPages = p)" />
-<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@GenerateDisabled" OnClick="Generate">Generate Prompt</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="@GenerateDisabled" OnClick="Generate">@L["GeneratePrompt"]</MudButton>
 
 @if (_loading)
 {
@@ -38,17 +38,17 @@ else if (_promptParts != null)
 {
     <MudPaper Class="pa-6">
         <MudStack Spacing="2">
-            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">@L["Download"]</MudButton>
             <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" />
             <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                 <MudTooltip Text='@L["PrevPartTooltip"]'>
                     <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="_partIndex == 0" OnClick="PrevPart" />
                 </MudTooltip>
-                <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                <MudText Typo="Typo.body2">@string.Format(L["PartFormat"], _partIndex + 1, _promptParts.Count)</MudText>
                 <MudTooltip Text='@L["NextPartTooltip"]'>
                     <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="_partIndex == _promptParts.Count - 1" OnClick="NextPart" />
                 </MudTooltip>
-                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">Copy</MudButton>
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">@L["Copy"]</MudButton>
             </MudStack>
         </MudStack>
     </MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.resx
@@ -21,4 +21,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Next part</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generate Prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Part {0}/{1}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.es.resx
@@ -21,4 +21,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Siguiente parte</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generar prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Parte {0}/{1}</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.razor
@@ -22,7 +22,7 @@
 }
 
 <WorkItemSelector Expanded="@_filtersExpanded" ExpandedChanged="@(v => _filtersExpanded = v)" UseIteration="true" SelectedChanged="OnWorkItemsSelected" StateKey="StateKey" />
-<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_selectedItems.Any()" OnClick="Generate">Generate Prompt</MudButton>
+<MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="!_selectedItems.Any()" OnClick="Generate">@L["GeneratePrompt"]</MudButton>
 
 @if (_loading)
 {
@@ -32,17 +32,17 @@ else if (_promptParts != null)
 {
     <MudPaper Class="pa-6">
         <MudStack Spacing="2">
-            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">Download</MudButton>
+            <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Download" OnClick="DownloadPrompt">@L["Download"]</MudButton>
             <MudTextField T="string" Text="@_promptParts[_partIndex]" Lines="10" ReadOnly="true" />
             <MudStack Row="true" Spacing="1" AlignItems="AlignItems.Center">
                 <MudTooltip Text='@L["PrevPartTooltip"]'>
                     <MudIconButton Icon="@Icons.Material.Filled.ChevronLeft" Disabled="_partIndex == 0" OnClick="PrevPart" />
                 </MudTooltip>
-                <MudText Typo="Typo.body2">@($"Part {_partIndex + 1}/{_promptParts.Count}")</MudText>
+                <MudText Typo="Typo.body2">@string.Format(L["PartFormat"], _partIndex + 1, _promptParts.Count)</MudText>
                 <MudTooltip Text='@L["NextPartTooltip"]'>
                     <MudIconButton Icon="@Icons.Material.Filled.ChevronRight" Disabled="_partIndex == _promptParts.Count - 1" OnClick="NextPart" />
                 </MudTooltip>
-                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">Copy</MudButton>
+                <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">@L["Copy"]</MudButton>
             </MudStack>
         </MudStack>
     </MudPaper>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/WorkItemQuality.resx
@@ -21,4 +21,16 @@
   <data name="NextPartTooltip" xml:space="preserve">
     <value>Next part</value>
   </data>
+  <data name="GeneratePrompt" xml:space="preserve">
+    <value>Generate Prompt</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Copy" xml:space="preserve">
+    <value>Copy</value>
+  </data>
+  <data name="PartFormat" xml:space="preserve">
+    <value>Part {0}/{1}</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- use localized strings for Release Notes page
- use localized strings for Requirements Planner page
- use localized strings for Requirements Quality page
- use localized strings for Work Item Quality page
- add translations to Spanish resx files

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6868fceca61483288a5fd4e9139373c5