### PR TITLE
Add high contrast theme option

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/GlobalOptionsDialogTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Components/GlobalOptionsDialogTests.cs
@@ -39,4 +39,20 @@ public class GlobalOptionsDialogTests : ComponentTestBase
 
         Assert.Equal("es", config.GlobalCulture);
     }
+
+    [Fact]
+    public async Task Save_Updates_GlobalHighContrast()
+    {
+        var config = SetupServices();
+        var fake = new FakeDialog();
+        var cut = RenderComponent<GlobalOptionsDialog>(p => p.AddCascadingValue(fake));
+
+        var field = cut.Instance.GetType().GetField("_highContrast", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        field.SetValue(cut.Instance, true);
+        var method = cut.Instance.GetType().GetMethod("Save", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        await cut.InvokeAsync(() => (Task)method.Invoke(cut.Instance, null)!);
+
+        Assert.True(config.GlobalHighContrast);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/DevOpsConfigServiceTests.cs
@@ -303,6 +303,19 @@ public class DevOpsConfigServiceTests
     }
 
     [Fact]
+    public async Task SaveGlobalHighContrastAsync_Persists_Value()
+    {
+        var storage = new FakeLocalStorageService();
+        var service = new DevOpsConfigService(storage);
+
+        await service.SaveGlobalHighContrastAsync(true);
+
+        Assert.True(service.GlobalHighContrast);
+        var stored = await storage.GetItemAsync<bool?>("devops-contrast");
+        Assert.True(stored);
+    }
+
+    [Fact]
     public async Task SaveGlobalOrganizationAsync_Persists_Value()
     {
         var storage = new FakeLocalStorageService();

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.es.resx
@@ -27,6 +27,9 @@
   <data name="Spanish" xml:space="preserve">
     <value>Español</value>
   </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>Alto contraste</value>
+  </data>
   <data name="Save" xml:space="preserve">
     <value>Guardar</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.razor
@@ -11,10 +11,11 @@
         <MudStack Spacing="2">
             <MudTextField @bind-Value="_organization" Label='@L["Organization"]' autocomplete="off" />
             <MudTextField @bind-Value="_token" Label='@L["PatToken"]' InputType="InputType.Password" autocomplete="off" />
-            <MudSelect @bind-Value="_culture" Label='@L["Language"]'>
-                <MudSelectItem Value="@("en-GB")">@L["English"]</MudSelectItem>
-                <MudSelectItem Value="@("es")">@L["Spanish"]</MudSelectItem>
-            </MudSelect>
+        <MudSelect @bind-Value="_culture" Label='@L["Language"]'>
+            <MudSelectItem Value="@("en-GB")">@L["English"]</MudSelectItem>
+            <MudSelectItem Value="@("es")">@L["Spanish"]</MudSelectItem>
+        </MudSelect>
+        <MudSwitch T="bool" @bind-Value="_highContrast" Color="Color.Primary" Label='@L["HighContrast"]' />
         </MudStack>
     </DialogContent>
     <DialogActions>
@@ -28,6 +29,7 @@
     private string _organization = string.Empty;
     private string _token = string.Empty;
     private string _culture = "en-GB";
+    private bool _highContrast;
     
 
     protected override async Task OnInitializedAsync()
@@ -36,6 +38,7 @@
         _organization = ConfigService.GlobalOrganization;
         _token = ConfigService.GlobalPatToken;
         _culture = ConfigService.GlobalCulture;
+        _highContrast = ConfigService.GlobalHighContrast;
         try
         {
             var stored = await JSRuntime.InvokeAsync<string>("blazorCulture.get");
@@ -53,6 +56,7 @@
         await ConfigService.SaveGlobalOrganizationAsync(_organization);
         await ConfigService.SaveGlobalPatAsync(_token);
         await ConfigService.SaveGlobalCultureAsync(_culture);
+        await ConfigService.SaveGlobalHighContrastAsync(_highContrast);
         try
         {
             await JSRuntime.InvokeVoidAsync("blazorCulture.set", _culture);

--- a/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
+++ b/src/DevOpsAssistant/DevOpsAssistant/Components/GlobalOptionsDialog.resx
@@ -27,6 +27,9 @@
   <data name="Spanish" xml:space="preserve">
     <value>Spanish</value>
   </data>
+  <data name="HighContrast" xml:space="preserve">
+    <value>High Contrast</value>
+  </data>
   <data name="Save" xml:space="preserve">
     <value>Save</value>
   </data>

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -89,7 +89,9 @@
     private bool _initialized;
     private bool _isDarkMode;
     private MudTheme CurrentTheme
-        => (ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme)
+        => (ThemeSession.IsDoom
+                ? DoomTheme.Theme
+                : (ConfigService.GlobalHighContrast ? HighContrastTheme.Theme : AzureDevOpsTheme.Theme))
             .WithPrimaryColor(ConfigService.CurrentProject.Color);
     
     private void HandleProjectChanged()

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/SimpleLayout.razor
@@ -53,7 +53,9 @@
 @code {
     private bool _isDarkMode;
     private MudTheme CurrentTheme
-        => (ThemeSession.IsDoom ? DoomTheme.Theme : AzureDevOpsTheme.Theme)
+        => (ThemeSession.IsDoom
+                ? DoomTheme.Theme
+                : (ConfigService.GlobalHighContrast ? HighContrastTheme.Theme : AzureDevOpsTheme.Theme))
             .WithPrimaryColor(ConfigService.CurrentProject.Color);
 
     protected override void OnInitialized()

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -9,6 +9,7 @@ public class DevOpsConfigService
     private const string StorageKey = "devops-projects";
     private const string GlobalPatKey = "devops-pat";
     private const string GlobalDarkKey = "devops-dark";
+    private const string GlobalContrastKey = "devops-contrast";
     private const string GlobalOrgKey = "devops-org";
     private const string GlobalCultureKey = "BlazorCulture";
     private const string CurrentKey = "devops-current";
@@ -29,6 +30,7 @@ public class DevOpsConfigService
     public string GlobalPatToken { get; private set; } = string.Empty;
     public string GlobalOrganization { get; private set; } = string.Empty;
     public bool GlobalDarkMode { get; private set; }
+    public bool GlobalHighContrast { get; private set; }
     public string GlobalCulture { get; private set; } = "en-GB";
 
     public DevOpsConfig Config => CurrentProject.Config;
@@ -46,6 +48,7 @@ public class DevOpsConfigService
         GlobalPatToken = await _localStorage.GetItemAsync<string>(GlobalPatKey) ?? string.Empty;
         GlobalOrganization = await _localStorage.GetItemAsync<string>(GlobalOrgKey) ?? string.Empty;
         GlobalDarkMode = await _localStorage.GetItemAsync<bool?>(GlobalDarkKey) ?? false;
+        GlobalHighContrast = await _localStorage.GetItemAsync<bool?>(GlobalContrastKey) ?? false;
         GlobalCulture = await _localStorage.GetItemAsync<string>(GlobalCultureKey) ?? "en-GB";
         var currentName = await _localStorage.GetItemAsync<string>(CurrentKey) ?? string.Empty;
         var projects = await _localStorage.GetItemAsync<List<DevOpsProject>>(StorageKey);
@@ -126,6 +129,12 @@ public class DevOpsConfigService
     {
         GlobalDarkMode = value;
         await _localStorage.SetItemAsync(GlobalDarkKey, GlobalDarkMode);
+    }
+
+    public async Task SaveGlobalHighContrastAsync(bool value)
+    {
+        GlobalHighContrast = value;
+        await _localStorage.SetItemAsync(GlobalContrastKey, GlobalHighContrast);
     }
 
     public async Task SaveGlobalCultureAsync(string culture)
@@ -272,12 +281,14 @@ public class DevOpsConfigService
         GlobalPatToken = string.Empty;
         GlobalOrganization = string.Empty;
         GlobalDarkMode = false;
+        GlobalHighContrast = false;
         GlobalCulture = "en-GB";
         await _localStorage.RemoveItemAsync(StorageKey);
         await _localStorage.RemoveItemAsync(LegacyStorageKey);
         await _localStorage.RemoveItemAsync(GlobalPatKey);
         await _localStorage.RemoveItemAsync(GlobalOrgKey);
         await _localStorage.RemoveItemAsync(GlobalDarkKey);
+        await _localStorage.RemoveItemAsync(GlobalContrastKey);
         await _localStorage.RemoveItemAsync(GlobalCultureKey);
         await _localStorage.RemoveItemAsync(CurrentKey);
         OnProjectChanged();
@@ -295,6 +306,12 @@ public class DevOpsConfigService
         await _localStorage.RemoveItemAsync(GlobalOrgKey);
     }
 
+    public async Task RemoveGlobalHighContrastAsync()
+    {
+        GlobalHighContrast = false;
+        await _localStorage.RemoveItemAsync(GlobalContrastKey);
+    }
+
     public async Task RemoveGlobalCultureAsync()
     {
         GlobalCulture = "en-GB";
@@ -305,5 +322,4 @@ public class DevOpsConfigService
     {
         await _localStorage.SetItemAsync(StorageKey, Projects);
         await _localStorage.SetItemAsync(CurrentKey, CurrentProject.Name);
-    }
-}
+    }}

--- a/src/DevOpsAssistant/DevOpsAssistant/Utils/HighContrastTheme.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Utils/HighContrastTheme.cs
@@ -1,0 +1,34 @@
+using MudBlazor;
+
+namespace DevOpsAssistant.Utils;
+
+public static class HighContrastTheme
+{
+    public static MudTheme Theme { get; } = new MudTheme
+    {
+        PaletteLight = new PaletteLight
+        {
+            Primary = Colors.Shades.Black,
+            Secondary = Colors.Shades.White,
+            Background = Colors.Shades.White,
+            Surface = Colors.Shades.White,
+            AppbarBackground = Colors.Shades.White,
+            AppbarText = Colors.Shades.Black,
+            TextPrimary = Colors.Shades.Black,
+            TextSecondary = Colors.Shades.Black
+        },
+        PaletteDark = new PaletteDark
+        {
+            Primary = Colors.Shades.White,
+            Secondary = Colors.Shades.Black,
+            Background = Colors.Shades.Black,
+            Surface = Colors.Shades.Black,
+            AppbarBackground = Colors.Shades.Black,
+            TextPrimary = Colors.Shades.White,
+            TextSecondary = Colors.Shades.White,
+            DrawerBackground = Colors.Shades.Black,
+            DrawerText = Colors.Shades.White,
+            DrawerIcon = Colors.Shades.White
+        }
+    };
+}


### PR DESCRIPTION
## Summary
- add HighContrastTheme and theme toggle in global options
- persist high contrast flag in config service
- update layouts to honor high contrast mode
- localize new setting
- cover new behavior with tests

## Testing
- `dotnet format --no-restore src/DevOpsAssistant/DevOpsAssistant.sln`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686d7f398d0c8328bb7638ff56477afe