### PR TITLE
Add localization checks for tooltips and placeholders

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Architecture/LocalizationTests.cs
@@ -6,6 +6,8 @@ namespace DevOpsAssistant.Tests.Architecture;
 public class LocalizationTests
 {
     private static readonly Regex PlainTextPattern = new(@">([^@<]*[A-Za-z][^@<]*)<", RegexOptions.Compiled);
+    private static readonly Regex AttributePattern = new("(?<attr>placeholder|title)\\s*=\\s*(?:\\\"|')(?<value>[^\\\"']*)(?:\\\"|')", RegexOptions.Compiled);
+    private static readonly Regex TooltipPattern = new("<MudTooltip[^>]*Text\\s*=\\s*(?:\\\"|')(?<value>[^\\\"']*)(?:\\\"|')", RegexOptions.Compiled);
 
 
     public static IEnumerable<object[]> RazorPageFiles()
@@ -52,6 +54,62 @@ public class LocalizationTests
                 if (!Regex.IsMatch(text, "[A-Za-z]"))
                     continue;
                 Assert.Fail($"Untranslated text '{text}' in {file}");
+            }
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(RazorPageFiles))]
+    public void Tooltip_and_placeholder_attributes_should_be_localized(string file)
+    {
+        var insideCode = false;
+        var braceDepth = 0;
+        foreach (var line in File.ReadLines(file))
+        {
+            var trimmed = line.Trim();
+            if (!insideCode && trimmed.StartsWith("@code"))
+            {
+                insideCode = true;
+                braceDepth = trimmed.Count(c => c == '{') - trimmed.Count(c => c == '}');
+                continue;
+            }
+            if (insideCode)
+            {
+                braceDepth += trimmed.Count(c => c == '{');
+                braceDepth -= trimmed.Count(c => c == '}');
+                if (braceDepth <= 0)
+                {
+                    insideCode = false;
+                }
+                if (insideCode)
+                    continue;
+            }
+
+            foreach (Match m in AttributePattern.Matches(line))
+            {
+                var value = m.Groups["value"].Value.Trim();
+                if (string.IsNullOrWhiteSpace(value))
+                    continue;
+                if (value.Contains("@"))
+                    continue;
+                if (!Regex.IsMatch(value, "[A-Za-z]"))
+                    continue;
+                Assert.Fail($"Untranslated {m.Groups["attr"].Value} '{value}' in {file}");
+            }
+
+            if (line.Contains("<MudTooltip"))
+            {
+                foreach (Match m in TooltipPattern.Matches(line))
+                {
+                    var value = m.Groups["value"].Value.Trim();
+                    if (string.IsNullOrWhiteSpace(value))
+                        continue;
+                    if (value.Contains("@"))
+                        continue;
+                    if (!Regex.IsMatch(value, "[A-Za-z]"))
+                        continue;
+                    Assert.Fail($"Untranslated tooltip text '{value}' in {file}");
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend architecture tests to detect unlocalized placeholders and tooltip text

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6869706b7320832898bee776ec55fd8c