### PR TITLE
Add hover effect for project menu

### DIFF
--- a/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
+++ b/src/DevOpsAssistant/DevOpsAssistant/Layout/MainLayout.razor
@@ -23,7 +23,9 @@
         <MudMenu Label='@(_selectedProject.Length > 0 ? _selectedProject : L["Projects"])' EndIcon="@Icons.Material.Filled.ArrowDropDown">
             @foreach (var p in ConfigService.Projects.OrderBy(p => p.Name))
             {
-                <MudMenuItem OnClick="() => ChangeProject(p.Name)" Style="@GetProjectStyle(p.Color)">@p.Name</MudMenuItem>
+                <MudMenuItem OnClick="() => ChangeProject(p.Name)"
+                             Style="@GetProjectStyle(p.Color)"
+                             Class="@GetProjectClass(p.Color)">@p.Name</MudMenuItem>
             }
             <MudDivider />
             <MudMenuItem Href="/projects/new">@L["NewProject"]</MudMenuItem>
@@ -96,6 +98,9 @@
 
     private static string GetProjectStyle(string color)
         => string.IsNullOrWhiteSpace(color) ? string.Empty : $"background-color:{color};";
+
+    private static string GetProjectClass(string color)
+        => string.IsNullOrWhiteSpace(color) ? string.Empty : "project-color-item";
     
     private void HandleProjectChanged()
     {

--- a/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
+++ b/src/DevOpsAssistant/DevOpsAssistant/wwwroot/css/app.css
@@ -216,3 +216,8 @@ body {
     border-radius: var(--mud-default-borderradius, 4px);
 }
 
+/* highlight project menu items on hover */
+.project-color-item:hover {
+    filter: brightness(1.1);
+}
+


### PR DESCRIPTION
## Summary
- add a class for project color menu items
- lighten project menu item background on hover

## Testing
- `dotnet test src/DevOpsAssistant/DevOpsAssistant.Tests/DevOpsAssistant.Tests.csproj --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_686f9b0d6d448328bb2ca390fbb6cf4a