### PR TITLE
Add localization architecture test

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace DevOpsAssistant.Tests.Architecture;
+
+public class LocalizationTests
+{
+    private static readonly Regex PlainTextPattern = new(@">([^@<]*[A-Za-z][^@<]*)<", RegexOptions.Compiled);
+
+    private static readonly HashSet<string> PendingFiles = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "BranchHealth.razor",
+        "BulkTag.razor",
+        "Help.razor",
+        "HelpContent.razor",
+        "Home.razor",
+        "MainLayout.razor",
+        "Metrics.razor",
+        "NewProject.razor",
+        "PlanItemEditor.razor",
+        "ProjectSettings.razor",
+        "ProjectsList.razor",
+        "ReleaseNotes.razor",
+        "RequirementsPlanner.razor",
+        "RequirementsQuality.razor",
+        "SimpleLayout.razor",
+        "Validation.razor",
+        "WorkItemQuality.razor",
+        "WorkItemSelector.razor",
+        "WorkItemViewer.razor",
+        "WorkItems.razor",
+    };
+
+    public static IEnumerable<object[]> RazorPageFiles()
+    {
+        var root = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../DevOpsAssistant"));
+        return Directory.GetFiles(root, "*.razor", SearchOption.AllDirectories)
+            .Where(f => !f.EndsWith("_Imports.razor", StringComparison.OrdinalIgnoreCase))
+            .Select(f => new object[] { f });
+    }
+
+    [Theory]
+    [MemberData(nameof(RazorPageFiles))]
+    public void Razor_page_should_not_contain_plain_text(string file)
+    {
+        if (PendingFiles.Contains(Path.GetFileName(file)))
+        {
+            return; // Localization pending
+        }
+
+        var insideCode = false;
+        foreach (var line in File.ReadLines(file))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith("@code"))
+            {
+                insideCode = true;
+            }
+            if (insideCode && trimmed.StartsWith("}"))
+            {
+                insideCode = false;
+            }
+            if (insideCode)
+                continue;
+
+            foreach (Match m in PlainTextPattern.Matches(line))
+            {
+                var text = m.Groups[1].Value.Trim();
+                if (string.IsNullOrWhiteSpace(text))
+                    continue;
+                if (!Regex.IsMatch(text, "[A-Za-z]"))
+                    continue;
+                Assert.Fail($"Untranslated text '{text}' in {file}");
+            }
+        }
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/App.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/App.razor
@@ -1,12 +1,15 @@
-﻿<Router AppAssembly="@typeof(App).Assembly">
+@using Microsoft.Extensions.Localization
+@inject IStringLocalizer<App> L
+
+<Router AppAssembly="@typeof(App).Assembly">
     <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
+        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
     </Found>
     <NotFound>
-        <PageTitle>DevOpsAssistant - Not found</PageTitle>
+        <PageTitle>@L["NotFoundTitle"]</PageTitle>
         <LayoutView Layout="@typeof(MainLayout)">
-            <p role="alert">Sorry, there's nothing at this address.</p>
+            <p role="alert">@L["NotFoundMessage"]</p>
         </LayoutView>
     </NotFound>
 </Router>

--- a/src/DevOpsAssistant/DevOpsAssistant/App.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/App.resx
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="NotFoundTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Not found</value>
+  </data>
+  <data name="NotFoundMessage" xml:space="preserve">
+    <value>Sorry, there's nothing at this address.</value>
+  </data>
+</root>


### PR DESCRIPTION
## Summary
- add architecture test to scan Razor pages for plain text
- localize `App.razor` not-found strings
- refactor localization test to allow enabling one file at a time

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-restore --verify-no-changes --verbosity minimal`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6869012c0ae88328a07c1d51df93239c