### PR TITLE
Adjust prompts action layout

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Pages/ProjectSettings.razor
@@ -191,10 +191,12 @@
                         </MudStack>
                     </MudTabPanel>
                 </MudTabs>
-                <MudStack Row="true" Spacing="1">
-                    <MudButton OnClick="CopyAllPrompts" Variant="Variant.Outlined" Color="Color.Primary">@L["CopyPrompts"]</MudButton>
+                <MudStack Spacing="1">
                     <MudButton OnClick="SavePrompts" Variant="Variant.Filled" Color="Color.Primary" Disabled="!_promptsDirty">@L["Save"]</MudButton>
-                    <MudButton OnClick="ApplyPromptsToAll" Variant="Variant.Outlined" Color="Color.Primary">@L["ApplyToAll"]</MudButton>
+                    <MudStack Row="true" Spacing="1">
+                        <MudButton OnClick="CopyAllPrompts" Variant="Variant.Outlined" Color="Color.Primary">@L["CopyPrompts"]</MudButton>
+                        <MudButton OnClick="ApplyPromptsToAll" Variant="Variant.Outlined" Color="Color.Primary">@L["ApplyToAll"]</MudButton>
+                    </MudStack>
                 </MudStack>
             </MudTabPanel>
             <MudTabPanel Text='@L["ValidationTab"]'>


### PR DESCRIPTION
## Summary
- make the save button stand alone
- group Copy Prompts and Apply to all projects buttons underneath

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686edb5a4e8c832885042f71a133c1da