### PR TITLE
Trim trailing blank lines in prompts

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Generators/PromptGeneratorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Generators/PromptGeneratorTests.cs
@@ -37,4 +37,16 @@ Line4
         Assert.Equal("Section2", result[1].Name);
         Assert.Equal($"Line4{System.Environment.NewLine}", result[1].Content);
     }
+
+    [Fact]
+    public void ParseFile_Trims_Trailing_Empty_Lines()
+    {
+        var text = "Line1\n\n\n";
+
+        var result = InvokeParseFile(text);
+
+        Assert.Single(result);
+        Assert.Equal("Test", result[0].Name);
+        Assert.Equal($"Line1{System.Environment.NewLine}", result[0].Content);
+    }
 }

--- a/src/DevOpsAssistant/PromptGenerator/PromptGenerator.cs
+++ b/src/DevOpsAssistant/PromptGenerator/PromptGenerator.cs
@@ -94,7 +94,20 @@ public class PromptGenerator : IIncrementalGenerator
         }
 
         return sections
-            .Select(s => (s.Item1, s.Item2.ToString()))
+            .Select(s => (s.Item1, TrimTrailingEmptyLines(s.Item2.ToString())))
             .ToImmutableArray();
+    }
+
+    private static string TrimTrailingEmptyLines(string text)
+    {
+        var lines = text.Replace("\r", "").Split('\n').ToList();
+        while (lines.Count > 0 && string.IsNullOrWhiteSpace(lines[lines.Count - 1]))
+            lines.RemoveAt(lines.Count - 1);
+
+        var sb = new StringBuilder();
+        foreach (var line in lines)
+            sb.AppendLine(line);
+
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- strip empty lines from the end of each prompt section when generating prompts
- test trimming of blank lines in `PromptGenerator`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686bd21482a4832889f1ae7fd4b0774d