### PR TITLE
Support work item linking in requirements planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/PlanItemEditorTests.cs
@@ -2,6 +2,7 @@ using Bunit;
 using DevOpsAssistant.Components;
 using DevOpsAssistant.Tests.Utils;
 using DevOpsAssistant.Utils;
+using DevOpsAssistant.Services.Models;
 using System.Reflection;
 
 namespace DevOpsAssistant.Tests.Components;
@@ -48,5 +49,18 @@ public class PlanItemEditorTests : ComponentTestBase
         cut.InvokeAsync(() => remove.Invoke(cut.Instance, [AppConstants.AiGeneratedTag]));
         var tags = (List<string>)field.GetValue(cut.Instance)!;
         Assert.Contains(AppConstants.AiGeneratedTag, tags);
+    }
+
+    [Fact]
+    public void Shows_Links_When_Present()
+    {
+        SetupServices();
+        var links = new List<PlanItemLink> { new() { Type = "related", Target = "Other" } };
+        var cut = RenderComponent<PlanItemEditor>(p => p
+            .Add(c => c.Type, "User Story")
+            .Add(c => c.Links, links)
+        );
+
+        Assert.Contains("related - Other", cut.Markup);
     }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Pages/RequirementsPlannerPageTests.cs
@@ -89,6 +89,27 @@ public class RequirementsPlannerPageTests : ComponentTestBase
     }
 
     [Fact]
+    public void ImportPlan_Parses_Links()
+    {
+        SetupServices(includeApi: true);
+        var cut = RenderWithProvider<TestPage>();
+        var responseField = typeof(RequirementsPlanner).GetField("_responseText", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var json = "{\"stories\":[{\"title\":\"S1\",\"description\":\"D\",\"acceptanceCriteria\":\"AC\",\"links\":[{\"type\":\"related\",\"target\":\"S2\"}]}]}";
+        responseField.SetValue(cut.Instance, json);
+        var method = typeof(RequirementsPlanner).GetMethod("ImportPlan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        cut.InvokeAsync(() => method.Invoke(cut.Instance, null));
+
+        var planField = typeof(RequirementsPlanner).GetField("_plan", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var plan = planField.GetValue(cut.Instance)!;
+        var storyType = typeof(RequirementsPlanner).GetNestedType("Story", BindingFlags.NonPublic)!;
+        var storiesProp = plan.GetType().GetProperty("Stories")!;
+        var story = ((IEnumerable<object>)storiesProp.GetValue(plan)!).Cast<object>().First();
+        var linksProp = storyType.GetProperty("Links")!;
+        var links = (IEnumerable<object>)linksProp.GetValue(story)!;
+        Assert.Single(links);
+    }
+
+    [Fact]
     public async Task DeleteCreatedItems_Removes_All_In_Reverse_Order()
     {
         var config = SetupServices(includeApi: true);

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.es.resx
@@ -30,4 +30,7 @@
   <data name="AddLabel" xml:space="preserve">
     <value>Añadir</value>
   </data>
+  <data name="LinksLabel" xml:space="preserve">
+    <value>Vínculos</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.razor
@@ -1,4 +1,5 @@
 @using Microsoft.Extensions.Localization
+@using DevOpsAssistant.Services.Models
 @inject IStringLocalizer<PlanItemEditor> L
 
 <MudPaper Class="@($"pa-6 {WorkItemHelpers.GetItemClass(Type)}")" @ondrop="OnDropInternal" @ondragover:preventDefault="Droppable">
@@ -118,6 +119,17 @@
         {
             <div>@string.Join(", ", Tags)</div>
         }
+
+        @if (Links.Count > 0)
+        {
+            <MudText Typo="Typo.subtitle2">@L["LinksLabel"]</MudText>
+            <MudList T="PlanItemLink" Dense="true">
+                @foreach (var l in Links)
+                {
+                    <MudListItem T="PlanItemLink">@l.Type - @l.Target</MudListItem>
+                }
+            </MudList>
+        }
     </MudStack>
 
     @if (ChildContent != null)
@@ -142,6 +154,7 @@
     [Parameter] public EventCallback<string?> AcceptanceCriteriaChanged { get; set; }
     [Parameter] public List<string> Tags { get; set; } = new();
     [Parameter] public EventCallback<List<string>> TagsChanged { get; set; }
+    [Parameter] public List<PlanItemLink> Links { get; set; } = new();
     [Parameter] public RenderFragment? ChildContent { get; set; }
 
     private string _newTag = string.Empty;

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/PlanItemEditor.resx
@@ -30,4 +30,7 @@
   <data name="AddLabel" xml:space="preserve">
     <value>Add</value>
   </data>
+  <data name="LinksLabel" xml:space="preserve">
+    <value>Links</value>
+  </data>
 </root>

--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/RequirementsPlanner.razor
@@ -98,7 +98,8 @@
                                     @bind-Title="story.Title"
                                     @bind-Description="story.Description"
                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
-                                    @bind-Tags="story.Tags" />
+                                    @bind-Tags="story.Tags"
+                                    Links="story.Links" />
                 }
                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="AddStory">@L["AddStory"]</MudButton>
             }
@@ -114,7 +115,8 @@
                                     OnDelete="EventCallback.Factory.Create(this, () => RemoveEpic(epic))"
                                     @bind-Title="epic.Title"
                                     @bind-Description="epic.Description"
-                                    @bind-Tags="epic.Tags" >
+                                    @bind-Tags="epic.Tags"
+                                    Links="epic.Links" >
                         @foreach (var feature in epic.Features)
                         {
                             <PlanItemEditor Type="Feature"
@@ -125,7 +127,8 @@
                                             OnDelete="EventCallback.Factory.Create(this, () => RemoveFeature(feature))"
                                             @bind-Title="feature.Title"
                                             @bind-Description="feature.Description"
-                                            @bind-Tags="feature.Tags" >
+                                            @bind-Tags="feature.Tags"
+                                            Links="feature.Links" >
                                 @foreach (var story in feature.Stories)
                                 {
                                     <PlanItemEditor Type="User Story"
@@ -137,7 +140,8 @@
                                                     @bind-Title="story.Title"
                                                     @bind-Description="story.Description"
                                                     @bind-AcceptanceCriteria="story.AcceptanceCriteria"
-                                                    @bind-Tags="story.Tags" />
+                                                    @bind-Tags="story.Tags"
+                                                    Links="story.Links" />
                                 }
                                 <MudButton Variant="Variant.Text" StartIcon="@Icons.Material.Filled.Add" OnClick="() => AddStory(feature)">@L["AddStory"]</MudButton>
                             </PlanItemEditor>
@@ -194,6 +198,7 @@
     private WorkItemInfo? _feature;
     private Plan? _plan;
     private readonly List<int> _createdItems = new();
+    private readonly Dictionary<string, int> _titleToId = new(StringComparer.OrdinalIgnoreCase);
     private const string StateKey = "requirements-planner";
     private const long MaxFileSize = 10 * 1024 * 1024;
 
@@ -487,6 +492,7 @@
     {
         if (_plan == null) return;
         _loading = true;
+        _titleToId.Clear();
         StateHasChanged();
         try
         {
@@ -506,6 +512,7 @@
                         tags
                     );
                     _createdItems.Add(story.Id);
+                    _titleToId[story.Title] = story.Id;
                 }
             }
             else
@@ -515,11 +522,13 @@
                     var epicTags = epic.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                     epic.Id = await ApiService.CreateWorkItemAsync("Epic", epic.Title, epic.Description, _backlog, null, null, epicTags);
                     _createdItems.Add(epic.Id);
+                    _titleToId[epic.Title] = epic.Id;
                     foreach (var feature in epic.Features)
                     {
                         var featureTags = feature.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
                         feature.Id = await ApiService.CreateWorkItemAsync("Feature", feature.Title, feature.Description, _backlog, epic.Id, null, featureTags);
                         _createdItems.Add(feature.Id);
+                        _titleToId[feature.Title] = feature.Id;
                         foreach (var story in feature.Stories)
                         {
                             var tags2 = story.Tags.Concat([AppConstants.AiGeneratedTag]).ToArray();
@@ -533,10 +542,12 @@
                                 tags2
                             );
                             _createdItems.Add(story.Id);
+                            _titleToId[story.Title] = story.Id;
                         }
                     }
                 }
             }
+            await AddLinks();
             _error = null;
         }
         catch (Exception ex)
@@ -547,6 +558,29 @@
         {
             _loading = false;
         }
+    }
+
+    private async Task AddLinks()
+    {
+        foreach (var story in _plan?.Stories ?? [])
+            await AddLinksForItem(story.Id, story.Links);
+        foreach (var epic in _plan?.Epics ?? [])
+        {
+            await AddLinksForItem(epic.Id, epic.Links);
+            foreach (var feature in epic.Features)
+            {
+                await AddLinksForItem(feature.Id, feature.Links);
+                foreach (var story in feature.Stories)
+                    await AddLinksForItem(story.Id, story.Links);
+            }
+        }
+    }
+
+    private async Task AddLinksForItem(int id, List<PlanItemLink> links)
+    {
+        foreach (var link in links)
+            if (_titleToId.TryGetValue(link.Target, out var targetId))
+                await ApiService.AddRelationAsync(id, targetId, link.Type);
     }
 
     private static TreeItemData<WikiPageNode> BuildTreeItem(WikiPageNode node)
@@ -687,6 +721,7 @@
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<string> Tags { get; set; } = new();
+        public List<PlanItemLink> Links { get; set; } = new();
 
         [JsonIgnore]
         public string TagString
@@ -705,6 +740,7 @@
         public string Title { get; set; } = string.Empty;
         public string Description { get; set; } = string.Empty;
         public List<string> Tags { get; set; } = new();
+        public List<PlanItemLink> Links { get; set; } = new();
 
         [JsonIgnore]
         public string TagString
@@ -724,6 +760,7 @@
         public string Description { get; set; } = string.Empty;
         public string AcceptanceCriteria { get; set; } = string.Empty;
         public List<string> Tags { get; set; } = new();
+        public List<PlanItemLink> Links { get; set; } = new();
 
         [JsonIgnore]
         public string TagString

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsPlanner.txt
@@ -47,12 +47,24 @@ Requirements Document:
 ==== RequirementsPlanner_EpicsFeaturesStories ====
 Epics, Features, and User Stories.
 Return strict JSON using this format:
-{"epics":[{"title":"","description":"","features":[{"title":"","description":"","stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""]}]}]}]}
+{"epics":[{"title":"","description":"","links":[{"type":"","target":""}],"features":[{"title":"","description":"","links":[{"type":"","target":""}],"stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""],"links":[{"type":"","target":""}]}]}]}]}
+Allowed link types: "related", "successor" and "predecessor".
+Set "target" to the title of the linked item.
+Use "successor" when the current item depends on the target. The reverse
+"predecessor" link is implied; do not create both directions.
+Only add links where there is a clear relationship that must be considered
+during refinement.
 
 ==== RequirementsPlanner_StoriesOnly ====
 User Stories.
 Return strict JSON using this format:
-{"stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""]}]}
+{"stories":[{"title":"","description":"","acceptanceCriteria":"","tags":[""],"links":[{"type":"","target":""}]}]}
+Allowed link types: "related", "successor" and "predecessor".
+Set "target" to the title of the linked item.
+Use "successor" when the current item depends on the target. The reverse
+"predecessor" link is implied; do not create both directions.
+Only add links where there is a clear relationship that must be considered
+during refinement.
 
 ==== RequirementsPlanner_ClarifyRequirements ====
 Clarify Requirements:

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PlanItemLink.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/Models/PlanItemLink.cs
@@ -1,0 +1,7 @@
+namespace DevOpsAssistant.Services.Models;
+
+public class PlanItemLink
+{
+    public string Type { get; set; } = string.Empty;
+    public string Target { get; set; } = string.Empty;
+}


### PR DESCRIPTION
## Summary
- extend DevOps API to add relations between work items
- update requirement planner prompt to include links
- display links in `PlanItemEditor`
- store links in generated plan and create them in DevOps
- test coverage for new functionality
- clarify allowed link types in planner prompt

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_686cf89dbac88328917a0b847298d75b