### PR TITLE
Fix requirements gatherer prompt test

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -42,7 +42,8 @@ public class PromptService
     {
         var sb = new StringBuilder();
         var pagesArray = pages as (string Name, string Text)[] ?? pages.ToArray();
-        sb.AppendFormat(RequirementsGatherer_MainPrompt.Value,
+        sb.AppendFormat(
+            RequirementsGatherer_MainPrompt.Value,
             GetRequirementsGathererTemplate(config),
             BuildRequirementsDocument(pagesArray));
 
@@ -134,8 +135,13 @@ public class PromptService
 
     private static string BuildRequirementsDocument(IEnumerable<(string Name, string Text)> pages)
     {
+        var pagesArray = pages as (string Name, string Text)[] ?? pages.ToArray();
+        if (pagesArray.Length == 0) return string.Empty;
+
         var sb = new StringBuilder();
-        foreach (var page in pages)
+        sb.AppendLine(RequirementsGatherer_DocumentIntroPrompt.Value);
+
+        foreach (var page in pagesArray)
         {
             sb.AppendLine($"## {page.Name}");
             sb.AppendLine(page.Text);


### PR DESCRIPTION
## Summary
- include document intro in BuildRequirementsDocument
- ensure BuildRequirementsGathererPrompt formats pages correctly

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --verify-no-changes`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686cf1e780f88328bc14a8b3a64181e4