### PR TITLE
Add more service tests

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DeploymentConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DeploymentConfigServiceTests.cs
@@ -1,0 +1,44 @@
+using System.Net;
+using System.Reflection;
+using DevOpsAssistant.Services;
+using DevOpsAssistant.Tests.Utils;
+using Xunit;
+
+namespace DevOpsAssistant.Tests.Services;
+
+public class DeploymentConfigServiceTests
+{
+    [Fact]
+    public async Task LoadAsync_Sets_Config_From_File()
+    {
+        var json = "{\"DevOpsApiBaseUrl\":\"http://api\"}";
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json)
+            });
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        var service = new DeploymentConfigService(client);
+
+        await service.LoadAsync();
+
+        Assert.Equal("http://api", service.Config.DevOpsApiBaseUrl);
+    }
+
+    [Fact]
+    public async Task LoadAsync_Resets_Config_On_Error()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            new HttpResponseMessage(HttpStatusCode.NotFound));
+        var client = new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        var service = new DeploymentConfigService(client);
+
+        typeof(DeploymentConfigService)
+            .GetProperty("Config")!
+            .SetValue(service, new DeploymentConfig { DevOpsApiBaseUrl = "old" });
+
+        await service.LoadAsync();
+
+        Assert.Null(service.Config.DevOpsApiBaseUrl);
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsApiServiceTests.cs
@@ -1052,6 +1052,10 @@ public class DevOpsApiServiceTests
 
     [Theory]
     [InlineData(HttpStatusCode.BadRequest, "Invalid request")]
+    [InlineData(HttpStatusCode.Unauthorized, "Authentication failed")]
+    [InlineData(HttpStatusCode.Forbidden, "Access denied")]
+    [InlineData(HttpStatusCode.NotFound, "The requested project was not found")]
+    [InlineData(HttpStatusCode.Conflict, "The item was updated elsewhere")]
     [InlineData(HttpStatusCode.TooManyRequests, "Rate limit exceeded")]
     [InlineData(HttpStatusCode.InternalServerError, "Azure DevOps service is unavailable")]
     public async Task HandleError_Maps_Status_To_Message(HttpStatusCode code, string expected)

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/ThemeSessionServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/ThemeSessionServiceTests.cs
@@ -1,0 +1,24 @@
+using Bunit;
+using DevOpsAssistant.Services;
+using Xunit;
+
+namespace DevOpsAssistant.Tests.Services;
+
+public class ThemeSessionServiceTests
+{
+    [Fact]
+    public async Task ToggleDoom_Toggles_State_And_Fires_Event()
+    {
+        var js = new BunitJSInterop();
+        js.SetupVoid("themeShortcut.setDoom", _ => true);
+        var service = new ThemeSessionService(js.JSRuntime);
+        var fired = false;
+        service.ThemeChanged += () => fired = true;
+
+        await service.ToggleDoom();
+
+        Assert.True(service.IsDoom);
+        Assert.True(fired);
+        js.VerifyInvoke("themeShortcut.setDoom");
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Utils/DocumentHelpersTests.cs
@@ -89,4 +89,14 @@ public class DocumentHelpersTests
 
         Assert.Contains("Pdf Text", result);
     }
+
+    [Fact]
+    public async Task ExtractText_Returns_Empty_For_Unknown_Extension()
+    {
+        using var ms = new MemoryStream(Encoding.UTF8.GetBytes("ignored"));
+
+        var result = await DocumentHelpers.ExtractTextAsync(ms, "file.txt");
+
+        Assert.Equal(string.Empty, result);
+    }
 }


### PR DESCRIPTION
## Summary
- cover unknown extension handling in DocumentHelpers
- add unit tests for DeploymentConfigService
- add unit tests for ThemeSessionService
- extend status mapping tests for DevOpsApiService

## Testing
- `dotnet test --no-build --no-restore --filter FullyQualifiedName~DeploymentConfigServiceTests --logger "console;verbosity=normal"`
- `dotnet test --no-build --no-restore --filter FullyQualifiedName~ThemeSessionServiceTests --logger "console;verbosity=normal"` *(fails: Attempting to cancel the build)*

------
https://chatgpt.com/codex/tasks/task_e_686a595d348c83289d05128b9e2b0c8f