### PR TITLE
Support output format in requirements gatherer

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PromptServiceTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Services/PromptServiceTests.cs
@@ -87,4 +87,25 @@ public class PromptServiceTests
         Assert.Contains("Document:", result);
         Assert.Contains("Page Name: Doc", result);
     }
+
+    [Fact]
+    public void BuildRequirementsGathererPrompt_Inline_Format_Does_Not_Request_Conversion()
+    {
+        var cfg = new DevOpsConfig { OutputFormat = OutputFormat.Inline };
+
+        var result = PromptService.BuildRequirementsGathererPrompt([], cfg);
+
+        Assert.Contains("Reply inline", result);
+        Assert.DoesNotContain("convert the content", result);
+    }
+
+    [Fact]
+    public void BuildRequirementsGathererPrompt_Convert_Format_Includes_Target()
+    {
+        var cfg = new DevOpsConfig { OutputFormat = OutputFormat.Markdown };
+
+        var result = PromptService.BuildRequirementsGathererPrompt([], cfg);
+
+        Assert.Contains("convert the content to Markdown", result);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/FormatInstructions.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/FormatInstructions.txt
@@ -10,3 +10,7 @@ After generating the notes, convert the content to {0} format and include that v
 Reply inline with the analysis results.
 ==== FormatInstructions_WorkItemAnalysisConvert ====
 After completing the analysis, convert the output to {0} format and include that version.
+==== FormatInstructions_RequirementsGathererInline ====
+Reply inline with the final requirements document.
+==== FormatInstructions_RequirementsGathererConvert ====
+After generating the requirements document, convert the content to {0} format and include that version.

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsGatherer.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsGatherer.txt
@@ -82,6 +82,9 @@ Only output this once all required info has been collected.
 //{1} - Document
 {1}
 
+//{2} - Format Instructions
+{2}
+
 ==== RequirementsGatherer_Template_General====
 ```markdown
 # Feature Name: [Title]

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -45,8 +45,11 @@ public class PromptService
         sb.AppendFormat(
             RequirementsGatherer_MainPrompt.Value,
             GetRequirementsGathererTemplate(config),
-            BuildRequirementsDocument(pagesArray));
-
+            BuildRequirementsDocument(pagesArray),
+            config.OutputFormat == OutputFormat.Inline
+                ? FormatInstructions_RequirementsGathererInlinePrompt.Value
+                : string.Format(FormatInstructions_RequirementsGathererConvertPrompt.Value, config.OutputFormat));
+        sb.AppendLine();
         return sb.ToString();
     }
 


### PR DESCRIPTION
## Summary
- allow the requirements gatherer prompt to respect output format
- add format instructions for the requirements gatherer
- test that inline and conversion formats are handled
- embed format instructions directly in the requirements gatherer prompt

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686ed57156dc83289dc6602b19e03426