### PR TITLE
Remove localization exceptions

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
@@ -9,9 +9,6 @@ public class LocalizationTests
 
     private static readonly HashSet<string> PendingFiles = new(StringComparer.OrdinalIgnoreCase)
     {
-        "ProjectsList.razor",
-        "ReleaseNotes.razor",
-        "RequirementsQuality.razor",
         "Validation.razor",
         "WorkItemQuality.razor",
         "WorkItemSelector.razor",

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.es.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Proyectos</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.razor
@@ -5,8 +5,9 @@
 @inject NavigationManager NavigationManager
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<Home> L
+@inject IStringLocalizer<ProjectsList> PL
 
-<PageTitle>DevOpsAssistant - Projects</PageTitle>
+<PageTitle>@PL["PageTitle"]</PageTitle>
 
 <MudPaper Class="p-4">
     <MudText Typo="Typo.h5">@L["Project"]</MudText>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectsList.resx
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Projects</value>
+  </data>
+</root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.es.resx
@@ -36,4 +36,7 @@
   <data name="PartFormat" xml:space="preserve">
     <value>Parte {0}/{1}</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Notas de lanzamiento</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.razor
@@ -15,7 +15,7 @@
 @using Microsoft.Extensions.Localization
 @inject IStringLocalizer<ReleaseNotes> L
 
-<PageTitle>DevOpsAssistant - Release Notes</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 @if (!string.IsNullOrWhiteSpace(_error))
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ReleaseNotes.resx
@@ -36,4 +36,7 @@
   <data name="PartFormat" xml:space="preserve">
     <value>Part {0}/{1}</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Release Notes</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.es.resx
@@ -33,4 +33,7 @@
   <data name="PartFormat" xml:space="preserve">
     <value>Parte {0}/{1}</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Calidad de requisitos</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.razor
@@ -12,7 +12,7 @@
 @inject IStringLocalizer<RequirementsQuality> L
 @inherits ProjectComponentBase
 
-<PageTitle>DevOpsAssistant - Requirements Quality</PageTitle>
+<PageTitle>@L["PageTitle"]</PageTitle>
 
 @if (!string.IsNullOrWhiteSpace(_error))
 {

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsQuality.resx
@@ -33,4 +33,7 @@
   <data name="PartFormat" xml:space="preserve">
     <value>Part {0}/{1}</value>
   </data>
+  <data name="PageTitle" xml:space="preserve">
+    <value>DevOpsAssistant - Requirements Quality</value>
+  </data>
 </root>


### PR DESCRIPTION
## Summary
- drop three pages from the localization test exclusions
- localize page titles for ProjectsList, ReleaseNotes and RequirementsQuality
- add resources for ProjectsList

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68695ee626488328b315ff79bbaa26f1