### PR TITLE
Centralize requirements gatherer prompt

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PromptServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PromptServiceTests.cs
@@ -16,7 +16,7 @@ public class PromptServiceTests
                 UserStoryAcceptanceCriteria = ["BulletPoints"]
             }
         };
-        
+
         var result = PromptService.BuildRequirementsPlannerPrompt(pages, false, false, cfg);
 
         Assert.Contains("Bullet Points", result);
@@ -35,5 +35,17 @@ public class PromptServiceTests
         var result = PromptService.BuildRequirementsPlannerPrompt(pages, false, false, cfg);
 
         Assert.StartsWith("Custom", result.Trim());
+    }
+
+    [Fact]
+    public void BuildRequirementsGathererPrompt_Includes_Document_When_Pages_Provided()
+    {
+        var pages = new List<(string Name, string Text)> { ("Doc", "content") };
+
+        var result = PromptService.BuildRequirementsGathererPrompt(pages);
+
+        Assert.Contains("Agile Business Analyst", result);
+        Assert.Contains("Document:", result);
+        Assert.Contains("## Doc", result);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/Metrics.razor
@@ -24,7 +24,7 @@
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
-/*end*/}
+}
 
 <MudPaper>
     <MudStack Spacing="2">
@@ -34,7 +34,7 @@
                 @foreach (var b in _backlogs)
                 {
                     <MudSelectItem Value="@b">@b</MudSelectItem>
-                /*end*/}
+                }
             </MudSelect>
             <MudDatePicker @bind-Date="_startDate" Label="@L["StartDate"]"/>
             <MudDatePicker @bind-Date="_endDate" Label="@L["EndDate"]" MaxDate="@DateTime.Today"/>
@@ -70,9 +70,9 @@
                 @foreach (var t in _ignoredTags)
                 {
                     <MudChip Value="@t" OnClose="(MudChip<string> _) => RemoveIgnoreTag(t)">@t</MudChip>
-                /*end*/}
+                }
             </MudChipSet>
-        /*end*/}
+        }
         <MudStack Row="true" Spacing="2" AlignItems="AlignItems.End" Wrap="Wrap.Wrap">
             <MudButton Variant="Variant.Filled" Color="Mud.Color.Primary" OnClick="Load">@L["Load"]</MudButton>
             <MudButton Variant="Variant.Outlined" OnClick="ExportCsv">@L["ExportCsv"]</MudButton>
@@ -83,7 +83,7 @@
 @if (_loading)
 {
     <MudProgressCircular Color="Mud.Color.Primary" Indeterminate="true"/>
-/*end*/}
+}
 else if (_periods.Any())
 {
     <MudText Typo="Typo.h6" Class="mt-4">@L["TableHeading"]</MudText>
@@ -203,7 +203,7 @@ else if (_periods.Any())
                                     </RowTemplate>
                                 </MudTable>
                             </MudStack>
-                            /*end*/}
+                            }
                         </MudItem>
                     </MudGrid>
                 </MudCollapse>
@@ -227,7 +227,7 @@ else if (_periods.Any())
                OnClick="CopyPrompt">
         @L["GeneratePrompt"]
     </MudButton>
-/*end*/}
+}
 
 @code {
     [Parameter] public string ProjectName { get; set; } = string.Empty;
@@ -292,7 +292,7 @@ else if (_periods.Any())
             ConfigService.CurrentProject.Name != ProjectName)
         {
             await ConfigService.SelectProjectAsync(ProjectName);
-        /*end*/}
+        }
 
         try
         {
@@ -321,15 +321,15 @@ else if (_periods.Any())
                 if (state.IgnoredTags != null)
                     foreach (var t in state.IgnoredTags)
                         _ignoredTags.Add(t);
-            /*end*/}
+            }
 
             _error = null;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private async Task Load()
     {
@@ -362,18 +362,18 @@ else if (_periods.Any())
                 TagMarksSprint = _tagMarksSprint,
                 UseSprintEfficiency = _useSprintEfficiency,
                 IgnoredTags = _ignoredTags.ToList()
-            /*end*/});
+            });
             _error = null;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
+        }
         finally
         {
             _loading = false;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private void ComputePeriods(List<StoryMetric> items, List<IterationInfo>? iterations = null)
     {
@@ -397,7 +397,7 @@ else if (_periods.Any())
                     AvgLeadTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.CreatedDate).TotalDays) : 0,
                     AvgCycleTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0,
                     Velocity = rangeItems.Sum(w => _velocityMode == VelocityMode.StoryPoints ? w.StoryPoints : w.OriginalEstimate)
-                /*end*/};
+                };
                 var overlap = items.Where(w => w.ActivatedDate <= metrics.End && w.ClosedDate >= metrics.Start);
                 double active = 0;
                 foreach (var w in overlap)
@@ -405,7 +405,7 @@ else if (_periods.Any())
                     var s = w.ActivatedDate > metrics.Start ? w.ActivatedDate.Date : metrics.Start.Date;
                     var e = w.ClosedDate < metrics.End ? w.ClosedDate.Date : metrics.End.Date;
                     active += (e - s).TotalDays + 1;
-                /*end*/}
+                }
 
                 var days = (metrics.End.Date - metrics.Start.Date).TotalDays + 1;
                 metrics.AvgWip = days > 0 ? active / days : 0;
@@ -418,11 +418,11 @@ else if (_periods.Any())
                             ? 100.0 * value / metrics.Velocity
                             : 100.0 * (metrics.Velocity - value) / metrics.Velocity
                         : 0;
-                /*end*/}
+                }
 
                 _periods.Add(metrics);
-            /*end*/}
-        /*end*/}
+            }
+        }
         else
         {
             DateTime start = _mode == AggregateMode.Month
@@ -436,7 +436,7 @@ else if (_periods.Any())
                     AggregateMode.Week => start.AddDays(7),
                     AggregateMode.Fortnight => start.AddDays(14),
                     _ => start.AddMonths(1)
-                /*end*/};
+                };
                 var rangeItems = items.Where(x => x.ClosedDate >= start && x.ClosedDate < next && x.ClosedDate <= endDate).ToList();
                 var metrics = new PeriodMetrics
                 {
@@ -446,7 +446,7 @@ else if (_periods.Any())
                     AvgLeadTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.CreatedDate).TotalDays) : 0,
                     AvgCycleTime = rangeItems.Any() ? rangeItems.Average(w => (w.ClosedDate - w.ActivatedDate).TotalDays) : 0,
                     Velocity = rangeItems.Sum(w => _velocityMode == VelocityMode.StoryPoints ? w.StoryPoints : w.OriginalEstimate)
-                /*end*/};
+                };
                 var overlap = items.Where(w => w.ActivatedDate <= metrics.End && w.ClosedDate >= metrics.Start);
                 double active = 0;
                 foreach (var w in overlap)
@@ -454,7 +454,7 @@ else if (_periods.Any())
                     var s = w.ActivatedDate > metrics.Start ? w.ActivatedDate.Date : metrics.Start.Date;
                     var e = w.ClosedDate < metrics.End ? w.ClosedDate.Date : metrics.End.Date;
                     active += (e - s).TotalDays + 1;
-                /*end*/}
+                }
 
                 var days = (metrics.End.Date - metrics.Start.Date).TotalDays + 1;
                 metrics.AvgWip = days > 0 ? active / days : 0;
@@ -467,12 +467,12 @@ else if (_periods.Any())
                             ? 100.0 * value / metrics.Velocity
                             : 100.0 * (metrics.Velocity - value) / metrics.Velocity
                         : 0;
-                /*end*/}
+                }
 
                 _periods.Add(metrics);
                 start = next;
-            /*end*/}
-        /*end*/}
+            }
+        }
 
         _xAxisLabels = _periods.Select(p => _mode == AggregateMode.Month
             ? p.End.ToString("yyyy-MM")
@@ -499,13 +499,13 @@ else if (_periods.Any())
         {
             var sprint = _periods.Select(p => p.SprintEfficiency).ToArray();
             _sprintSeries = [new ChartSeries { Name = "Sprint %", Data = sprint }];
-        /*end*/}
+        }
 
         _leadCycleApex = ToApexSeries(_leadCycleSeries, _xAxisLabels);
         _barApex = ToApexSeries(_barSeries, _xAxisLabels);
         _wipApex = ToApexSeries(_wipSeries, _xAxisLabels);
         _sprintApex = ToApexSeries(_sprintSeries, _xAxisLabels);
-    /*end*/}
+    }
 
     private void ComputeBurnUp(List<StoryMetric> items)
     {
@@ -515,7 +515,7 @@ else if (_periods.Any())
         {
             _burnLabels = [];
             return;
-        /*end*/}
+        }
         var efficiency = _useSprintEfficiency && !string.IsNullOrWhiteSpace(_tag)
             ? ComputeOverallSprintEfficiency(items)
             : _efficiency;
@@ -530,7 +530,7 @@ else if (_periods.Any())
             var idx = (it.ClosedDate.Date - start).Days;
             var val = _velocityMode == VelocityMode.StoryPoints ? it.StoryPoints : it.OriginalEstimate;
             daily[idx] += val;
-        /*end*/}
+        }
 
         double[] doneActual = new double[daysActual];
         double sum = 0;
@@ -538,7 +538,7 @@ else if (_periods.Any())
         {
             sum += daily[i];
             doneActual[i] = sum;
-        /*end*/}
+        }
 
         var avgVel = sum / Math.Max(1, daysActual);
         var effVel = avgVel * (efficiency.GetValueOrDefault() / 100.0);
@@ -568,7 +568,7 @@ else if (_periods.Any())
                 complete.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(doneActual[i], 2) });
                 minProj.Add(new ChartPoint { Label = labels[i], Value = null });
                 maxProj.Add(new ChartPoint { Label = labels[i], Value = null });
-            /*end*/}
+            }
             else
             {
                 complete.Add(new ChartPoint { Label = labels[i], Value = null });
@@ -582,19 +582,19 @@ else if (_periods.Any())
                     {
                         maxProj.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(finalTarget, 2) });
                         maxReached = true;
-                    /*end*/}
+                    }
                     else
                     {
                         maxProj.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(maxVal, 2) });
-                    /*end*/}
-                /*end*/}
+                    }
+                }
                 else
                 {
                     maxProj.Add(new ChartPoint { Label = labels[i], Value = null });
-                /*end*/}
-            /*end*/}
+                }
+            }
             target.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(finalTarget, 2) });
-        /*end*/}
+        }
 
         // Straight trend line from 0 to final completion
         double slope = daysActual > 1 ? sum / (daysActual - 1) : 0;
@@ -604,12 +604,12 @@ else if (_periods.Any())
             {
                 var val = slope * i;
                 trend.Add(new ChartPoint { Label = labels[i], Value = (decimal)Math.Round(val, 2) });
-            /*end*/}
+            }
             else
             {
                 trend.Add(new ChartPoint { Label = labels[i], Value = null });
-            /*end*/}
-        /*end*/}
+            }
+        }
 
         _burnApex = [
             new ApexSeries { Name = "Complete", Points = complete },
@@ -624,22 +624,22 @@ else if (_periods.Any())
             _daysMax = daysMax;
             _dateMin = end.AddDays(daysMin);
             _dateMax = end.AddDays(daysMax);
-        /*end*/}
+        }
         else
         {
             _daysMin = null;
             _daysMax = null;
             _dateMin = null;
             _dateMax = null;
-        /*end*/}
+        }
 
         List<double> dash = [];
         foreach (var s in _burnApex)
         {
             dash.Add(s.Name is "Trend" or "Projection Min" or "Projection Max" ? 5d : 0d);
-        /*end*/}
+        }
         _burnOptions.Stroke = new Stroke { DashArray = new ApexCharts.Size(dash) };
-    /*end*/}
+    }
 
     private void ComputeFlow(List<StoryMetric> items)
     {
@@ -648,7 +648,7 @@ else if (_periods.Any())
         {
             _flowLabels = [];
             return;
-        /*end*/}
+        }
 
         var start = (_startDate ?? items.Min(i => i.CreatedDate)).Date;
         var closedItems = items.Where(i => i.ClosedDate != StoryMetric.OpenClosedDate);
@@ -663,13 +663,13 @@ else if (_periods.Any())
             backlog[i] = items.Count(it => it.CreatedDate.Date <= day && it.ActivatedDate.Date > day);
             wip[i] = items.Count(it => it.ActivatedDate.Date <= day && it.ClosedDate.Date > day);
             done[i] = items.Count(it => it.ClosedDate.Date <= day);
-        /*end*/}
+        }
 
         string[] labels = new string[days];
         for (int i = 0; i < days; i++)
         {
             labels[i] = start.AddDays(i).ToLocalDateString();
-        /*end*/}
+        }
 
         _flowLabels = labels;
         _flowSeries =
@@ -680,7 +680,7 @@ else if (_periods.Any())
         ];
 
         _flowApex = ToApexSeries(_flowSeries, _flowLabels);
-    /*end*/}
+    }
 
     private double ComputeOverallSprintEfficiency(List<StoryMetric> items)
     {
@@ -692,7 +692,7 @@ else if (_periods.Any())
                 ? 100.0 * value / total
                 : 100.0 * (total - value) / total
             : 0;
-    /*end*/}
+    }
 
     private static List<ApexSeries> ToApexSeries(List<ChartSeries> series, string[] labels)
     {
@@ -706,11 +706,11 @@ else if (_periods.Any())
                 if (val.HasValue)
                     val = Math.Round(val.Value, 2);
                 converted.Points.Add(new ChartPoint { Label = labels[i], Value = val });
-            /*end*/}
+            }
             result.Add(converted);
-        /*end*/}
+        }
         return result;
-    /*end*/}
+    }
 
     private static string BuildCsv(IEnumerable<PeriodMetrics> periods)
     {
@@ -720,7 +720,7 @@ else if (_periods.Any())
         foreach (var p in periods)
             sb.AppendLine($"{p.End:yyyy-MM-dd},{p.AvgLeadTime:0.0},{p.AvgCycleTime:0.0},{p.Throughput},{p.Velocity:0.0}");
         return sb.ToString();
-    /*end*/}
+    }
 
     private static string BuildPromptData(IEnumerable<PeriodMetrics> periods)
     {
@@ -734,7 +734,7 @@ else if (_periods.Any())
             velocity = p.Velocity,
             avgWip = p.AvgWip,
             sprintEfficiency = p.SprintEfficiency
-        /*end*/});
+        });
         decimal totalLead = 0;
         decimal totalCycle = 0;
         decimal totalThroughput = 0;
@@ -752,7 +752,7 @@ else if (_periods.Any())
             totalWip += (decimal)p.AvgWip;
             totalSprint += (decimal)p.SprintEfficiency;
             count++;
-        /*end*/}
+        }
 
         var summary = new
         {
@@ -762,15 +762,15 @@ else if (_periods.Any())
             avgVelocity = count > 0 ? totalVelocity / count : 0,
             avgWip = count > 0 ? totalWip / count : 0,
             avgSprintEfficiency = count > 0 ? totalSprint / count : 0
-        /*end*/};
+        };
         var payload = new { metrics, summary };
         return JsonSerializer.Serialize(payload);
-    /*end*/}
+    }
 
     private void ToggleBurnChartControls()
     {
         _showBurnChartControls = !_showBurnChartControls;
-    /*end*/}
+    }
 
 
     private async Task ExportCsv()
@@ -778,7 +778,7 @@ else if (_periods.Any())
         if (_periods.Count == 0) return;
         var csv = BuildCsv(_periods);
         await JS.InvokeVoidAsync("downloadCsv", "metrics.csv", csv);
-    /*end*/}
+    }
 
     private async Task CopyPrompt()
     {
@@ -787,12 +787,12 @@ else if (_periods.Any())
         var prompt = PromptService.BuildMetricsPrompt(json, ConfigService.Config.OutputFormat);
         await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
-    /*end*/}
+    }
 
     private string FormatValue(decimal value)
     {
         return value.ToString("0.##");
-    /*end*/}
+    }
 
     private async Task UpdateBurnUp()
     {
@@ -811,9 +811,9 @@ else if (_periods.Any())
             TagMarksSprint = _tagMarksSprint,
             UseSprintEfficiency = _useSprintEfficiency,
             IgnoredTags = _ignoredTags.ToList()
-        /*end*/});
+        });
         StateHasChanged();
-    /*end*/}
+    }
 
     private void ToggleLeadCycle() => _leadCycleExpanded = !_leadCycleExpanded;
     private void ToggleBar() => _barExpanded = !_barExpanded;
@@ -833,7 +833,7 @@ else if (_periods.Any())
         if (!string.IsNullOrWhiteSpace(value))
             result = result.Where(t => t.Contains(value, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(result);
-    /*end*/}
+    }
 
     private Task<IEnumerable<string>> SearchIgnoreTags(string value, CancellationToken _)
     {
@@ -842,14 +842,14 @@ else if (_periods.Any())
             result = result.Where(t => t.Contains(value, StringComparison.OrdinalIgnoreCase));
         result = result.Where(t => !_ignoredTags.Contains(t));
         return Task.FromResult(result);
-    /*end*/}
+    }
 
     private IEnumerable<StoryMetric> FilterItems(IEnumerable<StoryMetric> items)
     {
         if (_ignoredTags.Count == 0)
             return items;
         return items.Where(i => !i.Tags.Any(t => _ignoredTags.Contains(t)));
-    /*end*/}
+    }
 
     private void AddIgnoreTag()
     {
@@ -857,18 +857,18 @@ else if (_periods.Any())
             return;
         _ignoredTags.Add(_ignoreTag);
         _ignoreTag = string.Empty;
-    /*end*/}
+    }
 
     private void RemoveIgnoreTag(string tag)
     {
         _ignoredTags.Remove(tag);
-    /*end*/}
+    }
 
     private static DateTime StartOfWeek(DateTime dt)
     {
         int diff = (7 + (int)dt.DayOfWeek - (int)DayOfWeek.Monday) % 7;
         return dt.Date.AddDays(-diff);
-    /*end*/}
+    }
 
 
 
@@ -886,11 +886,11 @@ else if (_periods.Any())
         public bool TagMarksSprint { get; set; }
         public bool UseSprintEfficiency { get; set; }
         public List<string>? IgnoredTags { get; set; }
-    /*end*/}
+    }
 
     protected override Task OnProjectChangedAsync()
     {
         return OnInitializedAsync();
-    /*end*/}
+    }
 
-/*end*/}
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -34,7 +34,7 @@
 @if (!string.IsNullOrWhiteSpace(_error))
 {
     <MudAlert Severity="Severity.Error">@_error</MudAlert>
-/*end*/}
+}
 
 <MudStepper @ref="_stepper" NonLinear="true">
     <MudStep Title="@L["SelectRequirements"]" Skippable="true">
@@ -73,7 +73,7 @@
                     </MudTooltip>
                     <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.ContentCopy" OnClick="() => CopyPart(_promptParts[_partIndex])">@L["Copy"]</MudButton>
                 </MudStack>
-            /*end*/}
+            }
             <MudTextField T="string" @bind-Value="_responseText" Lines="6" Label="@L["LLMResponse"]" />
             <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="ImportPlan">@L["Import"]</MudButton>
         </MudStack>
@@ -101,9 +101,9 @@
                                     @bind-Description="story.Description"
                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
                                     @bind-Tags="story.Tags" />
-                /*end*/}
+                }
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddStory">@L["AddStory"]</MudButton>
-            /*end*/}
+            }
             else
             {
                 @foreach (var epic in _plan.Epics)
@@ -140,34 +140,34 @@
                                                     @bind-Description="story.Description"
                                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
                                                     @bind-Tags="story.Tags" />
-                                /*end*/}
+                                }
                                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddStory(feature)">@L["AddStory"]</MudButton>
                             </PlanItemEditor>
-                        /*end*/}
+                        }
                         <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddFeature(epic)">@L["AddFeature"]</MudButton>
                     </PlanItemEditor>
-                /*end*/}
+                }
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddEpic">@L["AddEpic"]</MudButton>
-            /*end*/}
+            }
 
             <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Wrap="Wrap.Wrap">
                 <MudSelect T="string" @bind-Value="_backlog" Label="@L["Backlog"]">
                     @foreach (var b in _backlogs)
                     {
                         <MudSelectItem Value="@b">@b</MudSelectItem>
-                    /*end*/}
+                    }
                 </MudSelect>
                 <MudButton Variant="Variant.Filled" Color="Color.Primary" Disabled="_loading" OnClick="CreateItems">@L["CreateWorkItems"]</MudButton>
                 <MudButton Variant="Variant.Outlined" Color="Color.Error" Disabled="_loading || _createdItems.Count == 0" OnClick="UndoCreatedItems">@L["Undo"]</MudButton>
             </MudStack>
-        /*end*/}
+        }
     </MudStep>
 </MudStepper>
 
 @if (_loading)
 {
     <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-/*end*/}
+}
 
 @code {
     [Parameter] public string ProjectName { get; set; } = string.Empty;
@@ -199,13 +199,12 @@
     private const string StateKey = "requirements-planner";
     private const long MaxFileSize = 10 * 1024 * 1024;
 
-    private static readonly string InitialPrompt = RequirementsGatherer_MainPrompt.Value;
     private bool GenerateDisabled => _loading || _source switch
         {
             DocumentSource.Document => _file == null,
             DocumentSource.Text => string.IsNullOrWhiteSpace(_text),
             _ => _selectedPages == null || _selectedPages.Count == 0
-        /*end*/};
+        };
 
     protected override async Task OnInitializedAsync()
     {
@@ -214,7 +213,7 @@
             ConfigService.CurrentProject.Name != ProjectName)
         {
             await ConfigService.SelectProjectAsync(ProjectName);
-        /*end*/}
+        }
         try
         {
             _backlogs = await ApiService.GetBacklogsAsync();
@@ -228,7 +227,7 @@
                     _backlog = state.Backlog;
                 if (!string.IsNullOrWhiteSpace(state.WikiId))
                     _wikiId = state.WikiId;
-            /*end*/}
+            }
 
             var wikis = await ApiService.GetWikisAsync();
             if (wikis.Count > 0)
@@ -240,16 +239,16 @@
                 {
                     _wikiItems = [BuildTreeItem(root)];
                     _promptWikiItems = [BuildTreeItem(root)];
-                /*end*/}
-            /*end*/}
+                }
+            }
 
             _error = null;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private async Task Generate()
     {
@@ -267,7 +266,7 @@
                         using var stream = _file.OpenReadStream(MaxFileSize);
                         var text = await DocumentHelpers.ExtractTextAsync(stream, _file.Name);
                         pages.Add((_file.Name, text));
-                    /*end*/}
+                    }
                     break;
                 case DocumentSource.Text:
                     if (!string.IsNullOrWhiteSpace(_text))
@@ -280,10 +279,10 @@
                         {
                             var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
                             pages.Add((p.Name, text));
-                        /*end*/}
-                    /*end*/}
+                        }
+                    }
                     break;
-            /*end*/}
+            }
             _prompt = PromptService.BuildRequirementsPlannerPrompt(pages, _storiesOnly, _clarify, ConfigService.Config);
             _promptParts = PromptHelpers.SplitPrompt(_prompt, ConfigService.Config.PromptCharacterLimit).ToList();
             _partIndex = 0;
@@ -291,20 +290,20 @@
             {
                 Backlog = _backlog,
                 WikiId = _wikiId
-            /*end*/});
+            });
             _error = null;
             await CopyPrompt();
             await (_stepper?.NextStepAsync() ?? Task.CompletedTask);
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
+        }
         finally
         {
             _loading = false;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private async Task UndoCreatedItems()
     {
@@ -320,23 +319,23 @@
         {
             await DeleteCreatedItems();
             _error = null;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
+        }
         finally
         {
             _loading = false;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private async Task DeleteCreatedItems()
     {
         for (var i = _createdItems.Count - 1; i >= 0; i--)
             await ApiService.DeleteWorkItemAsync(_createdItems[i]);
         _createdItems.Clear();
-    /*end*/}
+    }
 
     private async Task CopyPrompt()
     {
@@ -344,49 +343,48 @@
         {
             await JS.InvokeVoidAsync("copyText", _prompt);
             Snackbar.Add(L["CopyToast"].Value, Severity.Success);
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private async Task CopyInitialPrompt()
     {
         var prompt = await BuildInitialPrompt();
         await JS.InvokeVoidAsync("copyText", prompt);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
-    /*end*/}
+    }
 
     private async Task CopyPart(string text)
     {
         await JS.InvokeVoidAsync("copyText", text);
         Snackbar.Add(L["CopyToast"].Value, Severity.Success);
-    /*end*/}
+    }
 
     private void PrevPart()
     {
         if (_partIndex > 0)
             _partIndex--;
-    /*end*/}
+    }
 
     private void NextPart()
     {
         if (_promptParts != null && _partIndex < _promptParts.Count - 1)
             _partIndex++;
-    /*end*/}
+    }
 
     private async Task DownloadPrompt()
     {
         if (!string.IsNullOrWhiteSpace(_prompt))
             await JS.InvokeVoidAsync("downloadText", "prompt.txt", _prompt);
-    /*end*/}
+    }
 
     private Task OnFileSelected(InputFileChangeEventArgs e)
     {
         _file = e.File;
         return Task.CompletedTask;
-    /*end*/}
+    }
 
     private async Task<string> BuildInitialPrompt()
     {
-        var sb = new System.Text.StringBuilder(InitialPrompt);
         List<(string Name, string Text)> pages = [];
         switch (_promptSource)
         {
@@ -396,7 +394,7 @@
                     using var stream = _promptFile.OpenReadStream(MaxFileSize);
                     var text = await DocumentHelpers.ExtractTextAsync(stream, _promptFile.Name);
                     pages.Add((_promptFile.Name, text));
-                /*end*/}
+                }
                 break;
             case DocumentSource.Text:
                 if (!string.IsNullOrWhiteSpace(_promptText))
@@ -409,23 +407,13 @@
                     {
                         var text = await ApiService.GetWikiPageContentAsync(_wikiId, p.Path);
                         pages.Add((p.Name, text));
-                    /*end*/}
-                /*end*/}
+                    }
+                }
                 break;
-        /*end*/}
-        if (pages.Count > 0)
-        {
-            sb.AppendLine();
-            sb.AppendLine(RequirementsGatherer_DocumentIntroPrompt.Value);
-            foreach (var page in pages)
-            {
-                sb.AppendLine($"## {page.Name}");
-                sb.AppendLine(page.Text);
-                sb.AppendLine();
-            /*end*/}
-        /*end*/}
-        return sb.ToString();
-    /*end*/}
+        }
+
+        return PromptService.BuildRequirementsGathererPrompt(pages);
+    }
 
 
     private void ImportPlan()
@@ -439,16 +427,16 @@
             {
                 AddAiGeneratedTags(_plan);
                 SetTagStrings(_plan);
-            /*end*/}
+            }
             _error = null;
             _ = _stepper?.NextStepAsync();
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _plan = null;
             _error = ex.Message;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private static string ExtractJson(string text)
     {
@@ -457,7 +445,7 @@
         return start >= 0 && end > start
             ? text[start..(end + 1)]
             : text;
-    /*end*/}
+    }
 
     private static void SetTagStrings(Plan plan)
     {
@@ -471,9 +459,9 @@
                 feature.TagString = string.Join(", ", feature.Tags);
                 foreach (var story in feature.Stories)
                     story.TagString = string.Join(", ", story.Tags);
-            /*end*/}
-        /*end*/}
-    /*end*/}
+            }
+        }
+    }
 
     private static void AddAiGeneratedTags(Plan plan)
     {
@@ -487,15 +475,15 @@
                 AddTagIfMissing(feature.Tags);
                 foreach (var story in feature.Stories)
                     AddTagIfMissing(story.Tags);
-            /*end*/}
-        /*end*/}
-    /*end*/}
+            }
+        }
+    }
 
     private static void AddTagIfMissing(ICollection<string> tags)
     {
         if (!tags.Any(t => string.Equals(t, AppConstants.AiGeneratedTag, StringComparison.OrdinalIgnoreCase)))
             tags.Add(AppConstants.AiGeneratedTag);
-    /*end*/}
+    }
 
     private async Task CreateItems()
     {
@@ -520,8 +508,8 @@
                         tags
                     );
                     _createdItems.Add(story.Id);
-                /*end*/}
-            /*end*/}
+                }
+            }
             else
             {
                 foreach (var epic in _plan.Epics)
@@ -547,21 +535,21 @@
                                 tags2
                             );
                             _createdItems.Add(story.Id);
-                        /*end*/}
-                    /*end*/}
-                /*end*/}
-            /*end*/}
+                        }
+                    }
+                }
+            }
             _error = null;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
-        /*end*/}
+        }
         finally
         {
             _loading = false;
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private static TreeItemData<WikiPageNode> BuildTreeItem(WikiPageNode node)
     {
@@ -569,7 +557,7 @@
         if (node.Children.Count > 0)
             item.Children = node.Children.Select(BuildTreeItem).ToList();
         return item;
-    /*end*/}
+    }
 
 
     private async Task<IEnumerable<WorkItemInfo>> SearchFeatures(string value, CancellationToken _)
@@ -581,20 +569,20 @@
             var result = await ApiService.SearchFeaturesAsync(value);
             _error = null;
             return result;
-        /*end*/}
+        }
         catch (Exception ex)
         {
             _error = ex.Message;
             return Array.Empty<WorkItemInfo>();
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private object? _dragItem;
 
     private void OnDragStart(object item)
     {
         _dragItem = item;
-    /*end*/}
+    }
 
 
     private void OnDropOnPlan(Epic target)
@@ -605,7 +593,7 @@
         var index = _plan.Epics.IndexOf(target);
         _plan.Epics.Insert(index + 1, epic);
         _dragItem = null;
-    /*end*/}
+    }
 
     private void OnDropOnEpic(Epic epic)
     {
@@ -615,7 +603,7 @@
         if (parent != null && !epic.Features.Contains(feature))
             epic.Features.Add(feature);
         _dragItem = null;
-    /*end*/}
+    }
 
     private void OnDropOnFeature(Feature feature)
     {
@@ -627,7 +615,7 @@
         if (!feature.Stories.Contains(story))
             feature.Stories.Add(story);
         _dragItem = null;
-    /*end*/}
+    }
 
     private void OnDropOnStoryList(Story target)
     {
@@ -638,12 +626,12 @@
         var index = list.IndexOf(target);
         list.Insert(index + 1, story);
         _dragItem = null;
-    /*end*/}
+    }
 
     private void RemoveEpic(Epic epic)
     {
         _plan?.Epics.Remove(epic);
-    /*end*/}
+    }
 
     private void RemoveFeature(Feature feature)
     {
@@ -652,7 +640,7 @@
         foreach (var e in _plan.Epics)
             if (e.Features.Remove(feature))
                 break;
-    /*end*/}
+    }
 
     private void RemoveStory(Story story)
     {
@@ -662,38 +650,38 @@
         {
             _plan.Stories.Remove(story);
             return;
-        /*end*/}
+        }
         foreach (var e in _plan.Epics)
             foreach (var f in e.Features)
                 if (f.Stories.Remove(story))
                     return;
-    /*end*/}
+    }
 
     private void AddEpic()
     {
         _plan?.Epics.Add(new Epic());
-    /*end*/}
+    }
 
     private void AddFeature(Epic epic)
     {
         epic.Features.Add(new Feature());
-    /*end*/}
+    }
 
     private void AddStory(Feature feature)
     {
         feature.Stories.Add(new Story());
-    /*end*/}
+    }
 
     private void AddStory()
     {
         _plan?.Stories.Add(new Story());
-    /*end*/}
+    }
 
     private class Plan
     {
         public List<Epic> Epics { get; set; } = new();
         public List<Story> Stories { get; set; } = new();
-    /*end*/}
+    }
 
     private class Epic
     {
@@ -709,9 +697,9 @@
             set => Tags = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
                                 .Select(t => t.Trim())
                                 .ToList();
-        /*end*/}
+        }
         public List<Feature> Features { get; set; } = new();
-    /*end*/}
+    }
 
     private class Feature
     {
@@ -727,9 +715,9 @@
             set => Tags = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
                                 .Select(t => t.Trim())
                                 .ToList();
-        /*end*/}
+        }
         public List<Story> Stories { get; set; } = new();
-    /*end*/}
+    }
 
     private class Story
     {
@@ -746,17 +734,17 @@
             set => Tags = value.Split(',', StringSplitOptions.RemoveEmptyEntries)
                                 .Select(t => t.Trim())
                                 .ToList();
-        /*end*/}
-    /*end*/}
+        }
+    }
 
     private class PageState
     {
         public string Backlog { get; set; } = string.Empty;
         public string WikiId { get; set; } = string.Empty;
-    /*end*/}
+    }
 
     protected override Task OnProjectChangedAsync()
     {
         return OnInitializedAsync();
-    /*end*/}
-/*end*/}
+    }
+}

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -37,6 +37,25 @@ public class PromptService
         return sb.ToString();
     }
 
+    public static string BuildRequirementsGathererPrompt(IEnumerable<(string Name, string Text)> pages)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine(RequirementsGatherer_MainPrompt.Value);
+        if (pages.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine(RequirementsGatherer_DocumentIntroPrompt.Value);
+            foreach (var page in pages)
+            {
+                sb.AppendLine($"## {page.Name}");
+                sb.AppendLine(page.Text);
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
+    }
+
     public static string BuildRequirementsQualityPrompt(IEnumerable<(string Name, string Text)> pages, DevOpsConfig config)
     {
         var sb = new StringBuilder();


### PR DESCRIPTION
## Summary
- move requirements gatherer construction into `PromptService`
- call new `BuildRequirementsGathererPrompt` from Requirements Planner
- drop leftover `/*end*/` markers from `.razor` pages
- add unit test for `BuildRequirementsGathererPrompt`

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686bef84c57c8328bf1986dc290d7ca5