### PR TITLE
Add NFR list to Requirements Planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -21,6 +21,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = "SQ",
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
+            Nfrs = ["NFR1"],
             StoryQualityPromptMode = PromptMode.Append,
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
@@ -62,6 +63,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("SQ", storedCfg.StoryQualityPrompt);
         Assert.Equal("RN", storedCfg.ReleaseNotesPrompt);
         Assert.Equal("RP", storedCfg.RequirementsPrompt);
+        Assert.Contains("NFR1", storedCfg.Nfrs);
         Assert.Equal("main", storedCfg.MainBranch);
         Assert.Equal(3, storedCfg.WorkItemGranularity);
         Assert.Equal(OutputFormat.Pdf, storedCfg.OutputFormat);
@@ -83,6 +85,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = "SQ",
             ReleaseNotesPrompt = "RN",
             RequirementsPrompt = "RP",
+            Nfrs = ["NFR1"],
             StoryQualityPromptMode = PromptMode.Append,
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
@@ -121,6 +124,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("SQ", service.Config.StoryQualityPrompt);
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
+        Assert.Contains("NFR1", service.Config.Nfrs);
         Assert.Equal(OutputFormat.Pdf, service.Config.OutputFormat);
         Assert.Contains("Gherkin", service.Config.Standards.UserStoryAcceptanceCriteria);
         Assert.Contains("ScrumUserStory", service.Config.Standards.UserStoryDescription);
@@ -142,6 +146,7 @@ public class DevOpsConfigServiceTests
             StoryQualityPrompt = " SQ ",
             ReleaseNotesPrompt = " RN ",
             RequirementsPrompt = " RP ",
+            Nfrs = [" NFR1 "],
             StoryQualityPromptMode = PromptMode.Append,
             ReleaseNotesPromptMode = PromptMode.Append,
             RequirementsPromptMode = PromptMode.Append,
@@ -167,6 +172,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal("SQ", service.Config.StoryQualityPrompt);
         Assert.Equal("RN", service.Config.ReleaseNotesPrompt);
         Assert.Equal("RP", service.Config.RequirementsPrompt);
+        Assert.Contains("NFR1", service.Config.Nfrs);
         Assert.Equal(OutputFormat.Pdf, service.Config.OutputFormat);
         Assert.Equal(5, service.Config.WorkItemGranularity);
         Assert.Contains("Gherkin", service.Config.Standards.UserStoryAcceptanceCriteria);
@@ -204,6 +210,7 @@ public class DevOpsConfigServiceTests
         Assert.Equal(string.Empty, service.Config.StoryQualityPrompt);
         Assert.Equal(string.Empty, service.Config.ReleaseNotesPrompt);
         Assert.Equal(string.Empty, service.Config.RequirementsPrompt);
+        Assert.Empty(service.Config.Nfrs);
         Assert.False(service.Config.Rules.Bug.IncludeReproSteps);
         Assert.False(service.Config.Rules.Bug.IncludeSystemInfo);
         Assert.False(service.Config.Rules.Bug.HasStoryPoints);

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.es.resx
@@ -24,6 +24,9 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Prompt de Requerimientos</value>
   </data>
+  <data name="NonFunctionalRequirements" xml:space="preserve">
+    <value>NFRs del proyecto (uno por línea)</value>
+  </data>
   <data name="PromptReplace" xml:space="preserve">
     <value>Reemplazar el prompt predeterminado</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -8,6 +8,7 @@
 @inject NavigationManager NavigationManager
 @inject IJSRuntime JS
 @using System.Text
+@using System.Linq
 @using System.Text.RegularExpressions
 
 <PageTitle>@L["PageTitle"]</PageTitle>
@@ -85,6 +86,7 @@
                         <MudRadio T="PromptMode" Value="PromptMode.Replace">@L["PromptReplace"]</MudRadio>
                         <MudRadio T="PromptMode" Value="PromptMode.Append">@L["PromptAppend"]</MudRadio>
                     </MudRadioGroup>
+                    <MudTextField T="string" Value="_nfrText" ValueChanged="OnNfrsChanged" Label='@L["NonFunctionalRequirements"]' Lines="3"/>
                     <MudText Typo="Typo.subtitle2">@L["WorkItemGranularity"]: @_model.WorkItemGranularity</MudText>
                     <MudSlider T="int" Min="1" Max="5" Step="1"
                                Value="_model.WorkItemGranularity"
@@ -212,6 +214,7 @@
     private bool _qualityDirty;
     private bool _promptsDirty;
     private bool _validationDirty;
+    private string _nfrText = string.Empty;
     private bool _generalDirty;
     private int _activeTab;
     private int _standardsTab;
@@ -236,6 +239,7 @@
             StoryQualityPrompt = cfg.StoryQualityPrompt,
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
+            Nfrs = cfg.Nfrs.ToList(),
             StoryQualityPromptMode = cfg.StoryQualityPromptMode,
             ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
             RequirementsPromptMode = cfg.RequirementsPromptMode,
@@ -267,6 +271,7 @@
                 }
             }
         };
+        _nfrText = string.Join("\n", _model.Nfrs);
         _color = ConfigService.CurrentProject.Color;
         _overrideOrg = !string.IsNullOrWhiteSpace(_model.Organization) || string.IsNullOrWhiteSpace(ConfigService.GlobalOrganization);
         _overridePat = !string.IsNullOrWhiteSpace(_model.PatToken) || string.IsNullOrWhiteSpace(ConfigService.GlobalPatToken);
@@ -330,6 +335,7 @@
         cfg.StoryQualityPrompt = _model.StoryQualityPrompt;
         cfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
         cfg.RequirementsPrompt = _model.RequirementsPrompt;
+        cfg.Nfrs = _nfrText.Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0).ToList();
         cfg.StoryQualityPromptMode = _model.StoryQualityPromptMode;
         cfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
         cfg.RequirementsPromptMode = _model.RequirementsPromptMode;
@@ -364,6 +370,7 @@
                 pcfg.StoryQualityPrompt = _model.StoryQualityPrompt;
                 pcfg.ReleaseNotesPrompt = _model.ReleaseNotesPrompt;
                 pcfg.RequirementsPrompt = _model.RequirementsPrompt;
+                pcfg.Nfrs = _nfrText.Split('\n').Select(l => l.Trim()).Where(l => l.Length > 0).ToList();
                 pcfg.StoryQualityPromptMode = _model.StoryQualityPromptMode;
                 pcfg.ReleaseNotesPromptMode = _model.ReleaseNotesPromptMode;
                 pcfg.RequirementsPromptMode = _model.RequirementsPromptMode;
@@ -388,6 +395,12 @@
         sb.AppendLine("---");
         sb.AppendLine($"### {L["RequirementsPrompt"].Value}");
         sb.AppendLine(WithDummyData(_model.RequirementsPrompt));
+        if (!string.IsNullOrWhiteSpace(_nfrText))
+        {
+            sb.AppendLine("---");
+            sb.AppendLine($"### {L["NonFunctionalRequirements"].Value}");
+            sb.AppendLine(_nfrText);
+        }
         await JS.InvokeVoidAsync("copyText", sb.ToString());
         Snackbar.Add(L["PromptsCopied"].Value, Severity.Success);
     }
@@ -511,6 +524,14 @@
     private Task OnPromptsChanged(Action update)
     {
         update();
+        _promptsDirty = true;
+        return Task.CompletedTask;
+    }
+
+    private Task OnNfrsChanged(string value)
+    {
+        _nfrText = value;
+        _model.Nfrs = value.Split('\n').Select(v => v.Trim()).Where(v => v.Length > 0).ToList();
         _promptsDirty = true;
         return Task.CompletedTask;
     }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.resx
@@ -24,6 +24,9 @@
   <data name="RequirementsPrompt" xml:space="preserve">
     <value>Requirements Prompt</value>
   </data>
+  <data name="NonFunctionalRequirements" xml:space="preserve">
+    <value>Project NFRs (one per line)</value>
+  </data>
   <data name="PromptReplace" xml:space="preserve">
     <value>Replace default prompt</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
@@ -30,15 +30,18 @@ User Story Granularity Grading Scale (1–5)
 //{4} Work Item AC Standards
 {4}
 
-//{5} Clarify Requirements
+//{5} Non-Functional Requirements
 {5}
 
-//{6} Appended User Prompt
+//{6} Clarify Requirements
 {6}
 
-//{7} - The text of the requirements document
-Requirements Document:
+//{7} Appended User Prompt
 {7}
+
+//{8} - The text of the requirements document
+Requirements Document:
+{8}
 
 ==== RequirementsPlanner_EpicsFeaturesStories ====
 Epics, Features, and User Stories.
@@ -103,3 +106,6 @@ Do not use gherkin syntax, bullet points or any other specific framework for wri
 
 ==== RequirementsPlanner_WorkItemACStandards_SAFe ====
 - SAFe - ensure the acceptance criteria follow the guidelines of SAFe, for more information consult https://framework.scaledagile.com/
+
+==== RequirementsPlanner_NonFunctionalIntro ====
+Non-Functional Requirements:

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfig.cs
@@ -1,4 +1,5 @@
 using DevOpsAssistant.Services.Models;
+using System.Collections.Generic;
 
 namespace DevOpsAssistant.Services;
 
@@ -12,6 +13,7 @@ public class DevOpsConfig
     public string StoryQualityPrompt { get; set; } = string.Empty;
     public string ReleaseNotesPrompt { get; set; } = string.Empty;
     public string RequirementsPrompt { get; set; } = string.Empty;
+    public List<string> Nfrs { get; set; } = new();
     public PromptMode StoryQualityPromptMode { get; set; }
     public PromptMode ReleaseNotesPromptMode { get; set; }
     public PromptMode RequirementsPromptMode { get; set; }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -1,4 +1,5 @@
 using Blazored.LocalStorage;
+using System.Linq;
 
 namespace DevOpsAssistant.Services;
 
@@ -208,6 +209,7 @@ public class DevOpsConfigService
             StoryQualityPrompt = config.StoryQualityPrompt.Trim(),
             ReleaseNotesPrompt = config.ReleaseNotesPrompt.Trim(),
             RequirementsPrompt = config.RequirementsPrompt.Trim(),
+            Nfrs = config.Nfrs.Select(n => n.Trim()).Where(n => n.Length > 0).ToList(),
             StoryQualityPromptMode = config.StoryQualityPromptMode,
             ReleaseNotesPromptMode = config.ReleaseNotesPromptMode,
             RequirementsPromptMode = config.RequirementsPromptMode,
@@ -239,6 +241,7 @@ public class DevOpsConfigService
             StoryQualityPrompt = cfg.StoryQualityPrompt,
             ReleaseNotesPrompt = cfg.ReleaseNotesPrompt,
             RequirementsPrompt = cfg.RequirementsPrompt,
+            Nfrs = cfg.Nfrs.ToList(),
             StoryQualityPromptMode = cfg.StoryQualityPromptMode,
             ReleaseNotesPromptMode = cfg.ReleaseNotesPromptMode,
             RequirementsPromptMode = cfg.RequirementsPromptMode,

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -82,6 +82,7 @@ public class PromptService
                 BuildWorkItemStandards(config),
                 BuildWorkItemDescriptionStandards(config),
                 BuildWorkItemAcStandards(config),
+                BuildNfrs(config),
                 clarify ? RequirementsPlanner_ClarifyRequirementsPrompt.Value : RequirementsPlanner_ClarifyRequirementsNonePrompt.Value,
                 ShouldAppendPrompt(config) ? config.RequirementsPrompt : string.Empty,
                 requirementsDocument
@@ -110,6 +111,17 @@ public class PromptService
             sb.AppendLine();
         }
 
+        return sb.ToString();
+    }
+
+    private static string BuildNfrs(DevOpsConfig config)
+    {
+        if (config.Nfrs.Count == 0) return string.Empty;
+
+        var sb = new StringBuilder();
+        sb.AppendLine(RequirementsPlanner_NonFunctionalIntroPrompt.Value);
+        foreach (var nfr in config.Nfrs)
+            sb.AppendLine($"- {nfr}");
         return sb.ToString();
     }
 


### PR DESCRIPTION
## Summary
- support a Non-Functional Requirements list per project
- display NFRs in Project Settings and copy dialog
- include NFRs in Requirements Planner prompt text
- update config service, prompt service and tests
- localize new setting string

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686bdffa0a188328853502337b5b94e3