### PR TITLE
Align standards prompts with planner

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/Metrics.txt
@@ -75,5 +75,9 @@ You will use the following **markdown report template** to structure your output
 _Compiled by:_ **Agile Coach Persona**  
 _Report Date:_ **{{today}}**
 ```
-==== Metrics_DataIntro ====
-Data: {0}
+
+//{0} - Format Instructions
+{0}
+
+//{1} - Data
+Data: {1}

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/ReleaseNotes.txt
@@ -110,5 +110,12 @@ Change control template:
 *Include any other relevant information for stakeholders, approvers, or implementers.*  
 [Other notes.]
 ```
+
+//{0} - Format Instructions
+{0}
+
+//{1} - Work Items
+{1}
+
 ==== ReleaseNotes_WorkItemsIntro ====
 Work items:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsDocumentationStandards.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsDocumentationStandards.txt
@@ -1,2 +1,13 @@
 ==== RequirementsDocumentationStandardsIntro ====
 Apply these requirements documentation standards:
+==== RequirementsDocumentationStandards_ISO29148 ====
+- ISO/IEC/IEEE 29148:2018 - for more information consult https://www.iso.org/standard/72030.html
+
+==== RequirementsDocumentationStandards_Volere ====
+- Volere Template - for more information consult https://www.volere.org
+
+==== RequirementsDocumentationStandards_BABOK ====
+- BABOK (Business Analysis Body of Knowledge) - for more information consult https://www.iiba.org/babok-guide/
+
+==== RequirementsDocumentationStandards_ISO25010 ====
+- ISO/IEC 25010 - for more information consult https://iso25000.com/index.php/en/iso-25000-standards/iso-25010

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/RequirementsQuality.txt
@@ -1,5 +1,12 @@
 ==== RequirementsQuality_Main ====
 You are an expert requirements analyst reviewing the following document.
 Assess whether the requirements are clear, complete, and testable. Identify ambiguities, missing information, or conflicts and provide improvement suggestions.
+
+//{0} - Requirements Documentation Standards
+{0}
+
+//{1} - Document
+{1}
+
 ==== RequirementsQuality_DocumentIntro ====
 Document:

--- a/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
+++ b/src/DevOpsAssistant/DevOpsAssistant/Prompts/WorkItemQuality.txt
@@ -77,11 +77,44 @@ Tailor your coaching based on the score:
 ---
 
 For bugs, check that the reproduction steps and system information are clear and complete.
+
+//{0} - Bug Reporting Standards
+{0}
+
+//{1} - Definition of Ready
+{1}
+
+//{2} - Story Quality Standards
+{2}
+
+//{3} - Format Instructions
+{3}
+
+//{4} - Work Items
+{4}
+
 ==== WorkItemQuality_BugReportingStandardsIntro ====
 Ensure bug reports follow these standards:
+
 ==== WorkItemQuality_DefinitionOfReadyIntro ====
 Also confirm each story meets this Definition of Ready:
+
 ==== WorkItemQuality_StoryQualityStandardsIntro ====
 Apply these story quality standards:
+
 ==== WorkItemQuality_WorkItemsIntro ====
 Work items:
+==== WorkItemQuality_BugReportingStandards_AzureDevOpsBug ====
+- Azure DevOps Bug - for more information consult https://learn.microsoft.com/azure/devops/boards/backlogs/about-bugs
+
+==== WorkItemQuality_BugReportingStandards_ISTQBDefect ====
+- ISTQB Defect Report - for more information consult https://glossary.istqb.org/en/term/defect-report
+
+==== WorkItemQuality_StoryQualityStandards_INVEST ====
+- INVEST - for more information consult https://agilealliance.org/glossary/invest/
+
+==== WorkItemQuality_StoryQualityStandards_SAFe ====
+- SAFe - for more information consult https://framework.scaledagile.com/
+
+==== WorkItemQuality_StoryQualityStandards_AgileAlliance ====
+- Agile Alliance - for more information consult https://www.agilealliance.org

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -321,5 +321,5 @@ public class DevOpsConfigService
     private async Task SaveProjectsAsync()
     {
         await _localStorage.SetItemAsync(StorageKey, Projects);
-        await _localStorage.SetItemAsync(CurrentKey, CurrentProject.Name);
-    }}
+        await _localStorage.SetItemAsync(CurrentKey, CurrentProject.Name);    }
+}


### PR DESCRIPTION
## Summary
- add bullet text for documentation, bug, and story quality standards
- reference new snippets in PromptService
- clean up DevOpsConfigService newline

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --no-restore`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686ee7641ac0832889e71775ceaeb056