### PR TITLE
Fix WIP metrics to include open items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -341,7 +341,7 @@ else if (_periods.Any())
             var items = await ApiService.GetStoryMetricsAsync(_path, _startDate);
             var endDate = _endDate ?? DateTime.Today;
             _items = FilterItems(items)
-                .Where(i => i.ClosedDate.Date <= endDate)
+                .Where(i => i.ClosedDate == StoryMetric.OpenClosedDate || i.ClosedDate.Date <= endDate)
                 .ToList();
             _iterations = _mode == AggregateMode.Iteration
                 ? await ApiService.GetIterationsAsync()
@@ -511,7 +511,8 @@ else if (_periods.Any())
     private void ComputeBurnUp(List<StoryMetric> items)
     {
         _burnApex.Clear();
-        if (items.Count == 0)
+        var closedItems = items.Where(i => i.ClosedDate != StoryMetric.OpenClosedDate).ToList();
+        if (closedItems.Count == 0)
         {
             _burnLabels = [];
             return;
@@ -520,11 +521,11 @@ else if (_periods.Any())
             ? ComputeOverallSprintEfficiency(items)
             : _efficiency;
 
-        var start = (_startDate ?? items.Min(i => i.ClosedDate)).Date;
+        var start = (_startDate ?? closedItems.Min(i => i.ClosedDate)).Date;
         var end = _endDate ?? DateTime.Today;
         var daysActual = (end - start).Days + 1;
         double[] daily = new double[daysActual];
-        foreach (var it in items)
+        foreach (var it in closedItems)
         {
             if (it.ClosedDate.Date < start || it.ClosedDate.Date > end) continue;
             var idx = (it.ClosedDate.Date - start).Days;
@@ -651,7 +652,8 @@ else if (_periods.Any())
         /*end*/}
 
         var start = (_startDate ?? items.Min(i => i.CreatedDate)).Date;
-        var end = (_endDate ?? items.Max(i => i.ClosedDate)).Date;
+        var closedItems = items.Where(i => i.ClosedDate != StoryMetric.OpenClosedDate);
+        var end = (_endDate ?? (closedItems.Any() ? closedItems.Max(i => i.ClosedDate) : DateTime.Today)).Date;
         var days = (end - start).Days + 1;
         double[] backlog = new double[days];
         double[] wip = new double[days];

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsApiService.cs
@@ -996,10 +996,15 @@ public class DevOpsApiService
         List<StoryMetric> list = [];
         foreach (var w in workItems)
         {
-            if (!w.Fields.TryGetValue("Microsoft.VSTS.Common.ClosedDate", out var cd) || cd.ValueKind != JsonValueKind.String)
-                continue;
-
-            var closed = cd.GetDateTime();
+            DateTime closed;
+            if (w.Fields.TryGetValue("Microsoft.VSTS.Common.ClosedDate", out var cd) && cd.ValueKind == JsonValueKind.String)
+            {
+                closed = cd.GetDateTime();
+            }
+            else
+            {
+                closed = StoryMetric.OpenClosedDate;
+            }
             var created = w.Fields.TryGetValue("System.CreatedDate", out var cr) && cr.ValueKind == JsonValueKind.String
                 ? cr.GetDateTime()
                 : closed;

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryMetric.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/StoryMetric.cs
@@ -2,6 +2,14 @@ namespace DevOpsAssistant.Services.Models;
 
 public class StoryMetric
 {
+    /// <summary>
+    /// Special value used for <see cref="ClosedDate"/> when the work item has
+    /// not yet been closed. This allows metrics to include active stories for
+    /// WIP calculations without affecting throughput or cycle/lead time
+    /// metrics.
+    /// </summary>
+    public static readonly DateTime OpenClosedDate = DateTime.MaxValue;
+
     public int Id { get; set; }
     public DateTime CreatedDate { get; set; }
     public DateTime ActivatedDate { get; set; }


### PR DESCRIPTION
## Summary
- mark open work items using a special `OpenClosedDate`
- populate missing closed dates when fetching story metrics
- include open items during metrics loading
- ignore open items for burn up calculations and adjust flow end date
- test open item inclusion

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686b838452048328a8b04fcd29362b7e