### PR TITLE
Add comment support to prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ The UI tests use Playwright to exercise the deployed staging site. Set
 `STAGING_URL` to the site's base URL when running the tests locally so they know
 where to connect.
 
+## Prompt files
+
+- All prompt text lives in the `Prompts` folder and is transformed into C# classes
+by a source generator. A file may define multiple sections using lines of the
+form `==== Name ====`. You can include comments that the generator will ignore:
+
+- Lines starting with `//` are treated as single line comments.
+- Text surrounded by `/*` and `*/` is ignored as a multiline comment.
+
+These comments are stripped from the generated classes so you can document each
+prompt without affecting runtime behavior.
+
 ## Accessibility
 
 DevOpsAssistant uses MudBlazor components which emit semantic HTML and ARIA

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj
@@ -17,11 +17,13 @@
         <PackageReference Include="bunit.web" Version="1.26.64"/>
         <PackageReference Include="DocumentFormat.OpenXml" Version="3.0.0"/>
         <PackageReference Include="PdfPig" Version="0.1.10"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0"/>
     </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="../DevOpsAssistant/DevOpsAssistant.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+      <ProjectReference Include="../DevOpsAssistant/DevOpsAssistant.csproj"/>
+      <ProjectReference Include="../PromptGenerator/PromptGenerator.csproj"/>
+  </ItemGroup>
 
     <ItemGroup>
         <Using Include="Xunit"/>

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Generators/PromptGeneratorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Generators/PromptGeneratorTests.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Collections.Immutable;
+using PromptGenerator;
+
+namespace DevOpsAssistant.Tests.Generators;
+
+public class PromptGeneratorTests
+{
+    private static ImmutableArray<(string Name, string Content)> InvokeParseFile(string text)
+    {
+        var method = typeof(PromptGenerator.PromptGenerator).GetMethod("ParseFile", BindingFlags.NonPublic | BindingFlags.Static)!
+            ?? throw new InvalidOperationException("Method not found");
+        return (ImmutableArray<(string, string)>)method.Invoke(null, ["Test.txt", text])!;
+    }
+
+    [Fact]
+    public void ParseFile_Ignores_Comments()
+    {
+        var text = """
+==== Section1 ====
+Line1
+// a comment
+Line2
+/*
+Multiline
+comment
+*/
+Line3
+==== Section2 ====
+Line4
+""";
+
+        var result = InvokeParseFile(text);
+
+        Assert.Equal(2, result.Length);
+        Assert.Equal("Section1", result[0].Name);
+        Assert.Equal($"Line1{System.Environment.NewLine}Line2{System.Environment.NewLine}Line3{System.Environment.NewLine}", result[0].Content);
+        Assert.Equal("Section2", result[1].Name);
+        Assert.Equal($"Line4{System.Environment.NewLine}", result[1].Content);
+    }
+}

--- a/src/DevOpsAssistant/PromptGenerator/PromptGenerator.csproj
+++ b/src/DevOpsAssistant/PromptGenerator/PromptGenerator.csproj
@@ -8,4 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DevOpsAssistant.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- allow the prompt generator to ignore `//` and `/* ... */` comment lines
- expose ParseFile for testing and grant test assembly access
- document comment usage in README
- add unit test for prompt comment parsing
- reference generator and Roslyn packages in test project

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686900d5abe48328a7d245ee1d3055b1