### PR TITLE
Localize pages removed from exceptions

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
@@ -9,9 +9,6 @@ public class LocalizationTests
 
     private static readonly HashSet<string> PendingFiles = new(StringComparer.OrdinalIgnoreCase)
     {
-        "BulkTag.razor",
-        "Help.razor",
-        "HelpContent.razor",
         "Home.razor",
         "NewProject.razor",
         "ProjectSettings.razor",

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/HelpContent.razor
@@ -6,41 +6,45 @@
 <MudText Typo="Typo.body1">@((MarkupString)L["Intro"].Value)</MudText>
 
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Epics &amp; Features</MudText>
+    <MudText Typo="Typo.h6">@L["EpicsHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Epics"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Story Validation</MudText>
+    <MudText Typo="Typo.h6">@L["ValidationHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Validation"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Story Quality</MudText>
+    <MudText Typo="Typo.h6">@L["QualityHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Quality"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Requirement Planner</MudText>
+    <MudText Typo="Typo.h6">@L["RequirementsPlannerHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["RequirementsPlanner"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Release Notes</MudText>
+    <MudText Typo="Typo.h6">@L["ReleaseNotesHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["ReleaseNotes"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Work Item Bulk Tag</MudText>
+    <MudText Typo="Typo.h6">@L["BulkTagHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["BulkTag"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Metrics</MudText>
+    <MudText Typo="Typo.h6">@L["MetricsHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["Metrics"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Branch Health</MudText>
+    <MudText Typo="Typo.h6">@L["BranchHealthHeading"]</MudText>
     <MudText Typo="Typo.body2">@((MarkupString)L["BranchHealth"].Value)</MudText>
 </MudPaper>
 <MudPaper Class="pa-6">
-    <MudText Typo="Typo.h6">Settings</MudText>
+    <MudText Typo="Typo.h6">@L["SettingsHeading"]</MudText>
     <MudText Typo="Typo.body2">
-        @((MarkupString)string.Format(L["Settings"],
-            "<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>this guide</a>"))
+        @((MarkupString)string.Format(L["Settings"], GuideLinkHtml))
     </MudText>
 </MudPaper>
+
+@code {
+    private string GuideLinkHtml =>
+        $"<a href='https://learn.microsoft.com/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate' target='_blank'>{L["GuideLinkText"]}</a>";
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.es.resx
@@ -27,4 +27,13 @@
   <data name="AddedMessage" xml:space="preserve">
     <value>Etiquetas agregadas</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Etiquetado masivo</value>
+  </data>
+  <data name="IdHeader" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="TitleHeader" xml:space="preserve">
+    <value>Título</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.razor
@@ -6,7 +6,7 @@
 @inject IStringLocalizer<BulkTag> L
 @inherits ProjectComponentBase
 
-<PageTitle>DevOpsAssistant - Work Item Bulk Tag</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 @if (!string.IsNullOrWhiteSpace(_error))
 {
@@ -38,8 +38,8 @@
 {
     <MudTable Items="_selectedItems" Dense="true">
         <HeaderContent>
-            <MudTh>ID</MudTh>
-            <MudTh>Title</MudTh>
+            <MudTh>@L["IdHeader"]</MudTh>
+            <MudTh>@L["TitleHeader"]</MudTh>
             <MudTh></MudTh>
         </HeaderContent>
         <RowTemplate>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/BulkTag.resx
@@ -27,4 +27,13 @@
   <data name="AddedMessage" xml:space="preserve">
     <value>Tags added</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Work Item Bulk Tag</value>
+  </data>
+  <data name="IdHeader" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="TitleHeader" xml:space="preserve">
+    <value>Title</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.es.resx
@@ -15,6 +15,9 @@
   <data name="Heading" xml:space="preserve">
     <value>Ayuda e instrucciones</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Ayuda</value>
+  </data>
   <data name="Intro" xml:space="preserve">
     <value>&lt;p&gt;Bienvenido a DevOpsAssistant. Esta página explica brevemente cómo funciona cada sección.&lt;/p&gt;&lt;p&gt;Utilice estas herramientas para revisar su backlog y generar métricas que mejoren la planificación.&lt;/p&gt;</value>
   </data>
@@ -35,6 +38,36 @@
   </data>
   <data name="BulkTag" xml:space="preserve">
     <value>&lt;p&gt;Elija varios elementos, seleccione una o más etiquetas y aplíquelas de una vez.&lt;/p&gt;</value>
+  </data>
+  <data name="EpicsHeading" xml:space="preserve">
+    <value>Épicas y características</value>
+  </data>
+  <data name="ValidationHeading" xml:space="preserve">
+    <value>Validación de historias</value>
+  </data>
+  <data name="QualityHeading" xml:space="preserve">
+    <value>Calidad de la historia</value>
+  </data>
+  <data name="RequirementsPlannerHeading" xml:space="preserve">
+    <value>Planificador de requisitos</value>
+  </data>
+  <data name="ReleaseNotesHeading" xml:space="preserve">
+    <value>Notas de lanzamiento</value>
+  </data>
+  <data name="BulkTagHeading" xml:space="preserve">
+    <value>Etiquetado masivo de elementos</value>
+  </data>
+  <data name="MetricsHeading" xml:space="preserve">
+    <value>Métricas</value>
+  </data>
+  <data name="BranchHealthHeading" xml:space="preserve">
+    <value>Salud de ramas</value>
+  </data>
+  <data name="SettingsHeading" xml:space="preserve">
+    <value>Configuración</value>
+  </data>
+  <data name="GuideLinkText" xml:space="preserve">
+    <value>esta guía</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Muestre gráficas de rendimiento, tiempo de entrega, tiempo de ciclo, velocidad, burn up y flujo para el backlog elegido.&lt;/p&gt;&lt;p&gt;El rendimiento cuenta los elementos cerrados en cada periodo. El tiempo de entrega es la diferencia entre la Fecha de creación y la Fecha de cierre. El tiempo de ciclo se calcula desde la Fecha de activación hasta el cierre. La velocidad suma los Puntos de Historia o la Estimación Original de las historias completadas. La gráfica burn up proyecta la finalización usando los puntos adicionales, la eficiencia y el rango de error, mientras que el flujo acumulado muestra backlog, trabajo en progreso y tareas terminadas día a día.&lt;/p&gt;&lt;p&gt;Utilice las gráficas para detectar tendencias y planificar iteraciones futuras.&lt;/p&gt;</value>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.razor
@@ -3,6 +3,6 @@
 @using DevOpsAssistant.Components
 @inject IStringLocalizer<Help> L
 
-<PageTitle>DevOpsAssistant - Help</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 <HelpContent />

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Help.resx
@@ -15,6 +15,9 @@
   <data name="Heading" xml:space="preserve">
     <value>Help &amp; Instructions</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Help</value>
+  </data>
   <data name="Intro" xml:space="preserve">
     <value>&lt;p&gt;Welcome to DevOpsAssistant! This page explains how each section can help you manage your workflow.&lt;/p&gt;&lt;p&gt;Explore the tools below to review your backlog and generate insights that drive better planning.&lt;/p&gt;</value>
   </data>
@@ -35,6 +38,36 @@
   </data>
   <data name="BulkTag" xml:space="preserve">
     <value>&lt;p&gt;Choose multiple work items, pick one or more tags, and apply them all at once.&lt;/p&gt;</value>
+  </data>
+  <data name="EpicsHeading" xml:space="preserve">
+    <value>Epics &amp; Features</value>
+  </data>
+  <data name="ValidationHeading" xml:space="preserve">
+    <value>Story Validation</value>
+  </data>
+  <data name="QualityHeading" xml:space="preserve">
+    <value>Story Quality</value>
+  </data>
+  <data name="RequirementsPlannerHeading" xml:space="preserve">
+    <value>Requirement Planner</value>
+  </data>
+  <data name="ReleaseNotesHeading" xml:space="preserve">
+    <value>Release Notes</value>
+  </data>
+  <data name="BulkTagHeading" xml:space="preserve">
+    <value>Work Item Bulk Tag</value>
+  </data>
+  <data name="MetricsHeading" xml:space="preserve">
+    <value>Metrics</value>
+  </data>
+  <data name="BranchHealthHeading" xml:space="preserve">
+    <value>Branch Health</value>
+  </data>
+  <data name="SettingsHeading" xml:space="preserve">
+    <value>Settings</value>
+  </data>
+  <data name="GuideLinkText" xml:space="preserve">
+    <value>this guide</value>
   </data>
   <data name="Metrics" xml:space="preserve">
     <value>&lt;p&gt;Display throughput, lead time, cycle time, velocity, burn up and flow charts for the chosen backlog.&lt;/p&gt;&lt;p&gt;Throughput counts the work items closed in each period. Lead time is the number of days from Created Date to Closed Date. Cycle time measures Activated Date to Closed Date. Velocity sums Story Points or Original Estimate for completed stories. The burn up forecast uses additional points, efficiency and error range, while cumulative flow tracks backlog, work in progress and done items each day.&lt;/p&gt;&lt;p&gt;Use these charts to spot trends and plan future iterations.&lt;/p&gt;</value>


### PR DESCRIPTION
## Summary
- drop `BulkTag.razor`, `Help.razor` and `HelpContent.razor` from the architecture test exception list
- localize BulkTag page markup and headers
- localize Help page title and headings
- update HelpContent to use localized headings and localized link text
- add Spanish translations

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6869542709988328bebacb8260b8b08a