### PR TITLE
Color project dropdown items

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant.Tests/Layout/MainLayoutTests.cs
@@ -151,4 +151,20 @@ public class MainLayoutTests : ComponentTestBase
         var button = cut.Find("div.mud-menu button");
         Assert.Contains("Demo", button.TextContent);
     }
+
+    [Fact]
+    public async Task Project_MenuItem_Uses_Project_Color()
+    {
+        var config = SetupServices();
+        await config.AddProjectAsync("Demo");
+        config.Projects[0].Color = "#123456";
+        await config.SelectProjectAsync("Demo");
+
+        var cut = RenderComponent<MainLayout>();
+
+        var button = cut.Find("div.mud-menu button");
+        button.Click();
+        var item = cut.Find("div.mud-popover-provider .mud-menu-item");
+        Assert.Contains("#123456", item.GetAttribute("style"));
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -23,7 +23,7 @@
         <MudMenu Label='@(_selectedProject.Length > 0 ? _selectedProject : L["Projects"])' EndIcon="@Icons.Material.Filled.ArrowDropDown">
             @foreach (var p in ConfigService.Projects.OrderBy(p => p.Name))
             {
-                <MudMenuItem OnClick="() => ChangeProject(p.Name)">@p.Name</MudMenuItem>
+                <MudMenuItem OnClick="() => ChangeProject(p.Name)" Style="@GetProjectStyle(p.Color)">@p.Name</MudMenuItem>
             }
             <MudDivider />
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
@@ -93,6 +93,9 @@
                 ? DoomTheme.Theme
                 : (ConfigService.GlobalHighContrast ? HighContrastTheme.Theme : AzureDevOpsTheme.Theme))
             .WithPrimaryColor(ConfigService.CurrentProject.Color);
+
+    private static string GetProjectStyle(string color)
+        => string.IsNullOrWhiteSpace(color) ? string.Empty : $"background-color:{color};";
     
     private void HandleProjectChanged()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/DevOpsConfigService.cs
@@ -321,5 +321,6 @@ public class DevOpsConfigService
     private async Task SaveProjectsAsync()
     {
         await _localStorage.SetItemAsync(StorageKey, Projects);
-        await _localStorage.SetItemAsync(CurrentKey, CurrentProject.Name);    }
+        await _localStorage.SetItemAsync(CurrentKey, CurrentProject.Name);
+    }
 }

--- a/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
+++ b/src/DevOpsAssistant/DevOpsAssistant/Services/PromptService.cs
@@ -367,4 +367,5 @@ public class PromptService
         }
 
         return sb.ToString();
-    }}
+    }
+}


### PR DESCRIPTION
## Summary
- color project dropdown items to match the project color
- ensure config services format passes lint
- test that menu items use the project color

## Testing
- `dotnet format src/DevOpsAssistant/DevOpsAssistant.sln --verify-no-changes`
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686f8cb6888c832893cdcb7274c4b214